### PR TITLE
[INIT/#11] MVI 공통 모듈 구현

### DIFF
--- a/core/ui/src/main/kotlin/com/boostcamp/mapisode/ui/base/BaseViewModel.kt
+++ b/core/ui/src/main/kotlin/com/boostcamp/mapisode/ui/base/BaseViewModel.kt
@@ -1,0 +1,37 @@
+package com.boostcamp.mapisode.ui.base
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import timber.log.Timber
+
+abstract class BaseViewModel<UI_STATE : UiState, SIDE_EFFECT : SideEffect>(
+	initialState: UI_STATE,
+) : ViewModel() {
+
+	private val _uiState = MutableStateFlow(initialState)
+	val uiState = _uiState.asStateFlow()
+
+	private val _sideEffect: Channel<SIDE_EFFECT> = Channel(Channel.UNLIMITED)
+	val sideEffect = _sideEffect.receiveAsFlow()
+
+	protected val currentState: UI_STATE
+		get() = _uiState.value
+
+	protected fun intent(reduce: UI_STATE.() -> UI_STATE) {
+		_uiState.update { currentState.reduce() }
+	}
+
+	protected fun postSideEffect(vararg effects: SIDE_EFFECT) {
+		effects.forEach { effect ->
+			val result = _sideEffect.trySend(effect)
+			if (result.isFailure) {
+				// TODO : 에러 로직처리 방법 결정 후 수정
+				Timber.e(result.exceptionOrNull())
+			}
+		}
+	}
+}

--- a/core/ui/src/main/kotlin/com/boostcamp/mapisode/ui/base/SideEffect.kt
+++ b/core/ui/src/main/kotlin/com/boostcamp/mapisode/ui/base/SideEffect.kt
@@ -1,0 +1,3 @@
+package com.boostcamp.mapisode.ui.base
+
+interface SideEffect

--- a/core/ui/src/main/kotlin/com/boostcamp/mapisode/ui/base/UiState.kt
+++ b/core/ui/src/main/kotlin/com/boostcamp/mapisode/ui/base/UiState.kt
@@ -1,0 +1,3 @@
+package com.boostcamp.mapisode.ui.base
+
+interface UiState

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeIntent.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeIntent.kt
@@ -1,0 +1,6 @@
+package com.boostcamp.mapisode.home
+
+sealed class HomeIntent {
+	data object Increment : HomeIntent()
+	data object Decrement : HomeIntent()
+}

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
@@ -1,24 +1,107 @@
 package com.boostcamp.mapisode.home
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
 @Composable
-internal fun HomeRoute() {
-	HomeScreen()
+internal fun HomeRoute(
+	viewModel: HomeViewModel = hiltViewModel(),
+) {
+	val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+	val snackbarHostState = remember { SnackbarHostState() }
+	val context = LocalContext.current
+
+	LaunchedEffect(viewModel) {
+		viewModel.sideEffect.collect { sideEffect ->
+			when (sideEffect) {
+				is HomeSideEffect.ShowToast -> {
+					snackbarHostState.showSnackbar(sideEffect.message)
+				}
+			}
+		}
+	}
+
+	HomeScreen(
+		state = uiState,
+		onIncrement = { viewModel.onIntent(HomeIntent.Increment) },
+		onDecrement = { viewModel.onIntent(HomeIntent.Decrement) },
+		snackbarHostState = snackbarHostState,
+	)
 }
 
 @Composable
-private fun HomeScreen() {
-	Box(
-		modifier = Modifier.fillMaxSize(),
-		contentAlignment = Alignment.Center,
+private fun HomeScreen(
+	state: HomeState,
+	onIncrement: () -> Unit,
+	onDecrement: () -> Unit,
+	snackbarHostState: SnackbarHostState,
+) {
+	Scaffold(
+		snackbarHost = { SnackbarHost(snackbarHostState) },
 	) {
-		Text(text = "HomeScreen", style = MaterialTheme.typography.displayMedium)
+		Box(
+			modifier = Modifier
+				.fillMaxSize()
+				.padding(it),
+			contentAlignment = Alignment.Center,
+		) {
+			Column(
+				horizontalAlignment = Alignment.CenterHorizontally,
+			) {
+				Text(
+					text = "Count: ${state.count}",
+					style = MaterialTheme.typography.displayMedium,
+				)
+				Spacer(modifier = Modifier.height(16.dp))
+				Row {
+					Button(
+						onClick = onDecrement,
+						modifier = Modifier.padding(8.dp),
+					) {
+						Text(text = "-")
+					}
+					Button(
+						onClick = onIncrement,
+						modifier = Modifier.padding(8.dp),
+					) {
+						Text(text = "+")
+					}
+				}
+			}
+		}
+
 	}
+}
+
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+private fun HomeScreenPreview() {
+	HomeScreen(
+		state = HomeState(count = 42),
+		onIncrement = {},
+		onDecrement = {},
+		snackbarHostState = SnackbarHostState(),
+	)
 }

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeSideEffect.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeSideEffect.kt
@@ -1,0 +1,7 @@
+package com.boostcamp.mapisode.home
+
+import com.boostcamp.mapisode.ui.base.SideEffect
+
+sealed class HomeSideEffect : SideEffect {
+	data class ShowToast(val message: String) : HomeSideEffect()
+}

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeState.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeState.kt
@@ -1,0 +1,7 @@
+package com.boostcamp.mapisode.home
+
+import com.boostcamp.mapisode.ui.base.UiState
+
+data class HomeState(
+	val count: Int = 0,
+) : UiState

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeViewModel.kt
@@ -1,0 +1,26 @@
+package com.boostcamp.mapisode.home
+
+import com.boostcamp.mapisode.ui.base.BaseViewModel
+
+class HomeViewModel : BaseViewModel<HomeState, HomeSideEffect>(HomeState()) {
+	fun onIntent(intent: HomeIntent) {
+		when (intent) {
+			is HomeIntent.Increment -> increment()
+			is HomeIntent.Decrement -> decrement()
+		}
+	}
+
+	private fun increment() {
+		intent {
+			copy(count = count + 1)
+		}
+		postSideEffect(HomeSideEffect.ShowToast("Incremented ${currentState.count}"))
+	}
+
+	private fun decrement() {
+		intent {
+			copy(count = count - 1)
+		}
+		postSideEffect(HomeSideEffect.ShowToast("Decremented ${currentState.count}"))
+	}
+}


### PR DESCRIPTION
- closed #11 

## *📍 Work Description*

Orbit이나 Mavericks와 같은 MVI 라이브러리 없이 아키텍처를 구축하는 것이 목표입니다. 이 PR에서는 프로젝트 전체적으로 쓰일 Base 파일들을 생성하고 공통 로직을 추상화하였습니다. 물론 이 과정에서 라이브러리가 주는 이점을 100% 구현할 수는 없습니다. 그치만 보일러 플레이트 감소 및 일관적인 코드 스타일을 이끌어 갈 수 있도록 설계했습니다. 밑에서 자세하게 설명하겠습니다. 

### MVI 아키텍처 구성요소
- Intent : 사용자의 행동, 인터렉션 (예시에서는 + - 버튼 클릭)
- UiState : 화면에서 표시되어야할 또는 관리되어야할 모든 상태. (예시에서는 count)
- SideEffect : 위 UiState를 제외한 모든 것. 사용자에게 피드백을 준다고 생각하면 됨 (예시에서는 스낵바 띄우는 동작)

### BaseViewModel

``` kotlin
// core:ui/base

abstract class BaseViewModel<UI_STATE : UiState, SIDE_EFFECT : SideEffect>(
	initialState: UI_STATE,
) : ViewModel() {

	private val _uiState = MutableStateFlow(initialState)
	val uiState = _uiState.asStateFlow()

	private val _sideEffect: Channel<SIDE_EFFECT> = Channel(Channel.UNLIMITED)
	val sideEffect = _sideEffect.receiveAsFlow()

	protected val currentState: UI_STATE
		get() = _uiState.value

	protected fun intent(reduce: UI_STATE.() -> UI_STATE) {
		_uiState.update { currentState.reduce() }
	}

	protected fun postSideEffect(vararg effects: SIDE_EFFECT) {
		effects.forEach { effect ->
			val result = _sideEffect.trySend(effect)
			if (result.isFailure) {
				// TODO : 에러 로직처리 방법 결정 후 수정
				Timber.e(result.exceptionOrNull())
			}
		}
	}
}
```
- SideEffect는 이벤트 유실에 대한 우려 때문에 sharedFlow는 사용하지 않았습니다. Flow와 Channel 중 Channel을 택한 이유는 단일 이벤트를 방출하고 소비하는데 중점을 두기 위해서 입니다. 또 `trySend`를 통해 별도의 코루틴 스코프를 생성하지 않고 non-blocking 방식으로 이벤트를 전송합니다. (이 방법은 좀 더 연구해볼 예정이며, 에러 처리 로직은 논의 후에 반영하겠습니다.)
- 제네릭 타입을 사용하여 모든 화면에서 사용할 수 있도록 하였습니다.
- 상태 변경이 일어날 때마다 intent 메서드를 통해 새 상태로 업데이트 하고, uiState를 해당 화면에서 collect합니다.
- `postSideEffect` 메서드는 여러 SideEffect를 한 번에 전송할 수 있도록 vararg 파라미터를 사용해 확장성을 높였습니다. 이 메서드를 통해 발생한 SideEffect는 trySend를 통해 채널에 안전하게 전송되며, 실패한 경우에는 Timber로 오류를 로깅하도록 설정했습니다.
- 채널의 버퍼를 UNLIMITED로 설정한 이유는 지도에서 발생할 수 있는 이벤트의 개수가 상당히 많지 않을까? 싶어서 일단 이렇게 했습니다. 추후 개발이 어느정도 되고 나서 변경할지 생각해볼 예정입니다. 


## *📸 Screenshot*

<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->

https://github.com/user-attachments/assets/a660cb10-3483-48f1-8e59-234389f20d88


## *📢 To Reviewers*
- 가이드를 위해 임시로 Home에 활용 코드를 작성했습니다. 헷갈리는 부분있으면 디코로 연락주세요.
- 좀 더 연구해보고 방식을 바꿀 수도 있습니다. 물론 사용하는 부분에서는 지장은 없습니다. 
- 추후 문서 작성 예정

## ⏲️Time

    - 5 (연구하는데 시간 많이 씀) 
