### PR TITLE
[FEAT/#31] 지도 권한 로직 구현 

### DIFF
--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeIntent.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeIntent.kt
@@ -5,6 +5,6 @@ import com.naver.maps.geometry.LatLng
 sealed class HomeIntent {
 	data object RequestLocationPermission : HomeIntent()
 	data class SetInitialLocation(val latLng: LatLng) : HomeIntent()
-	data class UpdateLocationPermission(val isGranted: Boolean) : HomeIntent()
-	data object MarkPermissionRequested : HomeIntent()
+	data class UpdateLocationPermission(val isGranted: Boolean) : HomeIntent() // 위치 권한 설정 여부 업데이트
+	data object MarkPermissionRequested : HomeIntent() // 위치 권한 요청 기록
 }

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeIntent.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeIntent.kt
@@ -1,5 +1,10 @@
 package com.boostcamp.mapisode.home
 
+import com.naver.maps.geometry.LatLng
+
 sealed class HomeIntent {
-	// TODO : Add HomeIntent
+	data object RequestLocationPermission : HomeIntent()
+	data class SetInitialLocation(val latLng: LatLng) : HomeIntent()
+	data class UpdateLocationPermission(val isGranted: Boolean) : HomeIntent()
+	data object MarkPermissionRequested : HomeIntent()
 }

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomePermissionHandler.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomePermissionHandler.kt
@@ -19,7 +19,8 @@ fun HomePermissionHandler(
 ) {
 	LaunchedEffect(uiState.isLocationPermissionGranted) {
 		val isFineLocationGranted = ContextCompat.checkSelfPermission(
-			context, Manifest.permission.ACCESS_FINE_LOCATION,
+			context,
+			Manifest.permission.ACCESS_FINE_LOCATION,
 		) == PackageManager.PERMISSION_GRANTED
 
 		if (!uiState.isLocationPermissionGranted && !isFineLocationGranted) {

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomePermissionHandler.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomePermissionHandler.kt
@@ -1,0 +1,47 @@
+package com.boostcamp.mapisode.home
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.activity.compose.ManagedActivityResultLauncher
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.core.content.ContextCompat
+
+@Composable
+fun HomePermissionHandler(
+	context: Context,
+	uiState: HomeState,
+	launcherLocationPermissions: ManagedActivityResultLauncher<Array<String>, Map<String, Boolean>>,
+	updatePermission: (Boolean) -> Unit,
+) {
+	LaunchedEffect(uiState.isLocationPermissionGranted) {
+		val isFineLocationGranted = ContextCompat.checkSelfPermission(
+			context, Manifest.permission.ACCESS_FINE_LOCATION,
+		) == PackageManager.PERMISSION_GRANTED
+
+		if (!uiState.isLocationPermissionGranted && !isFineLocationGranted) {
+			launcherLocationPermissions.launch(
+				arrayOf(
+					Manifest.permission.ACCESS_FINE_LOCATION,
+				),
+			)
+		} else if (isFineLocationGranted) {
+			updatePermission(true)
+		}
+	}
+}
+
+@Composable
+fun getPermissionsLauncher(
+	updatePermission: (Boolean) -> Unit,
+): ManagedActivityResultLauncher<Array<String>, Map<String, Boolean>> {
+	return rememberLauncherForActivityResult(
+		ActivityResultContracts.RequestMultiplePermissions(),
+	) { permissions ->
+		val isGranted = permissions.values.all { it }
+		updatePermission(isGranted)
+	}
+}

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomePermissionHandler.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomePermissionHandler.kt
@@ -17,6 +17,7 @@ fun HomePermissionHandler(
 	launcherLocationPermissions: ManagedActivityResultLauncher<Array<String>, Map<String, Boolean>>,
 	updatePermission: (Boolean) -> Unit,
 ) {
+	// 위치 권한 설정을 감시하고, 권한이 없으면 요청한다.
 	LaunchedEffect(uiState.isLocationPermissionGranted) {
 		val isFineLocationGranted = ContextCompat.checkSelfPermission(
 			context,
@@ -24,12 +25,14 @@ fun HomePermissionHandler(
 		) == PackageManager.PERMISSION_GRANTED
 
 		if (!uiState.isLocationPermissionGranted && !isFineLocationGranted) {
+			// 위치 권한이 허용되지 않은 경우 권한을 요청
 			launcherLocationPermissions.launch(
 				arrayOf(
 					Manifest.permission.ACCESS_FINE_LOCATION,
 				),
 			)
 		} else if (isFineLocationGranted) {
+			// 위치 권한이 허용된 경우 권한 상태를 업데이트
 			updatePermission(true)
 		}
 	}
@@ -38,11 +41,10 @@ fun HomePermissionHandler(
 @Composable
 fun getPermissionsLauncher(
 	updatePermission: (Boolean) -> Unit,
-): ManagedActivityResultLauncher<Array<String>, Map<String, Boolean>> {
-	return rememberLauncherForActivityResult(
+): ManagedActivityResultLauncher<Array<String>, Map<String, Boolean>> =
+	rememberLauncherForActivityResult(
 		ActivityResultContracts.RequestMultiplePermissions(),
 	) { permissions ->
 		val isGranted = permissions.values.all { it }
 		updatePermission(isGranted)
 	}
-}

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
@@ -4,9 +4,6 @@ import android.Manifest
 import android.content.pm.PackageManager
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -92,7 +89,6 @@ internal fun HomeRoute(
 	HomeScreen(
 		state = uiState,
 		cameraPositionState = cameraPositionState,
-		snackbarHostState = snackbarHostState,
 	)
 }
 
@@ -101,37 +97,30 @@ internal fun HomeRoute(
 private fun HomeScreen(
 	state: HomeState,
 	cameraPositionState: CameraPositionState,
-	snackbarHostState: SnackbarHostState,
 ) {
-	Scaffold(
-		snackbarHost = { SnackbarHost(snackbarHostState) },
+	Box(
+		modifier = Modifier.fillMaxSize(),
 	) {
-		Box(
-			modifier = Modifier
-				.fillMaxSize()
-				.padding(it),
-		) {
-			NaverMap(
-				modifier = Modifier.fillMaxSize(),
-				cameraPositionState = cameraPositionState,
-				properties = MapProperties(
-					locationTrackingMode = LocationTrackingMode.NoFollow,
-					isIndoorEnabled = true,
-				),
-				uiSettings = MapUiSettings(
-					isZoomGesturesEnabled = true,
-					isZoomControlEnabled = false,
-					isLocationButtonEnabled = true,
-					isLogoClickEnabled = false,
-					isScaleBarEnabled = false,
-					isCompassEnabled = false,
-				),
-				locationSource = rememberFusedLocationSource(),
-				onMapClick = { _, _ ->
-					// TODO : 마커 찍기 구현
-				},
-			)
-		}
+		NaverMap(
+			modifier = Modifier.fillMaxSize(),
+			cameraPositionState = cameraPositionState,
+			properties = MapProperties(
+				locationTrackingMode = LocationTrackingMode.NoFollow,
+				isIndoorEnabled = true,
+			),
+			uiSettings = MapUiSettings(
+				isZoomGesturesEnabled = true,
+				isZoomControlEnabled = false,
+				isLocationButtonEnabled = true,
+				isLogoClickEnabled = false,
+				isScaleBarEnabled = false,
+				isCompassEnabled = false,
+			),
+			locationSource = rememberFusedLocationSource(),
+			onMapClick = { _, _ ->
+				// TODO : 마커 찍기 구현
+			},
+		)
 	}
 }
 
@@ -146,6 +135,5 @@ private fun HomeScreenPreview() {
 				DEFAULT_ZOOM,
 			)
 		},
-		snackbarHostState = SnackbarHostState(),
 	)
 }

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
@@ -2,9 +2,9 @@ package com.boostcamp.mapisode.home
 
 import android.Manifest
 import android.content.pm.PackageManager
+import android.widget.Toast
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -12,7 +12,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.boostcamp.mapisode.home.common.HomeConstant.DEFAULT_ZOOM
@@ -34,9 +34,8 @@ internal fun HomeRoute(
 	viewModel: HomeViewModel = hiltViewModel(),
 ) {
 	val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-	val snackbarHostState = remember { SnackbarHostState() }
 	val context = LocalContext.current
-	val focusLocationProviderClient = remember {
+	val fusedLocationClient = remember {
 		LocationServices.getFusedLocationProviderClient(context)
 	}
 
@@ -44,36 +43,35 @@ internal fun HomeRoute(
 		position = uiState.cameraPosition
 	}
 
+	val launcherLocationPermissions = getPermissionsLauncher { isGranted ->
+		viewModel.onIntent(HomeIntent.UpdateLocationPermission(isGranted))
+	}
+
 	LaunchedEffect(viewModel) {
 		viewModel.sideEffect.collect { sideEffect ->
 			when (sideEffect) {
 				is HomeSideEffect.ShowToast -> {
-					snackbarHostState.showSnackbar(sideEffect.message)
+					Toast.makeText(context, sideEffect.message, Toast.LENGTH_SHORT).show()
+				}
+
+				is HomeSideEffect.RequestLocationPermission -> {
+					if (!uiState.isLocationPermissionGranted) {
+						launcherLocationPermissions.launch(
+							arrayOf(Manifest.permission.ACCESS_FINE_LOCATION),
+						)
+					}
 				}
 
 				is HomeSideEffect.SetInitialLocation -> {
-					if (!uiState.isInitialLocationSet) {
-						// 현재 위치 가져오기
-						if (
-							ActivityCompat.checkSelfPermission(
-								context,
-								Manifest.permission.ACCESS_FINE_LOCATION,
-							) != PackageManager.PERMISSION_GRANTED &&
-							ActivityCompat.checkSelfPermission(
-								context,
-								Manifest.permission.ACCESS_COARSE_LOCATION,
-							) != PackageManager.PERMISSION_GRANTED
-						) {
-							// 권한이 없을 경우 요청 필요
-							snackbarHostState.showSnackbar("위치 권한이 필요합니다.")
-							return@collect
-						}
-						focusLocationProviderClient.lastLocation.addOnSuccessListener { location ->
+					if (ContextCompat.checkSelfPermission(
+							context, Manifest.permission.ACCESS_FINE_LOCATION,
+						) == PackageManager.PERMISSION_GRANTED && !uiState.isInitialLocationSet
+					) {
+						fusedLocationClient.lastLocation.addOnSuccessListener { location ->
 							if (location != null) {
 								val userLatLng = LatLng(location.latitude, location.longitude)
-								// ViewModel의 상태 업데이트
-								viewModel.setInitialLocation(userLatLng)
-								// 카메라 위치 업데이트
+
+								viewModel.onIntent(HomeIntent.SetInitialLocation(userLatLng))
 								cameraPositionState.position =
 									CameraPosition(userLatLng, DEFAULT_ZOOM)
 							} else {
@@ -85,6 +83,15 @@ internal fun HomeRoute(
 			}
 		}
 	}
+
+	HomePermissionHandler(
+		context = context,
+		uiState = uiState,
+		launcherLocationPermissions = launcherLocationPermissions,
+		updatePermission = { isGranted ->
+			viewModel.onIntent(HomeIntent.UpdateLocationPermission(isGranted))
+		},
+	)
 
 	HomeScreen(
 		state = uiState,

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
@@ -56,6 +56,7 @@ internal fun HomeRoute(
 				}
 
 				is HomeSideEffect.RequestLocationPermission -> {
+					// 위치 권한이 허용되지 않은 경우 권한 요청
 					if (!uiState.isLocationPermissionGranted) {
 						launcherLocationPermissions.launch(
 							arrayOf(Manifest.permission.ACCESS_FINE_LOCATION),
@@ -64,10 +65,12 @@ internal fun HomeRoute(
 				}
 
 				is HomeSideEffect.SetInitialLocation -> {
+					// 초기 위치 설정: 권한이 허용된 경우 현재 위치를 가져온다. 
 					if (ContextCompat.checkSelfPermission(
 							context,
 							Manifest.permission.ACCESS_FINE_LOCATION,
-						) == PackageManager.PERMISSION_GRANTED && !uiState.isInitialLocationSet
+						) == PackageManager.PERMISSION_GRANTED &&
+						!uiState.isInitialLocationSet
 					) {
 						fusedLocationClient.lastLocation.addOnSuccessListener { location ->
 							if (location != null) {
@@ -77,7 +80,7 @@ internal fun HomeRoute(
 								cameraPositionState.position =
 									CameraPosition(userLatLng, DEFAULT_ZOOM)
 							} else {
-								Timber.e("위치 정보를 가져올 수 없습니다.")
+								Timber.e(context.getString(R.string.home_cannot_bring_location_error))
 							}
 						}
 					}

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
@@ -65,7 +65,7 @@ internal fun HomeRoute(
 				}
 
 				is HomeSideEffect.SetInitialLocation -> {
-					// 초기 위치 설정: 권한이 허용된 경우 현재 위치를 가져온다. 
+					// 초기 위치 설정: 권한이 허용된 경우 현재 위치를 가져온다.
 					if (ContextCompat.checkSelfPermission(
 							context,
 							Manifest.permission.ACCESS_FINE_LOCATION,

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
@@ -51,7 +51,8 @@ internal fun HomeRoute(
 		viewModel.sideEffect.collect { sideEffect ->
 			when (sideEffect) {
 				is HomeSideEffect.ShowToast -> {
-					Toast.makeText(context, sideEffect.message, Toast.LENGTH_SHORT).show()
+					val message = context.getString(sideEffect.messageResId)
+					Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
 				}
 
 				is HomeSideEffect.RequestLocationPermission -> {

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
@@ -65,7 +65,8 @@ internal fun HomeRoute(
 
 				is HomeSideEffect.SetInitialLocation -> {
 					if (ContextCompat.checkSelfPermission(
-							context, Manifest.permission.ACCESS_FINE_LOCATION,
+							context,
+							Manifest.permission.ACCESS_FINE_LOCATION,
 						) == PackageManager.PERMISSION_GRANTED && !uiState.isInitialLocationSet
 					) {
 						fusedLocationClient.lastLocation.addOnSuccessListener { location ->

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeSideEffect.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeSideEffect.kt
@@ -5,4 +5,5 @@ import com.boostcamp.mapisode.ui.base.SideEffect
 sealed class HomeSideEffect : SideEffect {
 	data class ShowToast(val message: String) : HomeSideEffect()
 	data object SetInitialLocation : HomeSideEffect()
+	data object RequestLocationPermission : HomeSideEffect()
 }

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeSideEffect.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeSideEffect.kt
@@ -3,7 +3,7 @@ package com.boostcamp.mapisode.home
 import com.boostcamp.mapisode.ui.base.SideEffect
 
 sealed class HomeSideEffect : SideEffect {
-	data class ShowToast(val message: String) : HomeSideEffect()
+	data class ShowToast(val messageResId: Int) : HomeSideEffect()
 	data object SetInitialLocation : HomeSideEffect()
 	data object RequestLocationPermission : HomeSideEffect()
 }

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeState.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeState.kt
@@ -14,7 +14,7 @@ data class HomeState(
 		),
 		DEFAULT_ZOOM,
 	),
-	val isInitialLocationSet: Boolean = false,
-	val isLocationPermissionGranted: Boolean = false,
-	val hasRequestedPermission: Boolean = false,
+	val isInitialLocationSet: Boolean = false, // 사용자의 현재 위치가 초기 설정되었는지 여부
+	val isLocationPermissionGranted: Boolean = false, // 위치 권한이 허용되었는지 여부
+	val hasRequestedPermission: Boolean = false, // 위치 권한을 요청한 적이 있는지 여부
 ) : UiState

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeState.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeState.kt
@@ -6,12 +6,15 @@ import com.naver.maps.geometry.LatLng
 import com.naver.maps.map.CameraPosition
 
 data class HomeState(
+	// 위치 권한 설정을 허용하지 않은 유저에게 보여줄 초기 위치 (양재 코드스쿼드)
 	val cameraPosition: CameraPosition = CameraPosition(
 		LatLng(
-			37.38026976485322,
-			127.11537099437301,
+			37.49083317052349,
+			127.03343085967185,
 		),
 		DEFAULT_ZOOM,
 	),
 	val isInitialLocationSet: Boolean = false,
+	val isLocationPermissionGranted: Boolean = false,
+	val hasRequestedPermission: Boolean = false,
 ) : UiState

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeViewModel.kt
@@ -25,7 +25,7 @@ class HomeViewModel : BaseViewModel<HomeState, HomeSideEffect>(HomeState()) {
 				if (intent.isGranted) {
 					postSideEffect(HomeSideEffect.SetInitialLocation)
 				} else {
-					postSideEffect(HomeSideEffect.ShowToast("위치 권한이 필요합니다."))
+					postSideEffect(HomeSideEffect.ShowToast(R.string.home_location_permission_needed))
 				}
 			}
 

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeViewModel.kt
@@ -10,6 +10,7 @@ class HomeViewModel : BaseViewModel<HomeState, HomeSideEffect>(HomeState()) {
 	fun onIntent(intent: HomeIntent) {
 		when (intent) {
 			is HomeIntent.RequestLocationPermission -> {
+				// 위치 권한 요청이 아직 이루어지지 않은 경우에만 요청
 				if (!currentState.hasRequestedPermission) {
 					postSideEffect(HomeSideEffect.RequestLocationPermission)
 					onIntent(HomeIntent.MarkPermissionRequested)
@@ -30,10 +31,14 @@ class HomeViewModel : BaseViewModel<HomeState, HomeSideEffect>(HomeState()) {
 			}
 
 			is HomeIntent.MarkPermissionRequested -> {
-				intent {
-					copy(hasRequestedPermission = true)
-				}
+				setHasRequestedPermission()
 			}
+		}
+	}
+
+	private fun setHasRequestedPermission() {
+		intent {
+			copy(hasRequestedPermission = true)
 		}
 	}
 

--- a/feature/home/src/main/res/values/strings.xml
+++ b/feature/home/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="home_location_permission_needed">위치 권한이 필요합니다.</string>
+</resources>

--- a/feature/home/src/main/res/values/strings.xml
+++ b/feature/home/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="home_location_permission_needed">위치 권한이 필요합니다.</string>
+	<string name="home_cannot_bring_location_error">위치 정보를 가져올 수 없습니다.</string>
 </resources>


### PR DESCRIPTION
- closed #31 

## *📍 Work Description*
- 메인 화면 진입 시 권한 요청 (첫 진입 시에만)
- 권한을 허용하면 현 위치로 카메라가 이동
- 권한을 허용하지 않으면 Toast 메세지를 노출하고, 기본 위치인 양재 코드 스쿼드에 카메라를 보여줌
- 권한을 허용하지 않은 상태에서 현위치 버튼을 클릭할 시 권한 재요청

## *📸 Screenshot*

<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->

### 권한 허용 시 현위치로 이동

https://github.com/user-attachments/assets/b3bf62df-2bf0-4fbd-870f-70cb6e0c083c

### 권한 거부하고 현위치 버튼에서 요청도 거부할 때
> 이건 라이브러리가 처리하는 거여서 추후에 보수를 해야될 것 같습니다

https://github.com/user-attachments/assets/c59d6d05-b2e3-4617-ba00-b538a01f8c29

### 권한 거부하고 현위치 버튼에서 허용 시 

https://github.com/user-attachments/assets/60d459b5-1119-4e1d-917a-e6c078392a30

## *📢 To Reviewers*
- UI 작업을 하려다 권한 작업 먼저 하였습니다.
- 추후에 수정될 가능성이 있습니다. (상태관리)
- 주석으로 설명을 추가하였습니다. 

## ⏲️Time

    - 2
