### PR TITLE
[FEAT/#24] Custom 버튼 제작 및 컬러 스킴 구정

### DIFF
--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeRipple.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeRipple.kt
@@ -1,0 +1,67 @@
+package com.boostcamp.mapisode.designsystem.compose
+
+import androidx.compose.animation.core.animate
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import kotlinx.coroutines.launch
+
+class MapisodeRippleState {
+	var rippleCenter by mutableStateOf(Offset.Zero)
+	var rippleRadius by mutableFloatStateOf(0f)
+}
+
+fun Modifier.mapisodeRippleEffect(
+	enabled: Boolean = true,
+	rippleColor: Color = Color.White.copy(alpha = 0.3f),
+): Modifier = composed {
+	val rippleState = remember { MapisodeRippleState() }
+	val coroutineScope = rememberCoroutineScope()
+
+    this.graphicsLayer(alpha = 0.99f)
+        .drawWithContent {
+            drawContent()
+            if (rippleState.rippleRadius > 0) {
+                drawCircle(
+                    color = rippleColor,
+                    radius = rippleState.rippleRadius,
+                    center = rippleState.rippleCenter,
+                )
+            }
+        }
+        .pointerInput(enabled) {
+            if (enabled) {
+                detectTapGestures(
+                    onTap = { offset ->
+                        rippleState.rippleCenter = offset
+                        coroutineScope.launch {
+                            val maxRadius = size.width.coerceAtLeast(size.height) * 1.5f
+
+                            animate(
+                                initialValue = 0f,
+                                targetValue = maxRadius,
+                                animationSpec = tween(50),
+                            ) { value, _ ->
+                                rippleState.rippleRadius = value
+                            }
+
+                            animate(
+                                initialValue = maxRadius,
+                                targetValue = 0f,
+                                animationSpec = tween(50),
+                            ) { value, _ ->
+                                rippleState.rippleRadius = value
+                            }
+                        }
+                    },
+                )
+            }
+        }
+}

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeRipple.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeRipple.kt
@@ -30,44 +30,43 @@ fun Modifier.mapisodeRippleEffect(
 	val rippleState = remember { MapisodeRippleState() }
 	val coroutineScope = rememberCoroutineScope()
 
-    this
-        .graphicsLayer(alpha = 0.99f)
-        .drawWithContent {
-            drawContent()
-            if (rippleState.rippleRadius > 0) {
-                drawCircle(
-                    color = rippleColor,
-                    radius = rippleState.rippleRadius,
-                    center = rippleState.rippleCenter,
-                )
-            }
-        }
-        .pointerInput(enabled) {
-            if (enabled) {
-                detectTapGestures(
-                    onTap = { offset ->
-                        rippleState.rippleCenter = offset
-                        coroutineScope.launch {
-                            val maxRadius = size.width.coerceAtLeast(size.height) * 1.5f
+	Modifier.graphicsLayer(alpha = 0.99f)
+		.drawWithContent {
+			drawContent()
+			if (rippleState.rippleRadius > 0) {
+				drawCircle(
+					color = rippleColor,
+					radius = rippleState.rippleRadius,
+					center = rippleState.rippleCenter,
+				)
+			}
+		}
+		.pointerInput(enabled) {
+			if (enabled) {
+				detectTapGestures(
+					onTap = { offset ->
+						rippleState.rippleCenter = offset
+						coroutineScope.launch {
+							val maxRadius = size.width.coerceAtLeast(size.height) * 1.5f
 
-                            animate(
-                                initialValue = 0f,
-                                targetValue = maxRadius,
-                                animationSpec = tween(50),
-                            ) { value, _ ->
-                                rippleState.rippleRadius = value
-                            }
+							animate(
+								initialValue = 0f,
+								targetValue = maxRadius,
+								animationSpec = tween(50),
+							) { value, _ ->
+								rippleState.rippleRadius = value
+							}
 
-                            animate(
-                                initialValue = maxRadius,
-                                targetValue = 0f,
-                                animationSpec = tween(50),
-                            ) { value, _ ->
-                                rippleState.rippleRadius = value
-                            }
-                        }
-                    },
-                )
-            }
-        }
+							animate(
+								initialValue = maxRadius,
+								targetValue = 0f,
+								animationSpec = tween(50),
+							) { value, _ ->
+								rippleState.rippleRadius = value
+							}
+						}
+					},
+				)
+			}
+		}
 }

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeRipple.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeRipple.kt
@@ -44,7 +44,7 @@ fun Modifier.mapisodeRippleEffect(
 		.pointerInput(enabled) {
 			if (enabled) {
 				detectTapGestures(
-					onTap = { offset ->
+					onPress = { offset ->
 						rippleState.rippleCenter = offset
 						coroutineScope.launch {
 							val maxRadius = size.width.coerceAtLeast(size.height) * 1.5f
@@ -56,6 +56,8 @@ fun Modifier.mapisodeRippleEffect(
 							) { value, _ ->
 								rippleState.rippleRadius = value
 							}
+
+							tryAwaitRelease()
 
 							animate(
 								initialValue = maxRadius,

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeRipple.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeRipple.kt
@@ -3,7 +3,12 @@ package com.boostcamp.mapisode.designsystem.compose
 import androidx.compose.animation.core.animate
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.runtime.*
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.drawWithContent
@@ -25,7 +30,8 @@ fun Modifier.mapisodeRippleEffect(
 	val rippleState = remember { MapisodeRippleState() }
 	val coroutineScope = rememberCoroutineScope()
 
-    this.graphicsLayer(alpha = 0.99f)
+    this
+        .graphicsLayer(alpha = 0.99f)
         .drawWithContent {
             drawContent()
             if (rippleState.rippleRadius > 0) {

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/Surface.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/Surface.kt
@@ -61,6 +61,7 @@ fun Surface(
 	color: Color = MapisodeTheme.colorScheme.surfaceBackground,
 	contentColor: Color = LocalMapisodeContentColor.current,
 	border: BorderStroke? = null,
+	showRipple: Boolean = false,
 	interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 	content: @Composable () -> Unit,
 ) {
@@ -76,9 +77,13 @@ fun Surface(
 					enabled = enabled,
 					onClick = onClick,
 				)
-				.mapisodeRippleEffect(
-					enabled = enabled,
-					rippleColor = contentColor.copy(alpha = 0.3f),
+				.then(
+					Modifier
+						.mapisodeRippleEffect(
+							enabled = enabled,
+							rippleColor = contentColor.copy(alpha = 0.3f),
+						)
+						.takeIf { showRipple } ?: Modifier,
 				),
 			propagateMinConstraints = true,
 		) {

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/Surface.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/Surface.kt
@@ -36,14 +36,11 @@ fun Surface(
 		LocalMapisodeContentColor provides contentColor,
 	) {
 		Box(
-			modifier = modifier
-                .surface(
+			modifier = modifier.surface(
                     shape = shape,
                     backgroundColor = color,
                     border = border,
-                )
-                .semantics { isTraversalGroup = true }
-                .pointerInput(Unit) {},
+                ).semantics { isTraversalGroup = true }.pointerInput(Unit) {},
 			propagateMinConstraints = true,
 		) {
 			content()
@@ -68,19 +65,16 @@ fun Surface(
 		LocalMapisodeContentColor provides contentColor,
 	) {
 		Box(
-			modifier = modifier
-                .surface(
+			modifier = modifier.surface(
                     shape = shape,
                     backgroundColor = color,
                     border = border,
-                )
-                .clickable(
+                ).clickable(
                     interactionSource = interactionSource,
                     indication = null,
                     enabled = enabled,
                     onClick = onClick,
-                )
-                .mapisodeRippleEffect(
+                ).mapisodeRippleEffect(
                     enabled = enabled,
                     rippleColor = contentColor.copy(alpha = 0.3f),
                 ),
@@ -95,7 +89,10 @@ private fun Modifier.surface(
 	shape: Shape,
 	backgroundColor: Color,
 	border: BorderStroke?,
-): Modifier = this
-    .then(if (border != null) Modifier.border(border, shape) else Modifier)
-    .background(color = backgroundColor, shape = shape)
-    .clip(shape)
+): Modifier = this.then(
+        if (border != null) {
+            Modifier.border(border, shape)
+        } else {
+            Modifier
+        },
+    ).background(color = backgroundColor, shape = shape).clip(shape)

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/Surface.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/Surface.kt
@@ -37,13 +37,13 @@ fun Surface(
 	) {
 		Box(
 			modifier = modifier
-				.surface(
-					shape = shape,
-					backgroundColor = color,
-					border = border,
-				)
-				.semantics { isTraversalGroup = true }
-				.pointerInput(Unit) {},
+                .surface(
+                    shape = shape,
+                    backgroundColor = color,
+                    border = border,
+                )
+                .semantics { isTraversalGroup = true }
+                .pointerInput(Unit) {},
 			propagateMinConstraints = true,
 		) {
 			content()
@@ -69,17 +69,21 @@ fun Surface(
 	) {
 		Box(
 			modifier = modifier
-				.surface(
-					shape = shape,
-					backgroundColor = color,
-					border = border,
-				)
-				.clickable(
-					interactionSource = interactionSource,
-					indication = null,
-					enabled = enabled,
-					onClick = onClick,
-				),
+                .surface(
+                    shape = shape,
+                    backgroundColor = color,
+                    border = border,
+                )
+                .clickable(
+                    interactionSource = interactionSource,
+                    indication = null,
+                    enabled = enabled,
+                    onClick = onClick,
+                )
+                .mapisodeRippleEffect(
+                    enabled = enabled,
+                    rippleColor = contentColor.copy(alpha = 0.3f),
+                ),
 			propagateMinConstraints = true,
 		) {
 			content()
@@ -92,6 +96,6 @@ private fun Modifier.surface(
 	backgroundColor: Color,
 	border: BorderStroke?,
 ): Modifier = this
-	.then(if (border != null) Modifier.border(border, shape) else Modifier)
-	.background(color = backgroundColor, shape = shape)
-	.clip(shape)
+    .then(if (border != null) Modifier.border(border, shape) else Modifier)
+    .background(color = backgroundColor, shape = shape)
+    .clip(shape)

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/Surface.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/Surface.kt
@@ -36,11 +36,14 @@ fun Surface(
 		LocalMapisodeContentColor provides contentColor,
 	) {
 		Box(
-			modifier = modifier.surface(
-                    shape = shape,
-                    backgroundColor = color,
-                    border = border,
-                ).semantics { isTraversalGroup = true }.pointerInput(Unit) {},
+			modifier = modifier
+				.surface(
+					shape = shape,
+					backgroundColor = color,
+					border = border,
+				)
+				.semantics { isTraversalGroup = true }
+				.pointerInput(Unit) {},
 			propagateMinConstraints = true,
 		) {
 			content()
@@ -65,19 +68,18 @@ fun Surface(
 		LocalMapisodeContentColor provides contentColor,
 	) {
 		Box(
-			modifier = modifier.surface(
-                    shape = shape,
-                    backgroundColor = color,
-                    border = border,
-                ).clickable(
-                    interactionSource = interactionSource,
-                    indication = null,
-                    enabled = enabled,
-                    onClick = onClick,
-                ).mapisodeRippleEffect(
-                    enabled = enabled,
-                    rippleColor = contentColor.copy(alpha = 0.3f),
-                ),
+			modifier = modifier
+				.surface(shape = shape, backgroundColor = color, border = border)
+				.clickable(
+					interactionSource = interactionSource,
+					indication = null,
+					enabled = enabled,
+					onClick = onClick,
+				)
+				.mapisodeRippleEffect(
+					enabled = enabled,
+					rippleColor = contentColor.copy(alpha = 0.3f),
+				),
 			propagateMinConstraints = true,
 		) {
 			content()
@@ -89,10 +91,13 @@ private fun Modifier.surface(
 	shape: Shape,
 	backgroundColor: Color,
 	border: BorderStroke?,
-): Modifier = this.then(
-        if (border != null) {
-            Modifier.border(border, shape)
-        } else {
-            Modifier
-        },
-    ).background(color = backgroundColor, shape = shape).clip(shape)
+): Modifier = this@surface
+	.then(
+		if (border != null) {
+			Modifier.border(border, shape)
+		} else {
+			Modifier
+		},
+	)
+	.background(color = backgroundColor, shape = shape)
+	.clip(shape)

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeButton.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeButton.kt
@@ -31,6 +31,7 @@ internal fun MapisodeButton(
 	borderColor: Color = Color.Transparent,
 	rounding: Dp = 8.dp,
 	contentPadding: PaddingValues = MapisodeButtonDefaults.ContentPadding,
+	showRipple: Boolean = false,
 	interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 	content: @Composable RowScope.() -> Unit,
 ) {
@@ -42,6 +43,7 @@ internal fun MapisodeButton(
 		color = backgroundColors,
 		contentColor = contentColor,
 		border = if (showBorder) BorderStroke(Thickness.Thin.value, borderColor) else null,
+		showRipple = showRipple,
 		interactionSource = interactionSource,
 	) {
 		ProvideTextStyle(value = MapisodeTheme.typography.labelLarge) {

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeButton.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeButton.kt
@@ -1,0 +1,74 @@
+package com.boostcamp.mapisode.designsystem.compose.button
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.boostcamp.mapisode.designsystem.compose.ProvideTextStyle
+import com.boostcamp.mapisode.designsystem.compose.Surface
+import com.boostcamp.mapisode.designsystem.compose.Thickness
+import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
+
+@Composable
+internal fun MapisodeButton(
+	onClick: () -> Unit,
+	backgroundColors: Color,
+	contentColor: Color,
+	modifier: Modifier = Modifier,
+	enabled: Boolean = true,
+	showBorder: Boolean = false,
+	borderColor: Color = Color.Transparent,
+	rounding: Dp = 8.dp,
+	contentPadding: PaddingValues = MapisodeButtonDefaults.ContentPadding,
+	interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+	content: @Composable RowScope.() -> Unit,
+) {
+	Surface(
+		onClick = onClick,
+		modifier = modifier,
+		enabled = enabled,
+		rounding = rounding,
+		color = backgroundColors,
+		contentColor = contentColor,
+		border = if (showBorder) BorderStroke(Thickness.Thin.value, borderColor) else null,
+		interactionSource = interactionSource,
+	) {
+		ProvideTextStyle(value = MapisodeTheme.typography.labelLarge) {
+			Row(
+				Modifier
+					.defaultMinSize(
+						minWidth = MapisodeButtonDefaults.MinWidth,
+						minHeight = MapisodeButtonDefaults.MinHeight,
+					)
+					.padding(contentPadding),
+				horizontalArrangement = Arrangement.Center,
+				verticalAlignment = Alignment.CenterVertically,
+				content = content,
+			)
+		}
+	}
+}
+
+object MapisodeButtonDefaults {
+	private val ButtonHorizontalPadding = 16.dp
+	private val ButtonVerticalPadding = 15.dp
+
+	val ContentPadding = PaddingValues(
+		horizontal = ButtonHorizontalPadding,
+		vertical = ButtonVerticalPadding,
+	)
+
+	val MinWidth = 64.dp
+	val MinHeight = 36.dp
+}

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeFilledButton.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeFilledButton.kt
@@ -21,69 +21,72 @@ import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 
 @Composable
 fun MapisodeFilledButton(
-    modifier: Modifier = Modifier,
-    onClick: () -> Unit,
-    text: String,
-    enabled: Boolean = true,
-    @DrawableRes leftIcon: Int? = null,
-    @DrawableRes rightIcon: Int? = null,
-    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
+	modifier: Modifier = Modifier,
+	onClick: () -> Unit,
+	text: String,
+	enabled: Boolean = true,
+	@DrawableRes leftIcon: Int? = null,
+	@DrawableRes rightIcon: Int? = null,
+	interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 ) {
-    MapisodeButton(
-        onClick = onClick,
-        backgroundColors = if (enabled) {
-            MapisodeTheme.colorScheme.filledButtonEnableBackground
-        } else {
-            MapisodeTheme.colorScheme.filledButtonDisableBackground
-        },
-        contentColor = MapisodeTheme.colorScheme.filledButtonContent,
-        modifier = Modifier.width(320.dp).height(52.dp).then(modifier),
-        enabled = enabled,
-        showBorder = false,
-        interactionSource = interactionSource,
-        rounding = 8.dp,
-        contentPadding = PaddingValues(horizontal = 16.dp),
-    ) {
-        leftIcon?.let { icon ->
-            MapisodeIcon(
-                id = icon,
-                iconSize = IconSize.Medium
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-        }
+	MapisodeButton(
+		onClick = onClick,
+		backgroundColors = if (enabled) {
+			MapisodeTheme.colorScheme.filledButtonEnableBackground
+		} else {
+			MapisodeTheme.colorScheme.filledButtonDisableBackground
+		},
+		contentColor = MapisodeTheme.colorScheme.filledButtonContent,
+		modifier = Modifier
+			.width(320.dp)
+			.height(52.dp)
+			.then(modifier),
+		enabled = enabled,
+		showBorder = false,
+		interactionSource = interactionSource,
+		rounding = 8.dp,
+		contentPadding = PaddingValues(horizontal = 16.dp),
+	) {
+		leftIcon?.let { icon ->
+			MapisodeIcon(
+				id = icon,
+				iconSize = IconSize.Medium
+			)
+			Spacer(modifier = Modifier.width(8.dp))
+		}
 
-        MapisodeText(
-            text = text,
-            color = MapisodeTheme.colorScheme.filledButtonContent,
-            style = MapisodeTheme.typography.titleLarge
-        )
+		MapisodeText(
+			text = text,
+			color = MapisodeTheme.colorScheme.filledButtonContent,
+			style = MapisodeTheme.typography.titleLarge
+		)
 
-        leftIcon ?: rightIcon?.let { icon ->
-            Spacer(modifier = Modifier.width(8.dp))
-            MapisodeIcon(
-                id = icon,
-                iconSize = IconSize.Medium
-            )
-        }
-    }
+		leftIcon ?: rightIcon?.let { icon ->
+			Spacer(modifier = Modifier.width(8.dp))
+			MapisodeIcon(
+				id = icon,
+				iconSize = IconSize.Medium
+			)
+		}
+	}
 }
 
 @Preview(showBackground = true)
 @Composable
 fun MapisodeFilledButtonPreview() {
-    Column(
-        modifier = Modifier.padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
-    ) {
-        MapisodeFilledButton(
-            onClick = { },
-            text = "활성화 버튼"
-        )
+	Column(
+		modifier = Modifier.padding(16.dp),
+		verticalArrangement = Arrangement.spacedBy(8.dp)
+	) {
+		MapisodeFilledButton(
+			onClick = { },
+			text = "활성화 버튼"
+		)
 
-        MapisodeFilledButton(
-            onClick = { },
-            text = "비활성화 버튼",
-            enabled = false
-        )
-    }
+		MapisodeFilledButton(
+			onClick = { },
+			text = "비활성화 버튼",
+			enabled = false
+		)
+	}
 }

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeFilledButton.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeFilledButton.kt
@@ -76,7 +76,7 @@ fun MapisodeFilledButton(
 fun MapisodeFilledButtonPreview() {
 	Column(
 		modifier = Modifier.padding(16.dp),
-		verticalArrangement = Arrangement.spacedBy(8.dp)
+		verticalArrangement = Arrangement.spacedBy(8.dp),
 	) {
 		MapisodeFilledButton(
 			onClick = { },

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeFilledButton.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeFilledButton.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.unit.dp
 import com.boostcamp.mapisode.designsystem.compose.IconSize
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
 import com.boostcamp.mapisode.designsystem.compose.MapisodeText
+import com.boostcamp.mapisode.designsystem.theme.MapisodeTextStyle
 import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 
 @Composable
@@ -24,6 +25,7 @@ fun MapisodeFilledButton(
 	modifier: Modifier = Modifier,
 	onClick: () -> Unit,
 	text: String,
+	textStyle: MapisodeTextStyle = MapisodeTheme.typography.titleLarge,
 	enabled: Boolean = true,
 	@DrawableRes leftIcon: Int? = null,
 	@DrawableRes rightIcon: Int? = null,
@@ -58,7 +60,7 @@ fun MapisodeFilledButton(
 		MapisodeText(
 			text = text,
 			color = MapisodeTheme.colorScheme.filledButtonContent,
-			style = MapisodeTheme.typography.titleLarge,
+			style = textStyle,
 		)
 
 		leftIcon ?: rightIcon?.let { icon ->

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeFilledButton.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeFilledButton.kt
@@ -50,7 +50,7 @@ fun MapisodeFilledButton(
 		leftIcon?.let { icon ->
 			MapisodeIcon(
 				id = icon,
-				iconSize = IconSize.Medium
+				iconSize = IconSize.Medium,
 			)
 			Spacer(modifier = Modifier.width(8.dp))
 		}
@@ -58,14 +58,14 @@ fun MapisodeFilledButton(
 		MapisodeText(
 			text = text,
 			color = MapisodeTheme.colorScheme.filledButtonContent,
-			style = MapisodeTheme.typography.titleLarge
+			style = MapisodeTheme.typography.titleLarge,
 		)
 
 		leftIcon ?: rightIcon?.let { icon ->
 			Spacer(modifier = Modifier.width(8.dp))
 			MapisodeIcon(
 				id = icon,
-				iconSize = IconSize.Medium
+				iconSize = IconSize.Medium,
 			)
 		}
 	}
@@ -80,13 +80,13 @@ fun MapisodeFilledButtonPreview() {
 	) {
 		MapisodeFilledButton(
 			onClick = { },
-			text = "활성화 버튼"
+			text = "활성화 버튼",
 		)
 
 		MapisodeFilledButton(
 			onClick = { },
 			text = "비활성화 버튼",
-			enabled = false
+			enabled = false,
 		)
 	}
 }

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeFilledButton.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeFilledButton.kt
@@ -38,9 +38,9 @@ fun MapisodeFilledButton(
         },
         contentColor = MapisodeTheme.colorScheme.filledButtonContent,
         modifier = Modifier
-            .then(modifier)
             .width(320.dp)
-            .height(52.dp),
+            .height(52.dp)
+            .then(modifier),
         enabled = enabled,
         showBorder = false,
         interactionSource = interactionSource,

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeFilledButton.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeFilledButton.kt
@@ -1,0 +1,92 @@
+package com.boostcamp.mapisode.designsystem.compose.button
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.boostcamp.mapisode.designsystem.compose.IconSize
+import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
+import com.boostcamp.mapisode.designsystem.compose.MapisodeText
+import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
+
+@Composable
+fun MapisodeFilledButton(
+    onClick: () -> Unit,
+    text: String,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    @DrawableRes leftIcon: Int? = null,
+    @DrawableRes rightIcon: Int? = null,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
+) {
+    MapisodeButton(
+        onClick = onClick,
+        backgroundColors = if (enabled) {
+            MapisodeTheme.colorScheme.filledButtonEnableBackground
+        } else {
+            MapisodeTheme.colorScheme.filledButtonDisableBackground
+        },
+        contentColor = MapisodeTheme.colorScheme.filledButtonContent,
+        modifier = Modifier
+            .then(modifier)
+            .width(320.dp)
+            .height(52.dp),
+        enabled = enabled,
+        showBorder = false,
+        interactionSource = interactionSource,
+        rounding = 8.dp,
+        contentPadding = PaddingValues(horizontal = 16.dp),
+    ) {
+        leftIcon?.let { icon ->
+            MapisodeIcon(
+                id = icon,
+                iconSize = IconSize.Medium
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+        }
+
+        MapisodeText(
+            text = text,
+            color = MapisodeTheme.colorScheme.filledButtonContent,
+            style = MapisodeTheme.typography.titleLarge
+        )
+
+        leftIcon ?: rightIcon?.let { icon ->
+            Spacer(modifier = Modifier.width(8.dp))
+            MapisodeIcon(
+                id = icon,
+                iconSize = IconSize.Medium
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun MapisodeFilledButtonPreview() {
+    Column(
+        modifier = Modifier.padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        MapisodeFilledButton(
+            onClick = { },
+            text = "활성화 버튼"
+        )
+
+        MapisodeFilledButton(
+            onClick = { },
+            text = "비활성화 버튼",
+            enabled = false
+        )
+    }
+}

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeFilledButton.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeFilledButton.kt
@@ -29,6 +29,7 @@ fun MapisodeFilledButton(
 	enabled: Boolean = true,
 	@DrawableRes leftIcon: Int? = null,
 	@DrawableRes rightIcon: Int? = null,
+	showRipple: Boolean = false,
 	interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 ) {
 	MapisodeButton(
@@ -45,6 +46,7 @@ fun MapisodeFilledButton(
 			.then(modifier),
 		enabled = enabled,
 		showBorder = false,
+		showRipple = showRipple,
 		interactionSource = interactionSource,
 		rounding = 8.dp,
 		contentPadding = PaddingValues(horizontal = 16.dp),

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeFilledButton.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeFilledButton.kt
@@ -21,9 +21,9 @@ import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 
 @Composable
 fun MapisodeFilledButton(
+    modifier: Modifier = Modifier,
     onClick: () -> Unit,
     text: String,
-    modifier: Modifier = Modifier,
     enabled: Boolean = true,
     @DrawableRes leftIcon: Int? = null,
     @DrawableRes rightIcon: Int? = null,
@@ -37,10 +37,7 @@ fun MapisodeFilledButton(
             MapisodeTheme.colorScheme.filledButtonDisableBackground
         },
         contentColor = MapisodeTheme.colorScheme.filledButtonContent,
-        modifier = Modifier
-            .width(320.dp)
-            .height(52.dp)
-            .then(modifier),
+        modifier = Modifier.width(320.dp).height(52.dp).then(modifier),
         enabled = enabled,
         showBorder = false,
         interactionSource = interactionSource,

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeOutlinedButton.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeOutlinedButton.kt
@@ -30,37 +30,40 @@ fun MapisodeOutlinedButton(
 	interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 ) {
 	MapisodeButton(
-        onClick = onClick,
-        backgroundColors = MapisodeTheme.colorScheme.outlineButtonBackground,
-        contentColor = MapisodeTheme.colorScheme.outlineButtonContent,
-        modifier = Modifier.width(320.dp).height(40.dp).then(modifier),
-        enabled = enabled,
-        showBorder = true,
-        borderColor = MapisodeTheme.colorScheme.outlineButtonStroke,
-        interactionSource = interactionSource,
-        rounding = 8.dp,
-        contentPadding = PaddingValues(horizontal = 16.dp),
-    ) {
+		onClick = onClick,
+		backgroundColors = MapisodeTheme.colorScheme.outlineButtonBackground,
+		contentColor = MapisodeTheme.colorScheme.outlineButtonContent,
+		modifier = Modifier
+			.width(320.dp)
+			.height(40.dp)
+			.then(modifier),
+		enabled = enabled,
+		showBorder = true,
+		borderColor = MapisodeTheme.colorScheme.outlineButtonStroke,
+		interactionSource = interactionSource,
+		rounding = 8.dp,
+		contentPadding = PaddingValues(horizontal = 16.dp),
+	) {
 		leftIcon?.let { icon ->
 			MapisodeIcon(
-                id = icon,
-                iconSize = IconSize.Small,
-            )
+				id = icon,
+				iconSize = IconSize.Small,
+			)
 			Spacer(modifier = Modifier.width(8.dp))
 		}
 
 		MapisodeText(
-            text = text,
-            color = MapisodeTheme.colorScheme.outlineButtonContent,
-            style = MapisodeTheme.typography.labelLarge,
-        )
+			text = text,
+			color = MapisodeTheme.colorScheme.outlineButtonContent,
+			style = MapisodeTheme.typography.labelLarge,
+		)
 
 		leftIcon ?: rightIcon?.let { icon ->
 			Spacer(modifier = Modifier.width(8.dp))
 			MapisodeIcon(
-                id = icon,
-                iconSize = IconSize.Small,
-            )
+				id = icon,
+				iconSize = IconSize.Small,
+			)
 		}
 	}
 }
@@ -69,12 +72,12 @@ fun MapisodeOutlinedButton(
 @Composable
 fun MapisodeOutlinedButtonPreview() {
 	Column(
-        modifier = Modifier.padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
+		modifier = Modifier.padding(16.dp),
+		verticalArrangement = Arrangement.spacedBy(8.dp),
+	) {
 		MapisodeOutlinedButton(
-            onClick = { },
-            text = "아웃라인 버튼",
-        )
+			onClick = { },
+			text = "아웃라인 버튼",
+		)
 	}
 }

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeOutlinedButton.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeOutlinedButton.kt
@@ -1,0 +1,83 @@
+package com.boostcamp.mapisode.designsystem.compose.button
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.boostcamp.mapisode.designsystem.compose.IconSize
+import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
+import com.boostcamp.mapisode.designsystem.compose.MapisodeText
+import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
+
+@Composable
+fun MapisodeOutlinedButton(
+	onClick: () -> Unit,
+	text: String,
+	modifier: Modifier = Modifier,
+	enabled: Boolean = true,
+	@DrawableRes leftIcon: Int? = null,
+	@DrawableRes rightIcon: Int? = null,
+	interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+	MapisodeButton(
+        onClick = onClick,
+        backgroundColors = MapisodeTheme.colorScheme.outlineButtonBackground,
+        contentColor = MapisodeTheme.colorScheme.outlineButtonContent,
+        modifier = Modifier
+            .then(modifier)
+            .width(320.dp)
+            .height(40.dp),
+        enabled = enabled,
+        showBorder = true,
+        borderColor = MapisodeTheme.colorScheme.outlineButtonStroke,
+        interactionSource = interactionSource,
+        rounding = 8.dp,
+        contentPadding = PaddingValues(horizontal = 16.dp),
+    ) {
+		leftIcon?.let { icon ->
+			MapisodeIcon(
+                id = icon,
+                iconSize = IconSize.Small,
+            )
+			Spacer(modifier = Modifier.width(8.dp))
+		}
+
+		MapisodeText(
+            text = text,
+            color = MapisodeTheme.colorScheme.outlineButtonContent,
+            style = MapisodeTheme.typography.labelLarge,
+        )
+
+		leftIcon ?: rightIcon?.let { icon ->
+			Spacer(modifier = Modifier.width(8.dp))
+			MapisodeIcon(
+                id = icon,
+                iconSize = IconSize.Small,
+            )
+		}
+	}
+}
+
+@Preview(showBackground = true)
+@Composable
+fun MapisodeOutlinedButtonPreview() {
+	Column(
+        modifier = Modifier.padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+		MapisodeOutlinedButton(
+            onClick = { },
+            text = "아웃라인 버튼",
+        )
+	}
+}

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeOutlinedButton.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeOutlinedButton.kt
@@ -27,6 +27,7 @@ fun MapisodeOutlinedButton(
 	enabled: Boolean = true,
 	@DrawableRes leftIcon: Int? = null,
 	@DrawableRes rightIcon: Int? = null,
+	showRipple: Boolean = false,
 	interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 ) {
 	MapisodeButton(
@@ -40,6 +41,7 @@ fun MapisodeOutlinedButton(
 		enabled = enabled,
 		showBorder = true,
 		borderColor = MapisodeTheme.colorScheme.outlineButtonStroke,
+		showRipple = showRipple,
 		interactionSource = interactionSource,
 		rounding = 8.dp,
 		contentPadding = PaddingValues(horizontal = 16.dp),

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeOutlinedButton.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeOutlinedButton.kt
@@ -21,9 +21,9 @@ import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 
 @Composable
 fun MapisodeOutlinedButton(
+	modifier: Modifier = Modifier,
 	onClick: () -> Unit,
 	text: String,
-	modifier: Modifier = Modifier,
 	enabled: Boolean = true,
 	@DrawableRes leftIcon: Int? = null,
 	@DrawableRes rightIcon: Int? = null,
@@ -33,10 +33,7 @@ fun MapisodeOutlinedButton(
         onClick = onClick,
         backgroundColors = MapisodeTheme.colorScheme.outlineButtonBackground,
         contentColor = MapisodeTheme.colorScheme.outlineButtonContent,
-        modifier = Modifier
-            .then(modifier)
-            .width(320.dp)
-            .height(40.dp),
+        modifier = Modifier.width(320.dp).height(40.dp).then(modifier),
         enabled = enabled,
         showBorder = true,
         borderColor = MapisodeTheme.colorScheme.outlineButtonStroke,

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/theme/ColorScheme.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/theme/ColorScheme.kt
@@ -5,114 +5,213 @@ import androidx.compose.ui.graphics.Color
 
 @Immutable
 data class CustomColorScheme(
+	// Navigation
 	val navSelectedItem: Color,
 	val navUnselectedItem: Color,
 	val navBackground: Color,
+
+	// Top App Bar
 	val topAppBarTitle: Color,
+
+	// Scaffold
 	val scaffoldBackground: Color,
-	val buttonBackground: Color,
-	val buttonContent: Color,
-	val buttonStroke: Color,
-	val chipBackground: Color,
-	val chipStroke: Color,
+
+	// Button
+	val filledButtonEnableBackground: Color,
+	val filledButtonDisableBackground: Color,
+	val filledButtonContent: Color,
+	val outlineButtonBackground: Color,
+	val outlineButtonStroke: Color,
+	val outlineButtonContent: Color,
+
+	// Chip
+	val chipUnselectedBackground: Color,
+	val chipSelectedBackground: Color,
+	val chipText: Color,
+	val chipSelectedStroke: Color,
+	val chipUnselectedStroke: Color,
+
+	// Text Field
 	val textFieldBackground: Color,
 	val textFieldContent: Color,
 	val textFieldStroke: Color,
+
+	// Dialog
 	val dialogBackground: Color,
 	val dialogStroke: Color,
 	val dialogDismiss: Color,
 	val dialogConfirm: Color,
+
+	// Toast
 	val toastBackground: Color,
 	val toastStroke: Color,
 	val toastContent: Color,
+
+	// Icon
 	val iconColor: Color,
-	val surfaceBackground: Color,
-	val dividerThinColor: Color,
-	val dividerThickColor: Color,
-	val textBackground: Color,
-	val textContent: Color,
-	val textStroke: Color,
-	val fabBackground: Color,
-	val fabContent: Color,
-	val systemBarTransparent: Color,
-	val systemBarColored: Color,
 	val eatIconColor: Color,
 	val seeIconColor: Color,
 	val otherIconColor: Color,
+
+	// Surface
+	val surfaceBackground: Color,
+
+	// Divider
+	val dividerThinColor: Color,
+	val dividerThickColor: Color,
+
+	// Text
+	val textBackground: Color,
+	val textContent: Color,
+	val textStroke: Color,
+
+	// FAB
+	val fabBackground: Color,
+	val fabContent: Color,
+
+	// System Bar
+	val systemBarTransparent: Color,
+	val systemBarColored: Color,
 )
 
 // Light Theme Color Scheme
 val lightColorScheme = CustomColorScheme(
+	// Navigation
 	navSelectedItem = Primary30,
 	navUnselectedItem = Neutral90,
 	navBackground = Neutral10,
+
+	// Top App Bar
 	topAppBarTitle = Primary90,
+
+	// Scaffold
 	scaffoldBackground = Neutral10,
-	buttonBackground = Primary30,
-	buttonContent = Neutral10,
-	buttonStroke = Color.Unspecified,
-	chipBackground = Neutral20,
-	chipStroke = Primary20,
+
+	// Button
+	filledButtonEnableBackground = Primary30,
+	filledButtonDisableBackground = Neutral60,
+	filledButtonContent = Neutral10,
+	outlineButtonBackground = Neutral110,
+	outlineButtonStroke = Neutral60,
+	outlineButtonContent = Neutral60,
+
+	// Chip
+	chipUnselectedBackground = Neutral10,
+	chipSelectedBackground = Neutral20,
+	chipText = Neutral110,
+	chipSelectedStroke = Primary30,
+	chipUnselectedStroke = Neutral40,
+
+	// Text Field
 	textFieldBackground = Color.Unspecified,
 	textFieldContent = Neutral60,
 	textFieldStroke = Neutral60,
+
+	// Dialog
 	dialogBackground = Neutral20,
 	dialogStroke = Color.Unspecified,
 	dialogDismiss = Error30,
 	dialogConfirm = Primary80,
+
+	// Toast
 	toastBackground = Neutral20,
 	toastStroke = Color.Unspecified,
 	toastContent = Neutral110,
+
+	// Icon
 	iconColor = Neutral110,
-	surfaceBackground = Neutral30,
-	dividerThinColor = Neutral50,
-	dividerThickColor = Neutral80,
-	textBackground = Color.Unspecified,
-	textContent = Neutral110,
-	textStroke = Color.Transparent,
-	fabBackground = Primary60,
-	fabContent = Primary30,
-	systemBarTransparent = Color.Transparent,
-	systemBarColored = Neutral20,
 	eatIconColor = Tertiary10,
 	seeIconColor = Error10,
 	otherIconColor = Primary40,
+
+	// Surface
+	surfaceBackground = Neutral30,
+
+	// Divider
+	dividerThinColor = Neutral50,
+	dividerThickColor = Neutral80,
+
+	// Text
+	textBackground = Color.Unspecified,
+	textContent = Neutral110,
+	textStroke = Color.Transparent,
+
+	// FAB
+	fabBackground = Primary30,
+	fabContent = Primary60,
+
+	// System Bar
+	systemBarTransparent = Color.Transparent,
+	systemBarColored = Neutral20,
 )
 
 // Dark Theme Color Scheme
 val darkColorScheme = CustomColorScheme(
-	navSelectedItem = Primary30,
+	// Navigation
+	navSelectedItem = Primary40,
 	navUnselectedItem = Neutral40,
 	navBackground = Neutral110,
+
+	// Top App Bar
 	topAppBarTitle = Primary10,
+
+	// Scaffold
 	scaffoldBackground = Neutral110,
-	buttonBackground = Primary60,
-	buttonContent = Neutral110,
-	buttonStroke = Color.Unspecified,
-	chipBackground = Neutral100,
-	chipStroke = Primary70,
+
+	// Button
+	filledButtonEnableBackground = Primary50,
+	filledButtonDisableBackground = Neutral80,
+	filledButtonContent = Neutral110,
+	outlineButtonBackground = Neutral40,
+	outlineButtonStroke = Neutral40,
+	outlineButtonContent = Neutral40,
+
+	// Chip
+	chipSelectedBackground = Neutral80,
+	chipUnselectedBackground = Neutral100,
+	chipText = Neutral10,
+	chipSelectedStroke = Primary30,
+	chipUnselectedStroke = Neutral40,
+
+	// Text Field
 	textFieldBackground = Color.Unspecified,
 	textFieldContent = Neutral70,
 	textFieldStroke = Neutral70,
+
+	// Dialog
 	dialogBackground = Neutral100,
 	dialogStroke = Color.Unspecified,
 	dialogDismiss = Error20,
 	dialogConfirm = Primary20,
+
+	// Toast
 	toastBackground = Neutral100,
 	toastStroke = Color.Unspecified,
 	toastContent = Neutral10,
+
+	// Icon
 	iconColor = Neutral10,
+	eatIconColor = Tertiary10,
+	seeIconColor = Error10,
+	otherIconColor = Primary20,
+
+	// Surface
 	surfaceBackground = Neutral90,
+
+	// Divider
 	dividerThinColor = Neutral80,
 	dividerThickColor = Neutral50,
+
+	// Text
 	textBackground = Color.Unspecified,
 	textContent = Neutral10,
 	textStroke = Color.Transparent,
-	fabBackground = Primary30,
-	fabContent = Primary60,
+
+	// FAB
+	fabBackground = Primary60,
+	fabContent = Primary30,
+
+	// System Bar
 	systemBarTransparent = Color.Transparent,
 	systemBarColored = Neutral100,
-	eatIconColor = Tertiary20,
-	seeIconColor = Error40,
-	otherIconColor = Primary50,
 )

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/theme/ColorScheme.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/theme/ColorScheme.kt
@@ -91,9 +91,9 @@ val lightColorScheme = CustomColorScheme(
 	filledButtonEnableBackground = Primary30,
 	filledButtonDisableBackground = Neutral60,
 	filledButtonContent = Neutral10,
-	outlineButtonBackground = Neutral110,
+	outlineButtonBackground = Neutral10,
 	outlineButtonStroke = Neutral60,
-	outlineButtonContent = Neutral60,
+	outlineButtonContent = Neutral70,
 
 	// Chip
 	chipUnselectedBackground = Neutral10,

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/theme/Theme.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/theme/Theme.kt
@@ -6,20 +6,11 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.staticCompositionLocalOf
-import androidx.compose.ui.graphics.Color
 
 internal val LocalMapisodeColorScheme = staticCompositionLocalOf { lightColorScheme }
 internal val LocalMapisodeTypography = staticCompositionLocalOf { AppTypography }
 internal val LocalMapisodeContentColor = compositionLocalOf { lightColorScheme.textContent }
 internal val LocalMapisodeContentAlpha = compositionLocalOf { 1f }
-
-private fun CustomColorScheme.pressedColorFor(color: Color): Color = when (color) {
-	navBackground -> dialogBackground
-	dialogBackground -> navBackground
-	textFieldBackground -> chipStroke
-	chipStroke -> textFieldBackground
-	else -> color
-}
 
 object MapisodeTheme {
 	val colorScheme: CustomColorScheme
@@ -29,10 +20,6 @@ object MapisodeTheme {
 	val typography: MaruBuriTypography
 		@Composable @ReadOnlyComposable
 		get() = LocalMapisodeTypography.current
-
-	@Composable
-	@ReadOnlyComposable
-	fun pressedColorFor(color: Color): Color = colorScheme.pressedColorFor(color)
 }
 
 @Composable

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/theme/Typography.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/theme/Typography.kt
@@ -145,7 +145,7 @@ data class MaruBuriTypography(
 
 	// label styles
 	val labelLarge: MapisodeTextStyle = MapisodeTextStyle(
-		fontWeight = FontWeight.Medium,
+		fontWeight = FontWeight.Bold,
 		fontSize = 14.dp,
 		lineHeight = 18.dp,
 	),

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/component/MapisodeChip.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/component/MapisodeChip.kt
@@ -33,14 +33,14 @@ fun MapisodeChip(
 	isSelected: Boolean = false,
 ) {
 	val backgroundColor = if (isSelected) {
-		MapisodeTheme.colorScheme.chipBackground
+		MapisodeTheme.colorScheme.chipSelectedBackground
 	} else {
-		MapisodeTheme.colorScheme.navBackground
+		MapisodeTheme.colorScheme.chipUnselectedBackground
 	}
 	val strokeColor = if (isSelected) {
-		MapisodeTheme.colorScheme.navSelectedItem
+		MapisodeTheme.colorScheme.chipSelectedStroke
 	} else {
-		MapisodeTheme.colorScheme.dividerThickColor
+		MapisodeTheme.colorScheme.chipUnselectedStroke
 	}
 	val rippleColor = MapisodeTheme.colorScheme.otherIconColor
 
@@ -65,7 +65,7 @@ fun MapisodeChip(
 			Spacer(modifier = Modifier.width(2.dp))
 			MapisodeText(
 				text = text,
-				color = MapisodeTheme.colorScheme.topAppBarTitle,
+				color = MapisodeTheme.colorScheme.chipText,
 				style = AppTypography.titleSmall,
 			)
 		}

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/component/MapisodeFabOverlayButton.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/component/MapisodeFabOverlayButton.kt
@@ -22,8 +22,8 @@ fun MapisodeFabOverlayButton(
 	onClick: () -> Unit,
 	modifier: Modifier = Modifier,
 	iconId: Int = R.drawable.ic_group,
-	backgroundColor: Color = MapisodeTheme.colorScheme.fabContent,
-	iconTint: Color = MapisodeTheme.colorScheme.fabBackground,
+	backgroundColor: Color = MapisodeTheme.colorScheme.fabBackground,
+	iconTint: Color = MapisodeTheme.colorScheme.fabContent,
 ) {
 	Surface(
 		modifier = modifier

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupScreen.kt
@@ -38,6 +38,7 @@ private fun GroupScreen() {
 			MapisodeFilledButton(
 				onClick = { },
 				text = "활성화 버튼",
+				showRipple = true,
 			)
 
 			MapisodeFilledButton(
@@ -49,6 +50,7 @@ private fun GroupScreen() {
 			MapisodeOutlinedButton(
 				onClick = { },
 				text = "아웃라인 버튼",
+				showRipple = true,
 			)
 		}
 	}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupScreen.kt
@@ -1,15 +1,17 @@
 package com.boostcamp.mapisode.mygroup
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
-import com.boostcamp.mapisode.designsystem.compose.MapisodeText
+import com.boostcamp.mapisode.designsystem.compose.button.MapisodeFilledButton
+import com.boostcamp.mapisode.designsystem.compose.button.MapisodeOutlinedButton
 import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
-import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 
 @Composable
 internal fun GroupRoute() {
@@ -28,15 +30,27 @@ private fun GroupScreen() {
 			)
 		},
 	) {
-		Box(
+		Column(
 			modifier = Modifier
-				.fillMaxSize()
-				.padding(it),
-			contentAlignment = Alignment.Center,
+                .fillMaxSize()
+                .padding(it),
+			verticalArrangement = Arrangement.spacedBy(16.dp),
+			horizontalAlignment = Alignment.CenterHorizontally,
 		) {
-			MapisodeText(
-				text = "Group",
-				style = MapisodeTheme.typography.displayMedium,
+			MapisodeFilledButton(
+				onClick = { },
+				text = "활성화 버튼",
+			)
+
+			MapisodeFilledButton(
+				onClick = { },
+				text = "비활성화 버튼",
+				enabled = false,
+			)
+
+			MapisodeOutlinedButton(
+				onClick = { },
+				text = "아웃라인 버튼",
 			)
 		}
 	}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupScreen.kt
@@ -31,9 +31,7 @@ private fun GroupScreen() {
 		},
 	) {
 		Column(
-			modifier = Modifier
-                .fillMaxSize()
-                .padding(it),
+			modifier = Modifier.fillMaxSize().padding(it),
 			verticalArrangement = Arrangement.spacedBy(16.dp),
 			horizontalAlignment = Alignment.CenterHorizontally,
 		) {


### PR DESCRIPTION
- closed #24 

## *📍 Work Description*

- 커스텀 FilledButton 제작
- 커스텀 OutlinedButton 제작
- 컬러 스킴 수정
- 커스텀 Ripple 제작

## *📸 Screenshot*

<img src="https://github.com/user-attachments/assets/5a4e1445-ffe8-466f-a046-0d827dc89f46" width=270 />
<br>
<img src="https://github.com/user-attachments/assets/71a938a0-52fe-4599-945d-79a1fcf49ea6" width=270 />
<br>

https://github.com/user-attachments/assets/ff9a897e-3ee2-46c2-a9ea-ccf35eaeb9b3

## *📢 To Reviewers*
- 버튼은 두가지 타입 FilledButton , OutlinedButton 을 생성하였습니다.
- 버튼의 너비는 기본 320 dp, 높이는 52 dp, stroke round는 8 dp 입니다.
- FilledButton 의 비활성화 버튼과 활성화 버튼의 색상를 구분했습니다.
- OutlinedButton 버튼은 색상이 활성화 상관없이 색상은 동일합니다.
- 버튼용 Surface의 modifier에 Custom Ripple을 적용했습니다.
- 클릭한 위치를 기반으로 원형 리플과 Surface 영역 전체의 리플 효과 두가지를 적용했습니다.

- 버튼 사용법 가이드 문서화 하겠습니다.

## ⏲️Time

    - 7시간
