### PR TITLE
[FEAT/#36]/ Custom TextField 제작

### DIFF
--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeTextField.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeTextField.kt
@@ -20,9 +20,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.Dp
@@ -33,10 +36,10 @@ import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 @Composable
 fun MapisodePlaceHolder(value: String) {
 	MapisodeText(
-        text = value,
-        style = MapisodeTheme.typography.labelLarge,
-        color = MapisodeTheme.colorScheme.textFieldContent,
-    )
+		text = value,
+		style = MapisodeTheme.typography.labelLarge,
+		color = MapisodeTheme.colorScheme.textFieldContent,
+	)
 }
 
 @Composable
@@ -59,11 +62,7 @@ fun MapisodeTextField(
 	keyboardOptions: KeyboardOptions = KeyboardOptions(
 		imeAction = ImeAction.Done,
 	),
-	keyboardActions: KeyboardActions = KeyboardActions(
-		onDone = {
-			onSubmitInput(value)
-		}
-	),
+	keyboardActions: KeyboardActions = KeyboardActions.Default,
 	singleLine: Boolean = false,
 	maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
 	minLines: Int = 1,
@@ -79,7 +78,8 @@ fun MapisodeTextField(
 ) {
 	@Suppress("NAME_SHADOWING")
 	val interactionSource = interactionSource ?: remember { MutableInteractionSource() }
-	val mergedTextStyle = textStyle.copy(color = textColor).toTextStyle()
+	val focusRequester = remember { FocusRequester() }
+	val focusManager = LocalFocusManager.current
 
 	Box(
 		modifier = modifier
@@ -109,47 +109,53 @@ fun MapisodeTextField(
 				}
 			}
 			BasicTextField(
-                value = value,
-                onValueChange = onValueChange,
-                modifier = Modifier
+				value = value,
+				onValueChange = onValueChange,
+				modifier = Modifier
                     .weight(1f)
-                    .fillMaxWidth(),
-                enabled = enabled,
-                readOnly = readOnly,
-                textStyle = mergedTextStyle,
-                cursorBrush = SolidColor(cursorColor),
-                visualTransformation = visualTransformation,
-                keyboardOptions = keyboardOptions,
-                keyboardActions = keyboardActions,
-                interactionSource = interactionSource,
-                singleLine = singleLine,
-                maxLines = maxLines,
-                minLines = minLines,
-                decorationBox = { innerTextField ->
-                    Box(
-                        modifier = Modifier.fillMaxWidth(),
-                        contentAlignment = Alignment.CenterStart,
-                    ) {
-                        if (prefix != null) {
-                            Box(modifier = Modifier.padding(end = 8.dp)) {
-                                prefix()
-                            }
-                        }
+                    .fillMaxWidth()
+                    .focusRequester(focusRequester),
+				enabled = enabled,
+				readOnly = readOnly,
+				textStyle = textStyle.copy(color = textColor).toTextStyle(),
+				cursorBrush = SolidColor(cursorColor),
+				visualTransformation = visualTransformation,
+				keyboardOptions = keyboardOptions,
+				keyboardActions = KeyboardActions(
+					onDone = {
+						onSubmitInput(value)
+						focusManager.clearFocus()
+					},
+				),
+				interactionSource = interactionSource,
+				singleLine = singleLine,
+				maxLines = maxLines,
+				minLines = minLines,
+				decorationBox = { innerTextField ->
+					Box(
+						modifier = Modifier.fillMaxWidth(),
+						contentAlignment = Alignment.CenterStart,
+					) {
+						if (prefix != null) {
+							Box(modifier = Modifier.padding(end = 8.dp)) {
+								prefix()
+							}
+						}
 
-                        if (value.isEmpty() && placeholder.isNotBlank()) {
-                            MapisodePlaceHolder(value = placeholder)
-                        }
+						if (value.isEmpty() && placeholder.isNotBlank()) {
+							MapisodePlaceHolder(value = placeholder)
+						}
 
-                        innerTextField()
+						innerTextField()
 
-                        if (suffix != null) {
-                            Box(modifier = Modifier.padding(start = 8.dp)) {
-                                suffix()
-                            }
-                        }
-                    }
-                },
-            )
+						if (suffix != null) {
+							Box(modifier = Modifier.padding(start = 8.dp)) {
+								suffix()
+							}
+						}
+					}
+				},
+			)
 		}
 	}
 }

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeTextField.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeTextField.kt
@@ -30,6 +30,15 @@ import com.boostcamp.mapisode.designsystem.theme.MapisodeTextStyle
 import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 
 @Composable
+fun MapisodePlaceHolder(value: String) {
+	MapisodeText(
+        text = value,
+        style = MapisodeTheme.typography.labelLarge,
+        color = MapisodeTheme.colorScheme.textFieldContent,
+    )
+}
+
+@Composable
 fun MapisodeTextField(
 	value: String,
 	onValueChange: (String) -> Unit,
@@ -38,7 +47,7 @@ fun MapisodeTextField(
 	readOnly: Boolean = false,
 	textStyle: MapisodeTextStyle = MapisodeTheme.typography.labelLarge,
 	label: @Composable (() -> Unit)? = null,
-	placeholder: @Composable (() -> Unit)? = null,
+	placeholder: String,
 	leadingIcon: @Composable (() -> Unit)? = null,
 	trailingIcon: @Composable (() -> Unit)? = null,
 	prefix: @Composable (() -> Unit)? = null,
@@ -66,20 +75,20 @@ fun MapisodeTextField(
 
 	Box(
 		modifier = modifier
-			.width(320.dp)
-			.height(42.dp)
-			.defaultMinSize(
-				minWidth = 320.dp,
-				minHeight = 42.dp,
-			)
-			.clickable(
-				interactionSource = interactionSource,
-				indication = null,
-				enabled = enabled && !readOnly,
-			) { }
-			.border(strokeWidth, strokeColor, shape)
-			.background(if (isError) errorContainerColor else containerColor, shape)
-			.padding(vertical = 12.dp, horizontal = 16.dp),
+            .width(320.dp)
+            .height(42.dp)
+            .defaultMinSize(
+                minWidth = 320.dp,
+                minHeight = 42.dp,
+            )
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                enabled = enabled && !readOnly,
+            ) { }
+            .border(strokeWidth, strokeColor, shape)
+            .background(if (isError) errorContainerColor else containerColor, shape)
+            .padding(vertical = 12.dp, horizontal = 16.dp),
 	) {
 		Row(
 			modifier = Modifier.fillMaxWidth(),
@@ -92,28 +101,48 @@ fun MapisodeTextField(
 				}
 			}
 			BasicTextField(
-				value = value,
-				onValueChange = onValueChange,
-				modifier = Modifier
-					.weight(1f)
-					.fillMaxWidth(),
-				enabled = enabled,
-				readOnly = readOnly,
-				textStyle = mergedTextStyle,
-				cursorBrush = SolidColor(cursorColor),
-				visualTransformation = visualTransformation,
-				keyboardOptions = keyboardOptions,
-				keyboardActions = keyboardActions,
-				interactionSource = interactionSource,
-				singleLine = singleLine,
-				maxLines = maxLines,
-				minLines = minLines,
-			)
-			if (trailingIcon != null) {
-				Box(modifier = Modifier.padding(start = 16.dp)) {
-					trailingIcon()
-				}
-			}
+                value = value,
+                onValueChange = onValueChange,
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth(),
+                enabled = enabled,
+                readOnly = readOnly,
+                textStyle = mergedTextStyle,
+                cursorBrush = SolidColor(cursorColor),
+                visualTransformation = visualTransformation,
+                keyboardOptions = keyboardOptions,
+                keyboardActions = keyboardActions,
+                interactionSource = interactionSource,
+                singleLine = singleLine,
+                maxLines = maxLines,
+                minLines = minLines,
+                decorationBox = { innerTextField ->
+                    Box(
+                        modifier = Modifier.fillMaxWidth(),
+                        contentAlignment = Alignment.CenterStart,
+                    ) {
+                        if (prefix != null) {
+                            Box(modifier = Modifier.padding(end = 8.dp)) {
+                                prefix()
+                            }
+                        }
+
+                        if (value.isEmpty() && placeholder.isNotBlank()) {
+                            MapisodePlaceHolder(value = placeholder)
+                        }
+
+                        innerTextField()
+
+                        if (suffix != null) {
+                            Box(modifier = Modifier.padding(start = 8.dp)) {
+                                suffix()
+                            }
+                        }
+                    }
+                },
+            )
 		}
 	}
 }
+

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeTextField.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeTextField.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -54,8 +55,15 @@ fun MapisodeTextField(
 	suffix: @Composable (() -> Unit)? = null,
 	isError: Boolean = false,
 	visualTransformation: VisualTransformation = VisualTransformation.None,
-	keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
-	keyboardActions: KeyboardActions = KeyboardActions.Default,
+	onSubmitInput: (String) -> Unit = {},
+	keyboardOptions: KeyboardOptions = KeyboardOptions(
+		imeAction = ImeAction.Done,
+	),
+	keyboardActions: KeyboardActions = KeyboardActions(
+		onDone = {
+			onSubmitInput(value)
+		}
+	),
 	singleLine: Boolean = false,
 	maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
 	minLines: Int = 1,

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeTextField.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeTextField.kt
@@ -1,0 +1,119 @@
+package com.boostcamp.mapisode.designsystem.compose
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.boostcamp.mapisode.designsystem.theme.MapisodeTextStyle
+import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
+
+@Composable
+fun MapisodeTextField(
+	value: String,
+	onValueChange: (String) -> Unit,
+	modifier: Modifier = Modifier,
+	enabled: Boolean = true,
+	readOnly: Boolean = false,
+	textStyle: MapisodeTextStyle = MapisodeTheme.typography.labelLarge,
+	label: @Composable (() -> Unit)? = null,
+	placeholder: @Composable (() -> Unit)? = null,
+	leadingIcon: @Composable (() -> Unit)? = null,
+	trailingIcon: @Composable (() -> Unit)? = null,
+	prefix: @Composable (() -> Unit)? = null,
+	suffix: @Composable (() -> Unit)? = null,
+	isError: Boolean = false,
+	visualTransformation: VisualTransformation = VisualTransformation.None,
+	keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+	keyboardActions: KeyboardActions = KeyboardActions.Default,
+	singleLine: Boolean = false,
+	maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
+	minLines: Int = 1,
+	interactionSource: MutableInteractionSource? = null,
+	shape: Shape = RoundedCornerShape(8.dp),
+	containerColor: Color = MapisodeTheme.colorScheme.textFieldBackground,
+	textColor: Color = MapisodeTheme.colorScheme.textFieldContent,
+	cursorColor: Color = MapisodeTheme.colorScheme.textFieldStroke,
+	errorContainerColor: Color = MapisodeTheme.colorScheme.seeIconColor,
+	errorTextColor: Color = MapisodeTheme.colorScheme.seeIconColor,
+	strokeColor: Color = MapisodeTheme.colorScheme.textFieldStroke,
+	strokeWidth: Dp = 1.dp,
+) {
+	@Suppress("NAME_SHADOWING")
+	val interactionSource = interactionSource ?: remember { MutableInteractionSource() }
+	val mergedTextStyle = textStyle.copy(color = textColor).toTextStyle()
+
+	Box(
+		modifier = modifier
+			.width(320.dp)
+			.height(42.dp)
+			.defaultMinSize(
+				minWidth = 320.dp,
+				minHeight = 42.dp,
+			)
+			.clickable(
+				interactionSource = interactionSource,
+				indication = null,
+				enabled = enabled && !readOnly,
+			) { }
+			.border(strokeWidth, strokeColor, shape)
+			.background(if (isError) errorContainerColor else containerColor, shape)
+			.padding(vertical = 12.dp, horizontal = 16.dp),
+	) {
+		Row(
+			modifier = Modifier.fillMaxWidth(),
+			verticalAlignment = Alignment.CenterVertically,
+			horizontalArrangement = Arrangement.SpaceBetween,
+		) {
+			if (leadingIcon != null) {
+				Box(modifier = Modifier.padding(end = 16.dp)) {
+					leadingIcon()
+				}
+			}
+			BasicTextField(
+				value = value,
+				onValueChange = onValueChange,
+				modifier = Modifier
+					.weight(1f)
+					.fillMaxWidth(),
+				enabled = enabled,
+				readOnly = readOnly,
+				textStyle = mergedTextStyle,
+				cursorBrush = SolidColor(cursorColor),
+				visualTransformation = visualTransformation,
+				keyboardOptions = keyboardOptions,
+				keyboardActions = keyboardActions,
+				interactionSource = interactionSource,
+				singleLine = singleLine,
+				maxLines = maxLines,
+				minLines = minLines,
+			)
+			if (trailingIcon != null) {
+				Box(modifier = Modifier.padding(start = 16.dp)) {
+					trailingIcon()
+				}
+			}
+		}
+	}
+}

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeTextField.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeTextField.kt
@@ -159,4 +159,3 @@ fun MapisodeTextField(
 		}
 	}
 }
-

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeTextField.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeTextField.kt
@@ -53,7 +53,7 @@ fun MapisodeTextField(
 	readOnly: Boolean = false,
 	textStyle: MapisodeTextStyle = MapisodeTheme.typography.labelLarge,
 	label: @Composable (() -> Unit)? = null,
-	placeholder: String,
+	placeholder: String = "",
 	leadingIcon: @Composable (() -> Unit)? = null,
 	trailingIcon: @Composable (() -> Unit)? = null,
 	prefix: @Composable (() -> Unit)? = null,

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeTextField.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeTextField.kt
@@ -112,9 +112,7 @@ fun MapisodeTextField(
 			horizontalArrangement = Arrangement.SpaceBetween,
 		) {
 			if (leadingIcon != null) {
-				Box(modifier = Modifier.padding(end = 16.dp)) {
-					leadingIcon()
-				}
+				leadingIcon()
 			}
 			BasicTextField(
 				value = value,
@@ -162,6 +160,9 @@ fun MapisodeTextField(
 					}
 				},
 			)
+			if (trailingIcon != null) {
+				trailingIcon()
+			}
 		}
 	}
 }

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeTextField.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeTextField.kt
@@ -17,11 +17,13 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.SolidColor
@@ -78,8 +80,8 @@ fun MapisodeTextField(
 ) {
 	@Suppress("NAME_SHADOWING")
 	val interactionSource = interactionSource ?: remember { MutableInteractionSource() }
-	val focusRequester = remember { FocusRequester() }
 	val focusManager = LocalFocusManager.current
+	var isFocused by remember { mutableStateOf(false) }
 
 	Box(
 		modifier = modifier
@@ -94,6 +96,12 @@ fun MapisodeTextField(
                 indication = null,
                 enabled = enabled && !readOnly,
             ) { }
+            .onFocusChanged { focusState ->
+                if (isFocused && !focusState.isFocused) {
+                    onSubmitInput(value)
+                }
+                isFocused = focusState.isFocused
+            }
             .border(strokeWidth, strokeColor, shape)
             .background(if (isError) errorContainerColor else containerColor, shape)
             .padding(vertical = 12.dp, horizontal = 16.dp),
@@ -113,8 +121,7 @@ fun MapisodeTextField(
 				onValueChange = onValueChange,
 				modifier = Modifier
                     .weight(1f)
-                    .fillMaxWidth()
-                    .focusRequester(focusRequester),
+                    .fillMaxWidth(),
 				enabled = enabled,
 				readOnly = readOnly,
 				textStyle = textStyle.copy(color = textColor).toTextStyle(),
@@ -123,7 +130,6 @@ fun MapisodeTextField(
 				keyboardOptions = keyboardOptions,
 				keyboardActions = KeyboardActions(
 					onDone = {
-						onSubmitInput(value)
 						focusManager.clearFocus()
 					},
 				),

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeTextField.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeTextField.kt
@@ -85,26 +85,26 @@ fun MapisodeTextField(
 
 	Box(
 		modifier = modifier
-            .width(320.dp)
-            .height(42.dp)
-            .defaultMinSize(
-                minWidth = 320.dp,
-                minHeight = 42.dp,
-            )
-            .clickable(
-                interactionSource = interactionSource,
-                indication = null,
-                enabled = enabled && !readOnly,
-            ) { }
-            .onFocusChanged { focusState ->
-                if (isFocused && !focusState.isFocused) {
-                    onSubmitInput(value)
-                }
-                isFocused = focusState.isFocused
-            }
-            .border(strokeWidth, strokeColor, shape)
-            .background(if (isError) errorContainerColor else containerColor, shape)
-            .padding(vertical = 12.dp, horizontal = 16.dp),
+			.width(320.dp)
+			.height(42.dp)
+			.defaultMinSize(
+				minWidth = 320.dp,
+				minHeight = 42.dp,
+			)
+			.clickable(
+				interactionSource = interactionSource,
+				indication = null,
+				enabled = enabled && !readOnly,
+			) { }
+			.onFocusChanged { focusState ->
+				if (isFocused && !focusState.isFocused) {
+					onSubmitInput(value)
+				}
+				isFocused = focusState.isFocused
+			}
+			.border(strokeWidth, strokeColor, shape)
+			.background(if (isError) errorContainerColor else containerColor, shape)
+			.padding(vertical = 12.dp, horizontal = 16.dp),
 	) {
 		Row(
 			modifier = Modifier.fillMaxWidth(),
@@ -118,8 +118,8 @@ fun MapisodeTextField(
 				value = value,
 				onValueChange = onValueChange,
 				modifier = Modifier
-                    .weight(1f)
-                    .fillMaxWidth(),
+					.weight(1f)
+					.fillMaxWidth(),
 				enabled = enabled,
 				readOnly = readOnly,
 				textStyle = textStyle.copy(color = textColor).toTextStyle(),

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupScreen.kt
@@ -1,5 +1,6 @@
 package com.boostcamp.mapisode.mygroup
 
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -11,6 +12,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
 import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
 import com.boostcamp.mapisode.designsystem.compose.MapisodeText
@@ -27,9 +30,16 @@ internal fun GroupRoute() {
 
 @Composable
 private fun GroupScreen() {
+	val focusManager = LocalFocusManager.current
+
 	MapisodeScaffold(
 		modifier = Modifier
-			.fillMaxSize(),
+            .fillMaxSize()
+            .pointerInput(Unit) {
+                detectTapGestures {
+					focusManager.clearFocus()
+                }
+            },
 		isStatusBarPaddingExist = true,
 		topBar = {
 			TopAppBar(
@@ -38,7 +48,9 @@ private fun GroupScreen() {
 		},
 	) {
 		Column(
-			modifier = Modifier.fillMaxSize().padding(it),
+			modifier = Modifier
+                .fillMaxSize()
+                .padding(it),
 			verticalArrangement = Arrangement.spacedBy(16.dp),
 			horizontalAlignment = Alignment.CenterHorizontally,
 		) {
@@ -64,13 +76,13 @@ private fun GroupScreen() {
 			var submittedText by remember { mutableStateOf("") }
 
 			MapisodeTextField(
-				value = inputText,
-				onValueChange = { text -> inputText = text },
-				placeholder = "텍스트 필드",
-				onSubmitInput = { text ->
-					submittedText = text
-				}
-			)
+                value = inputText,
+                onValueChange = { text -> inputText = text },
+                placeholder = "텍스트 필드",
+                onSubmitInput = { text ->
+                    submittedText = text
+				},
+            )
 
 			MapisodeText(
 				text = submittedText,
@@ -86,7 +98,7 @@ private fun GroupScreen() {
 				placeholder = "텍스트 필드",
 				onSubmitInput = { text ->
 					submittedText2 = text
-				}
+				},
 			)
 		}
 	}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
-import com.boostcamp.mapisode.designsystem.compose.MapisodeText
 import com.boostcamp.mapisode.designsystem.compose.MapisodeTextField
 import com.boostcamp.mapisode.designsystem.compose.button.MapisodeFilledButton
 import com.boostcamp.mapisode.designsystem.compose.button.MapisodeOutlinedButton
@@ -64,7 +63,7 @@ private fun GroupScreen() {
 			MapisodeTextField(
 				value = inputText,
 				onValueChange = { text -> inputText = text },
-				placeholder = { MapisodeText("텍스트 필드") },
+				placeholder = "텍스트 필드",
 			)
 		}
 	}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupScreen.kt
@@ -69,13 +69,24 @@ private fun GroupScreen() {
 				placeholder = "텍스트 필드",
 				onSubmitInput = { text ->
 					submittedText = text
-					inputText = ""
 				}
 			)
 
 			MapisodeText(
 				text = submittedText,
 				style = MapisodeTheme.typography.bodyLarge,
+			)
+
+			var inputText2 by remember { mutableStateOf("") }
+			var submittedText2 by remember { mutableStateOf("") }
+
+			MapisodeTextField(
+				value = inputText2,
+				onValueChange = { text -> inputText2 = text },
+				placeholder = "텍스트 필드",
+				onSubmitInput = { text ->
+					submittedText2 = text
+				}
 			)
 		}
 	}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupScreen.kt
@@ -52,6 +52,8 @@ private fun GroupScreen() {
 				text = "아웃라인 버튼",
 				showRipple = true,
 			)
+
+			
 		}
 	}
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupScreen.kt
@@ -13,10 +13,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
+import com.boostcamp.mapisode.designsystem.compose.MapisodeText
 import com.boostcamp.mapisode.designsystem.compose.MapisodeTextField
 import com.boostcamp.mapisode.designsystem.compose.button.MapisodeFilledButton
 import com.boostcamp.mapisode.designsystem.compose.button.MapisodeOutlinedButton
 import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
+import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 
 @Composable
 internal fun GroupRoute() {
@@ -59,11 +61,21 @@ private fun GroupScreen() {
 			)
 
 			var inputText by remember { mutableStateOf("") }
+			var submittedText by remember { mutableStateOf("") }
 
 			MapisodeTextField(
 				value = inputText,
 				onValueChange = { text -> inputText = text },
 				placeholder = "텍스트 필드",
+				onSubmitInput = { text ->
+					submittedText = text
+					inputText = ""
+				}
+			)
+
+			MapisodeText(
+				text = submittedText,
+				style = MapisodeTheme.typography.bodyLarge,
 			)
 		}
 	}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupScreen.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
+import com.boostcamp.mapisode.designsystem.R
+import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
 import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
 import com.boostcamp.mapisode.designsystem.compose.MapisodeText
 import com.boostcamp.mapisode.designsystem.compose.MapisodeTextField
@@ -92,6 +94,20 @@ private fun GroupScreen() {
 			MapisodeText(
 				text = submittedText,
 				style = MapisodeTheme.typography.bodyLarge,
+			)
+
+			MapisodeTextField(
+				value = inputText,
+				onValueChange = { text -> inputText = text },
+				placeholder = "위치를 입력하세요",
+				onSubmitInput = { text ->
+					submittedText = text
+				},
+				trailingIcon = {
+					MapisodeIcon(
+						id = R.drawable.ic_location,
+					)
+				},
 			)
 		}
 	}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupScreen.kt
@@ -5,10 +5,16 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
+import com.boostcamp.mapisode.designsystem.compose.MapisodeText
+import com.boostcamp.mapisode.designsystem.compose.MapisodeTextField
 import com.boostcamp.mapisode.designsystem.compose.button.MapisodeFilledButton
 import com.boostcamp.mapisode.designsystem.compose.button.MapisodeOutlinedButton
 import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
@@ -53,7 +59,13 @@ private fun GroupScreen() {
 				showRipple = true,
 			)
 
-			
+			var inputText by remember { mutableStateOf("") }
+
+			MapisodeTextField(
+				value = inputText,
+				onValueChange = { text -> inputText = text },
+				placeholder = { MapisodeText("텍스트 필드") },
+			)
 		}
 	}
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupScreen.kt
@@ -34,12 +34,14 @@ private fun GroupScreen() {
 
 	MapisodeScaffold(
 		modifier = Modifier
-            .fillMaxSize()
-            .pointerInput(Unit) {
-                detectTapGestures {
-					focusManager.clearFocus()
-                }
-            },
+			.fillMaxSize()
+			.pointerInput(Unit) {
+				detectTapGestures(
+					onPress = {
+						focusManager.clearFocus()
+					},
+				)
+			},
 		isStatusBarPaddingExist = true,
 		topBar = {
 			TopAppBar(
@@ -49,13 +51,19 @@ private fun GroupScreen() {
 	) {
 		Column(
 			modifier = Modifier
-                .fillMaxSize()
-                .padding(it),
+				.fillMaxSize()
+				.padding(it)
+				.padding(horizontal = 46.dp),
 			verticalArrangement = Arrangement.spacedBy(16.dp),
 			horizontalAlignment = Alignment.CenterHorizontally,
 		) {
+			var inputText by remember { mutableStateOf("") }
+			var submittedText by remember { mutableStateOf("") }
+
 			MapisodeFilledButton(
-				onClick = { },
+				onClick = {
+					focusManager.clearFocus()
+				},
 				text = "활성화 버튼",
 				showRipple = true,
 			)
@@ -67,38 +75,23 @@ private fun GroupScreen() {
 			)
 
 			MapisodeOutlinedButton(
-				onClick = { },
+				onClick = { submittedText = "아웃라인 버튼 클릭" },
 				text = "아웃라인 버튼",
 				showRipple = true,
 			)
 
-			var inputText by remember { mutableStateOf("") }
-			var submittedText by remember { mutableStateOf("") }
-
 			MapisodeTextField(
-                value = inputText,
-                onValueChange = { text -> inputText = text },
-                placeholder = "텍스트 필드",
-                onSubmitInput = { text ->
-                    submittedText = text
+				value = inputText,
+				onValueChange = { text -> inputText = text },
+				placeholder = "텍스트 필드",
+				onSubmitInput = { text ->
+					submittedText = text
 				},
-            )
+			)
 
 			MapisodeText(
 				text = submittedText,
 				style = MapisodeTheme.typography.bodyLarge,
-			)
-
-			var inputText2 by remember { mutableStateOf("") }
-			var submittedText2 by remember { mutableStateOf("") }
-
-			MapisodeTextField(
-				value = inputText2,
-				onValueChange = { text -> inputText2 = text },
-				placeholder = "텍스트 필드",
-				onSubmitInput = { text ->
-					submittedText2 = text
-				},
 			)
 		}
 	}


### PR DESCRIPTION
- closed #36 

## *📍 Work Description*

- PlaceHolder 제작을 통해 무엇을 입력해야 하는지 유저에게 알려줌. 문자열이 비어있지 않으면 사라짐
- 함수 인자 `value: String`, `onValueChang: (String) -> Unit`, `onSubmitInput: (String) -> Unit` 세가지를 사용하여 데이터를 입력받고 반환하도록 설정
- 키보드 옵션을 설정하여 imeAction 을 Done (Default는 엔터 버튼 -> Done은 체크 아이콘의 완료 버튼)으로 설정. 누르면 focus 를 clear
- focus 감지를 통해 focus가 clear되면 onSubmitInput 콜백함수가 실행되도록 설정. focus 감지는 `Modifier.onFocusChanged { }` 를 통해 인식

## *📸 Screenshot*

https://github.com/user-attachments/assets/1eefa007-0279-4cc5-a9b4-569222779cdc

https://github.com/user-attachments/assets/640e64f6-ff75-4cbc-8631-00d70128be71


## *📢 To Reviewers*
기본 사용법은 아래와 같습니다.
<img src="https://github.com/user-attachments/assets/e19056d2-e8d9-446c-9396-d19a6d6c7e22" width=600>

아이콘을 원하신다면
<img src="https://github.com/user-attachments/assets/f4a9760e-2cbe-4be2-bca5-17be379a2b50" width=600>

## ⏲️Time

    - 6.5시간


