### PR TITLE
[FIX/#43] Custom Button 관련 Modifier 수정

### DIFF
--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeRipple.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeRipple.kt
@@ -48,7 +48,7 @@ fun Modifier.mapisodeRippleEffect(
 						val event = awaitPointerEvent()
 						val pointer = event.changes.firstOrNull()
 
-						if (pointer!=null && pointer.pressed) {
+						if (pointer != null && pointer.pressed) {
 							rippleState.rippleCenter = pointer.position
 							coroutineScope.launch {
 								val maxRadius = size.width.coerceAtLeast(size.height) * 1.5f

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeFilledButton.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeFilledButton.kt
@@ -41,9 +41,9 @@ fun MapisodeFilledButton(
 		},
 		contentColor = MapisodeTheme.colorScheme.filledButtonContent,
 		modifier = Modifier
+			.then(modifier)
 			.width(320.dp)
-			.height(52.dp)
-			.then(modifier),
+			.height(52.dp),
 		enabled = enabled,
 		showBorder = false,
 		showRipple = showRipple,

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeOutlinedButton.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeOutlinedButton.kt
@@ -35,9 +35,9 @@ fun MapisodeOutlinedButton(
 		backgroundColors = MapisodeTheme.colorScheme.outlineButtonBackground,
 		contentColor = MapisodeTheme.colorScheme.outlineButtonContent,
 		modifier = Modifier
+			.then(modifier)
 			.width(320.dp)
-			.height(40.dp)
-			.then(modifier),
+			.height(40.dp),
 		enabled = enabled,
 		showBorder = true,
 		borderColor = MapisodeTheme.colorScheme.outlineButtonStroke,


### PR DESCRIPTION
- closed #43 

## *📍 Work Description*

- Custom Ripple 의 Modifier 수정
- Custom Button의 Modifier 수정

## *📸 Screenshot*

정상 작동 영상

- PR #44 

문제1. 리플에서 이벤트(Tap)를 소모(consume)하여 다음 Modifier.clickable이 이벤트를 받지 못하여 onClick 실행이 안되는 문제

https://github.com/user-attachments/assets/ba0b8726-5f96-49dc-ad76-15e32fc113bc

문제2. 단순히 Modifier.clickable 을 Modifier.CustomRipple 보다 먼저 실행시키니, clickable에서 이벤트를 소모하여 CustomRipple이 이벤트를 받지 못하는 문제.

https://github.com/user-attachments/assets/ddb2559a-b3f7-48fd-9669-7506c3296f04

## *📢 To Reviewers*
- Modifier.clickable, Modifier.CustomRipple의 로직은 Custom Surface에 존재합니다.
- Custom Surface는 Custom Button의 내부 컴포넌트입니다.
- Modifier.CustomRipple 을 먼저 실행시키되, 이벤트가 consume이 되지 않도록 Custom Ripple 함수 내부에서 이벤트가 감지될 때, Modifier.pointerInput 함수를 통해 PointerInputScope 타입의 람다식 바디 내부에서 awaitPointerEventScope 함수와 while(true)를 사용하여 이벤트가 소비되는 방식이 아닌 코루틴 내부에서 반복적으로 event가 감지될 때까지 block 되고 감지되면 ripple을 그리도록 했습니다.
- - -
- Button Modifier는 Modifier.then() 의 위치를 앞으로 당겼습니다.
- then 함수 특성상 then 인자의 Modifier에서 호출된 확장함수와 then의 호출객체 Modifier가 호출한 확장함수가 동일하다면, 가장 먼저 호출된 확장함수가 최종적으로 적용되는 특성이 있습니다.
- 아래와 같은 경우에서, then의 modifier가 Modifier.width(400.dp)라면 400.dp가 적용됩니다.
  <img src="https://github.com/user-attachments/assets/f73a003b-93b3-49b9-9b92-d72aee477ac3" width=300>
- 이와 같이 적용한 이유는, Custom Button을 초기화할 때 외부에서 너비랑 높이를 설정할 수 있도록 했습니다.

## ⏲️Time

    - 2.5시간
