### PR TITLE
[FEAT/#46] Custom IconButton 생성

### DIFF
--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeIcon.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeIcon.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.boostcamp.mapisode.designsystem.R
+import com.boostcamp.mapisode.designsystem.theme.LocalMapisodeIconColor
 import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 
 sealed class IconSize(val value: Dp) {
@@ -43,10 +44,12 @@ fun MapisodeIcon(
 	modifier: Modifier = Modifier,
 	contentDescription: String? = null,
 	iconSize: IconSize = IconSize.Medium,
-	tint: Color? = MapisodeTheme.colorScheme.iconColor,
+	tint: Color? = LocalMapisodeIconColor.current.let {
+		if (it == Color.Unspecified) MapisodeTheme.colorScheme.iconColor else it
+	},
 ) {
 	val colorFilter = tint?.let { ColorFilter.tint(it) }
-	val semantics = if (contentDescription != null) {
+	val semantics = if (contentDescription!=null) {
 		Modifier.semantics {
 			this.contentDescription = contentDescription
 			this.role = Role.Image

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeIcon.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeIcon.kt
@@ -49,7 +49,7 @@ fun MapisodeIcon(
 	},
 ) {
 	val colorFilter = tint?.let { ColorFilter.tint(it) }
-	val semantics = if (contentDescription!=null) {
+	val semantics = if (contentDescription != null) {
 		Modifier.semantics {
 			this.contentDescription = contentDescription
 			this.role = Role.Image

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeIconButton.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeIconButton.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
-import com.boostcamp.mapisode.designsystem.theme.LocalMapisodeContentColor
+import com.boostcamp.mapisode.designsystem.theme.LocalMapisodeIconColor
 import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 
 @Composable
@@ -50,7 +50,10 @@ fun MapisodeIconButton(
 			?: MapisodeTheme.colorScheme.run {
 				if (enabled) iconButtonEnabled else iconButtonDisabled
 			}
-		CompositionLocalProvider(LocalMapisodeContentColor provides finalContentColor, content = content)
+		CompositionLocalProvider(
+			value = LocalMapisodeIconColor provides finalContentColor,
+			content = content,
+		)
 	}
 }
 

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeIconButton.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeIconButton.kt
@@ -1,0 +1,56 @@
+package com.boostcamp.mapisode.designsystem.compose
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
+import com.boostcamp.mapisode.designsystem.theme.LocalMapisodeContentColor
+import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
+
+@Composable
+fun MapisodeIconButton(
+	onClick: () -> Unit,
+	modifier: Modifier = Modifier,
+	enabled: Boolean = true,
+	backgroundColor: Color = MapisodeTheme.colorScheme.iconButtonBackground,
+	contentColor: Color? = null,
+	interactionSource: MutableInteractionSource? = null,
+	content: @Composable () -> Unit,
+) {
+	Box(
+		modifier = modifier
+			.size(IconSize.Large.value)
+			.clip(
+				shape = RoundedCornerShape(100),
+			)
+			.background(color = backgroundColor)
+			.mapisodeRippleEffect(
+				enabled = enabled,
+				rippleColor = MapisodeTheme.colorScheme.iconButtonDisabled.copy(alpha = 0.1f),
+			)
+			.clickable(
+				onClick = onClick,
+				enabled = enabled,
+				role = Role.Button,
+				interactionSource = interactionSource,
+				indication = null,
+			),
+		contentAlignment = Alignment.Center,
+	) {
+		val finalContentColor = contentColor?.copy(alpha = if (enabled) 1f else 0.5f)
+			?: MapisodeTheme.colorScheme.run {
+				if (enabled) iconButtonEnabled else iconButtonDisabled
+			}
+		CompositionLocalProvider(LocalMapisodeContentColor provides finalContentColor, content = content)
+	}
+}
+

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/theme/ColorScheme.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/theme/ColorScheme.kt
@@ -47,6 +47,11 @@ data class CustomColorScheme(
 	val toastStroke: Color,
 	val toastContent: Color,
 
+	// Icon Button
+	val iconButtonBackground: Color,
+	val iconButtonEnabled: Color,
+	val iconButtonDisabled: Color,
+
 	// Icon
 	val iconColor: Color,
 	val eatIconColor: Color,
@@ -118,6 +123,11 @@ val lightColorScheme = CustomColorScheme(
 	toastStroke = Color.Unspecified,
 	toastContent = Neutral110,
 
+	// Icon Button
+	iconButtonBackground = Neutral10,
+	iconButtonEnabled = Neutral110,
+	iconButtonDisabled = Neutral50,
+
 	// Icon
 	iconColor = Neutral110,
 	eatIconColor = Tertiary10,
@@ -188,6 +198,11 @@ val darkColorScheme = CustomColorScheme(
 	toastBackground = Neutral100,
 	toastStroke = Color.Unspecified,
 	toastContent = Neutral10,
+
+	// Icon Button
+	iconButtonBackground = Neutral110,
+	iconButtonEnabled = Neutral10,
+	iconButtonDisabled = Neutral50,
 
 	// Icon
 	iconColor = Neutral10,

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/theme/Theme.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/theme/Theme.kt
@@ -6,11 +6,13 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
 
 internal val LocalMapisodeColorScheme = staticCompositionLocalOf { lightColorScheme }
 internal val LocalMapisodeTypography = staticCompositionLocalOf { AppTypography }
 internal val LocalMapisodeContentColor = compositionLocalOf { lightColorScheme.textContent }
 internal val LocalMapisodeContentAlpha = compositionLocalOf { 1f }
+internal val LocalMapisodeIconColor = compositionLocalOf { Color.Unspecified }
 
 object MapisodeTheme {
 	val colorScheme: CustomColorScheme

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupCreationScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupCreationScreen.kt
@@ -1,0 +1,56 @@
+package com.boostcamp.mapisode.mygroup
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
+import com.boostcamp.mapisode.designsystem.compose.MapisodeIconButton
+import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
+import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
+import com.boostcamp.mapisode.designsystem.R
+import com.boostcamp.mapisode.designsystem.compose.button.MapisodeFilledButton
+
+@Composable
+fun GroupCreationScreen() {
+	var isNavigationIconEnabled by remember { mutableStateOf(true) }
+
+	MapisodeScaffold(
+		isStatusBarPaddingExist = true,
+		topBar = {
+			TopAppBar(
+				title = "그룹 생성",
+				navigationIcon = {
+					MapisodeIconButton(
+						onClick = { },
+						enabled = isNavigationIconEnabled,
+					) {
+						MapisodeIcon(
+							id = R.drawable.ic_arrow_back_ios,
+						)
+					}
+				},
+			)
+		},
+	) {
+		Column(
+			modifier = Modifier.fillMaxSize().padding(it),
+			verticalArrangement = Arrangement.spacedBy(16.dp),
+			horizontalAlignment = Alignment.CenterHorizontally,
+		) {
+			MapisodeFilledButton(
+				onClick = { isNavigationIconEnabled = !isNavigationIconEnabled },
+				text = "네비게이션 아이콘 활성/비활성화",
+				showRipple = true,
+			)
+		}
+	}
+}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupCreationScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupCreationScreen.kt
@@ -12,12 +12,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.boostcamp.mapisode.designsystem.R
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIconButton
 import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
-import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
-import com.boostcamp.mapisode.designsystem.R
 import com.boostcamp.mapisode.designsystem.compose.button.MapisodeFilledButton
+import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
 
 @Composable
 fun GroupCreationScreen() {


### PR DESCRIPTION
- closed #46 

## *📍 Work Description*

- Custom IconButton 생성
- enable, disable 상태에 따른 아이콘 색상 구분 적용
- 에뮬레이터 테스트

## *📸 Screenshot*

https://github.com/user-attachments/assets/e66e102c-5c3a-4476-9c98-81c7b40fefbf

## *📢 To Reviewers*
- Custom IconButton 사용 예시입니다.
<img src="https://github.com/user-attachments/assets/1a2e055a-5017-4cfa-b5ba-398c73470ff0" width=500>

## ⏲️Time

    - 3시간
