### PR TITLE
[FIX/#51] Custom Scaffold 하단 system bar padding 적용

### DIFF
--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeScaffold.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeScaffold.kt
@@ -25,6 +25,7 @@ private enum class ScaffoldLayoutContent { TopBar, MainContent, Snackbar, Bottom
 fun MapisodeScaffold(
 	modifier: Modifier = Modifier,
 	isStatusBarPaddingExist: Boolean = false,
+	isNavigationBarPaddingExist: Boolean = false,
 	toastHostState: ToastHostState = rememberToastHostState(),
 	topBar: @Composable () -> Unit = {},
 	bottomBar: @Composable () -> Unit = {},
@@ -40,6 +41,7 @@ fun MapisodeScaffold(
 	) {
 		ScaffoldLayout(
 			isStatusBarPaddingExist = isStatusBarPaddingExist,
+			isNavigationBarPaddingExist = isNavigationBarPaddingExist,
 			topBar = topBar,
 			bottomBar = bottomBar,
 			toast = { toastHost(toastHostState) },
@@ -51,6 +53,7 @@ fun MapisodeScaffold(
 @Composable
 private fun ScaffoldLayout(
 	isStatusBarPaddingExist: Boolean,
+	isNavigationBarPaddingExist: Boolean = false,
 	topBar: @Composable () -> Unit,
 	bottomBar: @Composable () -> Unit,
 	toast: @Composable () -> Unit,
@@ -62,7 +65,7 @@ private fun ScaffoldLayout(
 	} else {
 		0.dp
 	}
-	val bottomPadding = if (bottomBar != { }) {
+	val bottomPadding = if (isNavigationBarPaddingExist) {
 		WindowInsets.systemBars.asPaddingValues()
 			.calculateTopPadding()
 	} else {

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeScaffold.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeScaffold.kt
@@ -62,7 +62,13 @@ private fun ScaffoldLayout(
 	} else {
 		0.dp
 	}
-	val systemBar = WindowInsets(top = topPadding, bottom = 0.dp)
+	val bottomPadding = if (bottomBar != { }) {
+		WindowInsets.systemBars.asPaddingValues()
+			.calculateTopPadding()
+	} else {
+		0.dp
+	}
+	val systemBar = WindowInsets(top = topPadding, bottom = bottomPadding)
 
 	SubcomposeLayout { constraints ->
 		val layoutWidth = constraints.maxWidth


### PR DESCRIPTION
- closed #51 

## *📍 Work Description*

- status bar와 마찬가지로 navigation bar 또한 사용자가 패딩의 유무를 결정할 수 있도록 수정

## *📸 Screenshot*

<img src="https://github.com/user-attachments/assets/00ebda5f-a2da-49ca-8e92-7fdfaa584aa8" width=200>

<img src="https://github.com/user-attachments/assets/901b4312-68f9-43c6-9f1f-7640668cf36d" width=200>


## *📢 To Reviewers*
- #50  코드리뷰 중에 하단 system bar 패딩이 없다는 것을 알고 수정했습니다.
- 기본값으로는 navigation bar 패딩은 적용되어 있지 않습니다.
<img src="https://github.com/user-attachments/assets/bfb7187b-d82b-4fb8-9167-58b879acfd38" width=500>
<br>

- 중첩 Scaffold 를 쓰게되면 외부 Scaffold 의 topAppBar, bottomAppBar 유무에 따라 내부 Scaffold 의 content 패딩을 적용 안하고 하고가 결정되는데, 이를 코드로서 판별하기에 무리가 있어서 사용자가 수동으로 인자를 통해 조작할 수 있도록 했습니다.


## ⏲️Time

    - 0.5시간
