### PR TITLE
[FEAT/#49] Custom DropDownMenu 생성

### DIFF
--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/menu/MapisodeMenu.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/menu/MapisodeMenu.kt
@@ -43,6 +43,7 @@ import com.boostcamp.mapisode.designsystem.compose.menu.MapisodeDropdownMenuDefa
 import com.boostcamp.mapisode.designsystem.compose.menu.MapisodeDropdownMenuDefaults.EXPANDED_SCALE_TARGET
 import com.boostcamp.mapisode.designsystem.compose.menu.MapisodeDropdownMenuDefaults.IN_TRANSITION_DURATION
 import com.boostcamp.mapisode.designsystem.compose.menu.MapisodeDropdownMenuDefaults.OUT_TRANSITION_DURATION
+import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 
 private object MapisodeDropdownMenuDefaults {
 	const val IN_TRANSITION_DURATION = 120
@@ -78,8 +79,8 @@ fun MapisodeDropdownMenu(
 				transformOriginState = transformOriginState,
 				scrollState = ScrollState(0),
 				shape = RoundedCornerShape(1.dp),
-				containerColor = Color.White,
-				border = BorderStroke(1.dp, Color.Gray),
+				containerColor = MapisodeTheme.colorScheme.menuBackground,
+				border = BorderStroke(1.dp, MapisodeTheme.colorScheme.menuStroke),
 				content = content,
 			)
 		}

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/menu/MapisodeMenu.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/menu/MapisodeMenu.kt
@@ -154,8 +154,7 @@ internal fun MapisodeDropdownMenuContent(
 				}
 				this.alpha = if (!isInspecting) {
 					alpha
-				}
-				else if (expandedState.targetState) {
+				} else if (expandedState.targetState) {
 					EXPANDED_ALPHA_TARGET
 				} else {
 					CLOSED_ALPHA_TARGET

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/menu/MapisodeMenu.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/menu/MapisodeMenu.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -24,7 +25,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.Density
@@ -44,10 +44,9 @@ fun MapisodeDropdownMenu(
 	onDismissRequest: () -> Unit,
 	modifier: Modifier = Modifier,
 	offset: DpOffset = DpOffset(0.dp, 0.dp),
-	content: @Composable ColumnScope.() -> Unit
+	content: @Composable ColumnScope.() -> Unit,
 ) {
 	val density = LocalDensity.current
-	val windowSize = rememberWindowSize()
 	val transformOriginState = remember { mutableStateOf(TransformOrigin.Center) }
 
 	if (expanded) {
@@ -55,8 +54,8 @@ fun MapisodeDropdownMenu(
 			onDismissRequest = onDismissRequest,
 			popupPositionProvider = MapisodeDropdownMenuPositionProvider(
 				offset,
-				density
-			)
+				density,
+			),
 		) {
 			MapisodeDropdownMenuContent(
 				modifier = modifier,
@@ -66,7 +65,7 @@ fun MapisodeDropdownMenu(
 				shape = RoundedCornerShape(1.dp),
 				containerColor = Color.White,
 				border = BorderStroke(1.dp, Color.Gray),
-				content = content
+				content = content,
 			)
 		}
 	}
@@ -81,58 +80,58 @@ internal fun MapisodeDropdownMenuContent(
 	shape: Shape,
 	containerColor: Color,
 	border: BorderStroke?,
-	content: @Composable ColumnScope.() -> Unit
+	content: @Composable ColumnScope.() -> Unit,
 ) {
-	// Menu open/close animation.
-	@Suppress("DEPRECATION") val transition = updateTransition(expandedState, "DropDownMenu")
+	// 메뉴 열고 닫는 애니메이션
+	@Suppress("DEPRECATION")
+	val transition = updateTransition(expandedState, "DropDownMenu")
 
-	val scale by
-	transition.animateFloat(
+	val scale by transition.animateFloat(
 		transitionSpec = {
 			if (false isTransitioningTo true) {
-				// Dismissed to expanded
+				// 확장
 				tween(durationMillis = InTransitionDuration, easing = LinearOutSlowInEasing)
 			} else {
-				// Expanded to dismissed.
+				// 축소
 				tween(durationMillis = 1, delayMillis = OutTransitionDuration - 1)
 			}
 		},
-		label = "FloatAnimation"
+		label = "FloatAnimation",
 	) { expanded ->
 		if (expanded) ExpandedScaleTarget else ClosedScaleTarget
 	}
 
-	val alpha by
-	transition.animateFloat(
+	val alpha by transition.animateFloat(
 		transitionSpec = {
 			if (false isTransitioningTo true) {
-				// Dismissed to expanded
+				// 확장
 				tween(durationMillis = 30)
 			} else {
-				// Expanded to dismissed.
+				// 축소
 				tween(durationMillis = OutTransitionDuration)
 			}
 		},
-		label = "FloatAnimation"
+		label = "FloatAnimation",
 	) { expanded ->
 		if (expanded) ExpandedAlphaTarget else ClosedAlphaTarget
 	}
 
 	val isInspecting = LocalInspectionMode.current
 	Surface(
-		modifier =
-		Modifier.graphicsLayer {
-			scaleX =
-				if (!isInspecting) scale
-				else if (expandedState.targetState) ExpandedScaleTarget else ClosedScaleTarget
-			scaleY =
-				if (!isInspecting) scale
-				else if (expandedState.targetState) ExpandedScaleTarget else ClosedScaleTarget
-			this.alpha =
-				if (!isInspecting) alpha
-				else if (expandedState.targetState) ExpandedAlphaTarget else ClosedAlphaTarget
-			transformOrigin = transformOriginState.value
-		},
+		modifier = Modifier
+			.heightIn(min = 0.dp, max = 300.dp)
+			.graphicsLayer {
+				scaleX =
+					if (!isInspecting) scale
+					else if (expandedState.targetState) ExpandedScaleTarget else ClosedScaleTarget
+				scaleY =
+					if (!isInspecting) scale
+					else if (expandedState.targetState) ExpandedScaleTarget else ClosedScaleTarget
+				this.alpha =
+					if (!isInspecting) alpha
+					else if (expandedState.targetState) ExpandedAlphaTarget else ClosedAlphaTarget
+				transformOrigin = transformOriginState.value
+			},
 		shape = shape,
 		color = containerColor,
 		border = border,
@@ -140,23 +139,23 @@ internal fun MapisodeDropdownMenuContent(
 		Column(
 			modifier =
 			modifier
-				.padding(vertical = DropdownMenuVerticalPadding)
+				.padding(vertical = 8.dp)
 				.width(IntrinsicSize.Max)
 				.verticalScroll(scrollState),
-			content = content
+			content = content,
 		)
 	}
 }
 
 private class MapisodeDropdownMenuPositionProvider(
 	private val offset: DpOffset,
-	private val density: Density
+	private val density: Density,
 ) : PopupPositionProvider {
 	override fun calculatePosition(
 		anchorBounds: IntRect,
 		windowSize: IntSize,
 		layoutDirection: LayoutDirection,
-		popupContentSize: IntSize
+		popupContentSize: IntSize,
 	): IntOffset {
 		val offsetX = with(density) { offset.x.roundToPx() }
 		val offsetY = with(density) { offset.y.roundToPx() }
@@ -166,29 +165,10 @@ private class MapisodeDropdownMenuPositionProvider(
 
 		return IntOffset(
 			x.coerceIn(0, windowSize.width - popupContentSize.width),
-			y.coerceIn(0, windowSize.height - popupContentSize.height)
+			y.coerceIn(0, windowSize.height - popupContentSize.height),
 		)
 	}
 }
-
-
-@Composable
-private fun rememberWindowSize(): IntSize {
-	val configuration = LocalConfiguration.current
-	return remember(configuration) {
-		IntSize(
-			configuration.screenWidthDp,
-			configuration.screenHeightDp
-		)
-	}
-}
-
-internal val MenuVerticalMargin = 48.dp
-private val MenuListItemContainerHeight = 48.dp
-private val DropdownMenuItemHorizontalPadding = 12.dp
-internal val DropdownMenuVerticalPadding = 8.dp
-private val DropdownMenuItemDefaultMinWidth = 112.dp
-private val DropdownMenuItemDefaultMaxWidth = 280.dp
 
 internal const val InTransitionDuration = 120
 internal const val OutTransitionDuration = 75

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/menu/MapisodeMenu.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/menu/MapisodeMenu.kt
@@ -138,15 +138,28 @@ internal fun MapisodeDropdownMenuContent(
 		modifier = Modifier
 			.heightIn(min = 0.dp, max = 300.dp)
 			.graphicsLayer {
-				scaleX =
-					if (!isInspecting) scale
-					else if (expandedState.targetState) EXPANDED_SCALE_TARGET else CLOSED_SCALE_TARGET
-				scaleY =
-					if (!isInspecting) scale
-					else if (expandedState.targetState) EXPANDED_SCALE_TARGET else CLOSED_SCALE_TARGET
-				this.alpha =
-					if (!isInspecting) alpha
-					else if (expandedState.targetState) EXPANDED_ALPHA_TARGET else CLOSED_ALPHA_TARGET
+				scaleX = if (!isInspecting) {
+					scale
+				} else if (expandedState.targetState) {
+					EXPANDED_SCALE_TARGET
+				} else {
+					CLOSED_SCALE_TARGET
+				}
+				scaleY = if (!isInspecting) {
+					scale
+				} else if (expandedState.targetState) {
+					EXPANDED_SCALE_TARGET
+				} else {
+					CLOSED_SCALE_TARGET
+				}
+				this.alpha = if (!isInspecting) {
+					alpha
+				}
+				else if (expandedState.targetState) {
+					EXPANDED_ALPHA_TARGET
+				} else {
+					CLOSED_ALPHA_TARGET
+				}
 				transformOrigin = transformOriginState.value
 			},
 		shape = shape,

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/menu/MapisodeMenu.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/menu/MapisodeMenu.kt
@@ -117,6 +117,7 @@ internal fun MapisodeDropdownMenuContent(
 	}
 
 	val isInspecting = LocalInspectionMode.current
+
 	Surface(
 		modifier = Modifier
 			.heightIn(min = 0.dp, max = 300.dp)

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/menu/MapisodeMenu.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/menu/MapisodeMenu.kt
@@ -1,0 +1,198 @@
+package com.boostcamp.mapisode.designsystem.compose.menu
+
+import androidx.compose.animation.core.LinearOutSlowInEasing
+import androidx.compose.animation.core.MutableTransitionState
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.core.updateTransition
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupPositionProvider
+import com.boostcamp.mapisode.designsystem.compose.Surface
+
+@Composable
+fun MapisodeDropdownMenu(
+	expanded: Boolean,
+	onDismissRequest: () -> Unit,
+	modifier: Modifier = Modifier,
+	offset: DpOffset = DpOffset(0.dp, 0.dp),
+	content: @Composable ColumnScope.() -> Unit
+) {
+	val density = LocalDensity.current
+	val windowSize = rememberWindowSize()
+	val transformOriginState = remember { mutableStateOf(TransformOrigin.Center) }
+
+	if (expanded) {
+		Popup(
+			onDismissRequest = onDismissRequest,
+			popupPositionProvider = MapisodeDropdownMenuPositionProvider(
+				offset,
+				density
+			)
+		) {
+			MapisodeDropdownMenuContent(
+				modifier = modifier,
+				expandedState = MutableTransitionState(true),
+				transformOriginState = transformOriginState,
+				scrollState = ScrollState(0),
+				shape = RoundedCornerShape(1.dp),
+				containerColor = Color.White,
+				border = BorderStroke(1.dp, Color.Gray),
+				content = content
+			)
+		}
+	}
+}
+
+@Composable
+internal fun MapisodeDropdownMenuContent(
+	modifier: Modifier,
+	expandedState: MutableTransitionState<Boolean>,
+	transformOriginState: MutableState<TransformOrigin>,
+	scrollState: ScrollState,
+	shape: Shape,
+	containerColor: Color,
+	border: BorderStroke?,
+	content: @Composable ColumnScope.() -> Unit
+) {
+	// Menu open/close animation.
+	@Suppress("DEPRECATION") val transition = updateTransition(expandedState, "DropDownMenu")
+
+	val scale by
+	transition.animateFloat(
+		transitionSpec = {
+			if (false isTransitioningTo true) {
+				// Dismissed to expanded
+				tween(durationMillis = InTransitionDuration, easing = LinearOutSlowInEasing)
+			} else {
+				// Expanded to dismissed.
+				tween(durationMillis = 1, delayMillis = OutTransitionDuration - 1)
+			}
+		},
+		label = "FloatAnimation"
+	) { expanded ->
+		if (expanded) ExpandedScaleTarget else ClosedScaleTarget
+	}
+
+	val alpha by
+	transition.animateFloat(
+		transitionSpec = {
+			if (false isTransitioningTo true) {
+				// Dismissed to expanded
+				tween(durationMillis = 30)
+			} else {
+				// Expanded to dismissed.
+				tween(durationMillis = OutTransitionDuration)
+			}
+		},
+		label = "FloatAnimation"
+	) { expanded ->
+		if (expanded) ExpandedAlphaTarget else ClosedAlphaTarget
+	}
+
+	val isInspecting = LocalInspectionMode.current
+	Surface(
+		modifier =
+		Modifier.graphicsLayer {
+			scaleX =
+				if (!isInspecting) scale
+				else if (expandedState.targetState) ExpandedScaleTarget else ClosedScaleTarget
+			scaleY =
+				if (!isInspecting) scale
+				else if (expandedState.targetState) ExpandedScaleTarget else ClosedScaleTarget
+			this.alpha =
+				if (!isInspecting) alpha
+				else if (expandedState.targetState) ExpandedAlphaTarget else ClosedAlphaTarget
+			transformOrigin = transformOriginState.value
+		},
+		shape = shape,
+		color = containerColor,
+		border = border,
+	) {
+		Column(
+			modifier =
+			modifier
+				.padding(vertical = DropdownMenuVerticalPadding)
+				.width(IntrinsicSize.Max)
+				.verticalScroll(scrollState),
+			content = content
+		)
+	}
+}
+
+private class MapisodeDropdownMenuPositionProvider(
+	private val offset: DpOffset,
+	private val density: Density
+) : PopupPositionProvider {
+	override fun calculatePosition(
+		anchorBounds: IntRect,
+		windowSize: IntSize,
+		layoutDirection: LayoutDirection,
+		popupContentSize: IntSize
+	): IntOffset {
+		val offsetX = with(density) { offset.x.roundToPx() }
+		val offsetY = with(density) { offset.y.roundToPx() }
+
+		val x = anchorBounds.left + offsetX
+		val y = anchorBounds.bottom + offsetY
+
+		return IntOffset(
+			x.coerceIn(0, windowSize.width - popupContentSize.width),
+			y.coerceIn(0, windowSize.height - popupContentSize.height)
+		)
+	}
+}
+
+
+@Composable
+private fun rememberWindowSize(): IntSize {
+	val configuration = LocalConfiguration.current
+	return remember(configuration) {
+		IntSize(
+			configuration.screenWidthDp,
+			configuration.screenHeightDp
+		)
+	}
+}
+
+internal val MenuVerticalMargin = 48.dp
+private val MenuListItemContainerHeight = 48.dp
+private val DropdownMenuItemHorizontalPadding = 12.dp
+internal val DropdownMenuVerticalPadding = 8.dp
+private val DropdownMenuItemDefaultMinWidth = 112.dp
+private val DropdownMenuItemDefaultMaxWidth = 280.dp
+
+internal const val InTransitionDuration = 120
+internal const val OutTransitionDuration = 75
+internal const val ExpandedScaleTarget = 1f
+internal const val ClosedScaleTarget = 0.8f
+internal const val ExpandedAlphaTarget = 1f
+internal const val ClosedAlphaTarget = 0f

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/menu/MapisodeMenu.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/menu/MapisodeMenu.kt
@@ -37,6 +37,21 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupPositionProvider
 import com.boostcamp.mapisode.designsystem.compose.Surface
+import com.boostcamp.mapisode.designsystem.compose.menu.MapisodeDropdownMenuDefaults.CLOSED_ALPHA_TARGET
+import com.boostcamp.mapisode.designsystem.compose.menu.MapisodeDropdownMenuDefaults.CLOSED_SCALE_TARGET
+import com.boostcamp.mapisode.designsystem.compose.menu.MapisodeDropdownMenuDefaults.EXPANDED_ALPHA_TARGET
+import com.boostcamp.mapisode.designsystem.compose.menu.MapisodeDropdownMenuDefaults.EXPANDED_SCALE_TARGET
+import com.boostcamp.mapisode.designsystem.compose.menu.MapisodeDropdownMenuDefaults.IN_TRANSITION_DURATION
+import com.boostcamp.mapisode.designsystem.compose.menu.MapisodeDropdownMenuDefaults.OUT_TRANSITION_DURATION
+
+private object MapisodeDropdownMenuDefaults {
+	const val IN_TRANSITION_DURATION = 120
+	const val OUT_TRANSITION_DURATION = 75
+	const val EXPANDED_SCALE_TARGET = 1f
+	const val CLOSED_SCALE_TARGET = 0.8f
+	const val EXPANDED_ALPHA_TARGET = 1f
+	const val CLOSED_ALPHA_TARGET = 0f
+}
 
 @Composable
 fun MapisodeDropdownMenu(
@@ -90,15 +105,15 @@ internal fun MapisodeDropdownMenuContent(
 		transitionSpec = {
 			if (false isTransitioningTo true) {
 				// 확장
-				tween(durationMillis = InTransitionDuration, easing = LinearOutSlowInEasing)
+				tween(durationMillis = IN_TRANSITION_DURATION, easing = LinearOutSlowInEasing)
 			} else {
 				// 축소
-				tween(durationMillis = 1, delayMillis = OutTransitionDuration - 1)
+				tween(durationMillis = 1, delayMillis = OUT_TRANSITION_DURATION - 1)
 			}
 		},
 		label = "FloatAnimation",
 	) { expanded ->
-		if (expanded) ExpandedScaleTarget else ClosedScaleTarget
+		if (expanded) EXPANDED_SCALE_TARGET else CLOSED_SCALE_TARGET
 	}
 
 	val alpha by transition.animateFloat(
@@ -108,12 +123,12 @@ internal fun MapisodeDropdownMenuContent(
 				tween(durationMillis = 30)
 			} else {
 				// 축소
-				tween(durationMillis = OutTransitionDuration)
+				tween(durationMillis = OUT_TRANSITION_DURATION)
 			}
 		},
 		label = "FloatAnimation",
 	) { expanded ->
-		if (expanded) ExpandedAlphaTarget else ClosedAlphaTarget
+		if (expanded) EXPANDED_ALPHA_TARGET else CLOSED_ALPHA_TARGET
 	}
 
 	val isInspecting = LocalInspectionMode.current
@@ -124,13 +139,13 @@ internal fun MapisodeDropdownMenuContent(
 			.graphicsLayer {
 				scaleX =
 					if (!isInspecting) scale
-					else if (expandedState.targetState) ExpandedScaleTarget else ClosedScaleTarget
+					else if (expandedState.targetState) EXPANDED_SCALE_TARGET else CLOSED_SCALE_TARGET
 				scaleY =
 					if (!isInspecting) scale
-					else if (expandedState.targetState) ExpandedScaleTarget else ClosedScaleTarget
+					else if (expandedState.targetState) EXPANDED_SCALE_TARGET else CLOSED_SCALE_TARGET
 				this.alpha =
 					if (!isInspecting) alpha
-					else if (expandedState.targetState) ExpandedAlphaTarget else ClosedAlphaTarget
+					else if (expandedState.targetState) EXPANDED_ALPHA_TARGET else CLOSED_ALPHA_TARGET
 				transformOrigin = transformOriginState.value
 			},
 		shape = shape,
@@ -138,8 +153,7 @@ internal fun MapisodeDropdownMenuContent(
 		border = border,
 	) {
 		Column(
-			modifier =
-			modifier
+			modifier = modifier
 				.padding(vertical = 8.dp)
 				.width(IntrinsicSize.Max)
 				.verticalScroll(scrollState),
@@ -170,10 +184,3 @@ private class MapisodeDropdownMenuPositionProvider(
 		)
 	}
 }
-
-internal const val InTransitionDuration = 120
-internal const val OutTransitionDuration = 75
-internal const val ExpandedScaleTarget = 1f
-internal const val ClosedScaleTarget = 0.8f
-internal const val ExpandedAlphaTarget = 1f
-internal const val ClosedAlphaTarget = 0f

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/menu/MapisodeMenuItem.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/menu/MapisodeMenuItem.kt
@@ -38,9 +38,9 @@ fun MapisodeDropdownMenuItem(
 			)
 			.fillMaxWidth(),
 		color = if (enabled) {
-			MapisodeTheme.colorScheme.surfaceBackground
+			MapisodeTheme.colorScheme.menuItemBackground
 		} else {
-			MapisodeTheme.colorScheme.surfaceBackground.copy(alpha = 0.38f)
+			MapisodeTheme.colorScheme.scrim
 		},
 	) {
 		Row(

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/menu/MapisodeMenuItem.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/menu/MapisodeMenuItem.kt
@@ -1,0 +1,60 @@
+package com.boostcamp.mapisode.designsystem.compose.menu
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.boostcamp.mapisode.designsystem.compose.Surface
+import com.boostcamp.mapisode.designsystem.compose.mapisodeRippleEffect
+import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
+
+@Composable
+fun MapisodeDropdownMenuItem(
+	onClick: () -> Unit,
+	modifier: Modifier = Modifier,
+	enabled: Boolean = true,
+	contentPadding: PaddingValues = MapisodeMenuDefaults.DropdownMenuItemContentPadding,
+	interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+	content: @Composable RowScope.() -> Unit
+) {
+	Surface(
+		modifier = modifier
+			.mapisodeRippleEffect(
+				rippleColor = Color.Black.copy(alpha = 0.1f),
+			)
+			.clickable(
+				enabled = enabled,
+				onClick = onClick,
+				interactionSource = interactionSource,
+				indication = null,
+			)
+			.fillMaxWidth(),
+		color = if (enabled) {
+			MapisodeTheme.colorScheme.surfaceBackground
+		} else {
+			MapisodeTheme.colorScheme.surfaceBackground.copy(alpha = 0.38f)
+		}
+	) {
+		Row(
+			modifier = Modifier.padding(contentPadding),
+			verticalAlignment = Alignment.CenterVertically,
+			content = content
+		)
+	}
+}
+
+private object MapisodeMenuDefaults {
+	val DropdownMenuItemContentPadding = PaddingValues(
+		horizontal = 16.dp,
+		vertical = 8.dp
+	)
+}

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/menu/MapisodeMenuItem.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/menu/MapisodeMenuItem.kt
@@ -11,10 +11,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.boostcamp.mapisode.designsystem.compose.Surface
-import com.boostcamp.mapisode.designsystem.compose.mapisodeRippleEffect
 import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 
 @Composable
@@ -24,13 +22,10 @@ fun MapisodeDropdownMenuItem(
 	enabled: Boolean = true,
 	contentPadding: PaddingValues = MapisodeMenuDefaults.DropdownMenuItemContentPadding,
 	interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-	content: @Composable RowScope.() -> Unit
+	content: @Composable RowScope.() -> Unit,
 ) {
 	Surface(
 		modifier = modifier
-			.mapisodeRippleEffect(
-				rippleColor = Color.Black.copy(alpha = 0.1f),
-			)
 			.clickable(
 				enabled = enabled,
 				onClick = onClick,
@@ -42,12 +37,12 @@ fun MapisodeDropdownMenuItem(
 			MapisodeTheme.colorScheme.surfaceBackground
 		} else {
 			MapisodeTheme.colorScheme.surfaceBackground.copy(alpha = 0.38f)
-		}
+		},
 	) {
 		Row(
 			modifier = Modifier.padding(contentPadding),
 			verticalAlignment = Alignment.CenterVertically,
-			content = content
+			content = content,
 		)
 	}
 }
@@ -55,6 +50,6 @@ fun MapisodeDropdownMenuItem(
 private object MapisodeMenuDefaults {
 	val DropdownMenuItemContentPadding = PaddingValues(
 		horizontal = 16.dp,
-		vertical = 8.dp
+		vertical = 8.dp,
 	)
 }

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/menu/MapisodeMenuItem.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/menu/MapisodeMenuItem.kt
@@ -11,8 +11,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.unit.dp
 import com.boostcamp.mapisode.designsystem.compose.Surface
+import com.boostcamp.mapisode.designsystem.compose.ripple.MapisodeRippleBIndication
 import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 
 @Composable
@@ -20,17 +23,18 @@ fun MapisodeDropdownMenuItem(
 	onClick: () -> Unit,
 	modifier: Modifier = Modifier,
 	enabled: Boolean = true,
-	contentPadding: PaddingValues = MapisodeMenuDefaults.DropdownMenuItemContentPadding,
+	contentPadding: PaddingValues = MapisodeMenuItemDefaults.DropdownMenuItemContentPadding,
 	interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 	content: @Composable RowScope.() -> Unit,
 ) {
 	Surface(
 		modifier = modifier
+			.clip(RectangleShape)
 			.clickable(
 				enabled = enabled,
 				onClick = onClick,
 				interactionSource = interactionSource,
-				indication = null,
+				indication = MapisodeRippleBIndication,
 			)
 			.fillMaxWidth(),
 		color = if (enabled) {
@@ -47,7 +51,7 @@ fun MapisodeDropdownMenuItem(
 	}
 }
 
-private object MapisodeMenuDefaults {
+private object MapisodeMenuItemDefaults {
 	val DropdownMenuItemContentPadding = PaddingValues(
 		horizontal = 16.dp,
 		vertical = 8.dp,

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/theme/ColorScheme.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/theme/ColorScheme.kt
@@ -135,7 +135,7 @@ val lightColorScheme = CustomColorScheme(
 	otherIconColor = Primary40,
 
 	// Surface
-	surfaceBackground = Neutral30,
+	surfaceBackground = Neutral10,
 
 	// Divider
 	dividerThinColor = Neutral50,
@@ -211,7 +211,7 @@ val darkColorScheme = CustomColorScheme(
 	otherIconColor = Primary20,
 
 	// Surface
-	surfaceBackground = Neutral90,
+	surfaceBackground = Neutral110,
 
 	// Divider
 	dividerThinColor = Neutral80,

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/theme/ColorScheme.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/theme/ColorScheme.kt
@@ -16,6 +16,14 @@ data class CustomColorScheme(
 	// Scaffold
 	val scaffoldBackground: Color,
 
+	// Scrim
+	val scrim: Color,
+
+	// Menu
+	val menuBackground: Color,
+	val menuStroke: Color,
+	val menuItemBackground: Color,
+
 	// Button
 	val filledButtonEnableBackground: Color,
 	val filledButtonDisableBackground: Color,
@@ -92,6 +100,14 @@ val lightColorScheme = CustomColorScheme(
 	// Scaffold
 	scaffoldBackground = Neutral10,
 
+	// Scrim
+	scrim = Neutral110.copy(alpha = 0.32f),
+
+	// Menu
+	menuBackground = Neutral10,
+	menuStroke = Neutral110,
+	menuItemBackground = Neutral10,
+
 	// Button
 	filledButtonEnableBackground = Primary30,
 	filledButtonDisableBackground = Neutral60,
@@ -167,6 +183,14 @@ val darkColorScheme = CustomColorScheme(
 
 	// Scaffold
 	scaffoldBackground = Neutral110,
+
+	// Scrim
+	scrim = Neutral10.copy(alpha = 0.32f),
+
+	// Menu
+	menuBackground = Neutral110,
+	menuStroke = Neutral20,
+	menuItemBackground = Neutral110,
 
 	// Button
 	filledButtonEnableBackground = Primary50,

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.boostcamp.mapisode.designsystem.R
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
@@ -23,6 +24,8 @@ import com.boostcamp.mapisode.designsystem.compose.MapisodeText
 import com.boostcamp.mapisode.designsystem.compose.MapisodeTextField
 import com.boostcamp.mapisode.designsystem.compose.button.MapisodeFilledButton
 import com.boostcamp.mapisode.designsystem.compose.button.MapisodeOutlinedButton
+import com.boostcamp.mapisode.designsystem.compose.menu.MapisodeDropdownMenu
+import com.boostcamp.mapisode.designsystem.compose.menu.MapisodeDropdownMenuItem
 import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
 import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 
@@ -40,6 +43,7 @@ internal fun GroupRoute() {
 @Composable
 private fun GroupScreen(onAddGroupClick: () -> Unit) {
 	val focusManager = LocalFocusManager.current
+	var isMenuPoppedUp by remember { mutableStateOf(false) }
 
 	MapisodeScaffold(
 		modifier = Modifier
@@ -58,12 +62,33 @@ private fun GroupScreen(onAddGroupClick: () -> Unit) {
 				actions = {
 					MapisodeIconButton(
 						onClick = {
-							onAddGroupClick()
+							isMenuPoppedUp = true
 						},
 					) {
 						MapisodeIcon(
 							id = R.drawable.ic_add,
 						)
+						MapisodeDropdownMenu(
+							expanded = isMenuPoppedUp,
+							onDismissRequest = { isMenuPoppedUp = false },
+							offset = DpOffset(0.dp, 0.dp).minus(DpOffset(41.dp, 0.dp)),
+						) {
+							MapisodeDropdownMenuItem(
+								onClick = onAddGroupClick
+							) {
+								MapisodeText(
+									text = "그룹 생성",
+								)
+							}
+							MapisodeDropdownMenuItem(
+								onClick = {  },
+							) {
+								MapisodeText(
+									text = "그룹 생성",
+								)
+							}
+						}
+
 					}
 				},
 			)

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupScreen.kt
@@ -74,21 +74,27 @@ private fun GroupScreen(onAddGroupClick: () -> Unit) {
 							offset = DpOffset(0.dp, 0.dp).minus(DpOffset(41.dp, 0.dp)),
 						) {
 							MapisodeDropdownMenuItem(
-								onClick = onAddGroupClick
+								onClick = onAddGroupClick,
 							) {
 								MapisodeText(
 									text = "그룹 생성",
 								)
 							}
 							MapisodeDropdownMenuItem(
-								onClick = {  },
+								onClick = { },
+							) {
+								MapisodeText(
+									text = "그룹 생성",
+								)
+							}
+							MapisodeDropdownMenuItem(
+								onClick = { },
 							) {
 								MapisodeText(
 									text = "그룹 생성",
 								)
 							}
 						}
-
 					}
 				},
 			)


### PR DESCRIPTION
- closed #49

## *📍 Work Description*

- Custom DropDownMenu 생성
- Custom DropDownMenuItem 생성
- Item Ripple 오류 수정
- topAppBar 의 action 버튼에 적용
- menu 컬러 설정

## *📸 Screenshot*

https://github.com/user-attachments/assets/8ac18fa5-a790-46ab-bc55-0ece63eb0d5d

https://github.com/user-attachments/assets/8abf04a7-8cfa-414d-8013-eeca1f2a20c2

https://github.com/user-attachments/assets/7d763040-4bf8-4648-ba53-ba352fc9b7b3


## *📢 To Reviewers*
- Custom DropDownMenu와 DropDownMenuItem 은 Material 을 참고하여 만들었습니다.
- 첫 영상을 보면 초기에 리플이 다른 아이템을 침범하는 문제가 있는 것을 볼 수 있습니다. 
- 기획에서는 두 메뉴 아이템만 필요했지만 트러블을 파악하기 위해 메뉴 아이템을 하나 더 추가하여 실행한 결과, Ripple이 원형으로 맨 위에까지 도달했음을 알 수 있었습니다.
  - Indication 타입으로 정의한 Custom Ripple 에서 지름을 최대값으로 한 원형 리플이 나타나도록 설정했다는 것을 기억해냈고, 메뉴 아이템 컴포넌트가 영역이 제한되어 있지 않았기에 리플이 다른 공간을 침범했음을 알 수 있었습니다.
- 오류에서 리플이 위의 메뉴 아이템만을 침범하는 이유는 composition된 순서에 따라 z값이 다르기 때문입니다.
  - 위의 메뉴 아이템이 먼저 composition 되었기에 z가 낮게 형성되어 있습니다.
- 이를 해결하기 위해 각 menuItem 에 Modifier.clip( ) 함수를 적용시켜 리플의 영역을 한정시켰습니다.

## ⏲️Time

    - 5시간


