### PR TITLE
[FEAT/#48][FIX/#60] Custom ImageButton 제작, Coil 라이브러리 수정

### DIFF
--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeIcon.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeIcon.kt
@@ -166,6 +166,7 @@ fun OtherIconsPreview() {
 				Pair("ic_settings", R.drawable.ic_settings),
 				Pair("ic_calendar", R.drawable.ic_calendar),
 				Pair("ic_group", R.drawable.ic_group),
+				Pair("ic_image", R.drawable.ic_image),
 				Pair("ic_eat", R.drawable.ic_eat),
 				Pair("ic_see", R.drawable.ic_see),
 				Pair("ic_other", R.drawable.ic_other),

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeIcon.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeIcon.kt
@@ -35,7 +35,8 @@ sealed class IconSize(val value: Dp) {
 	data object Small : IconSize(20.dp)
 	data object Medium : IconSize(24.dp)
 	data object Normal : IconSize(30.dp)
-	data object Large : IconSize(48.dp)
+	data object Large : IconSize(36.dp)
+	data object ExtraLarge : IconSize(48.dp)
 }
 
 @Composable
@@ -80,7 +81,7 @@ fun IconSizeComparisonPreview() {
 		IconSize.Small,
 		IconSize.Medium,
 		IconSize.Normal,
-		IconSize.Large,
+		IconSize.ExtraLarge,
 	)
 
 	Column(

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeIconButton.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeIconButton.kt
@@ -29,7 +29,7 @@ fun MapisodeIconButton(
 ) {
 	Box(
 		modifier = modifier
-			.size(IconSize.Large.value)
+			.size(IconSize.ExtraLarge.value)
 			.clip(
 				shape = RoundedCornerShape(100),
 			)

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeButton.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeButton.kt
@@ -23,9 +23,9 @@ import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 @Composable
 internal fun MapisodeButton(
 	onClick: () -> Unit,
+	modifier: Modifier = Modifier,
 	backgroundColors: Color,
 	contentColor: Color,
-	modifier: Modifier = Modifier,
 	enabled: Boolean = true,
 	showBorder: Boolean = false,
 	borderColor: Color = Color.Transparent,

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeFilledButton.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeFilledButton.kt
@@ -6,9 +6,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -22,8 +23,8 @@ import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 
 @Composable
 fun MapisodeFilledButton(
-	modifier: Modifier = Modifier,
 	onClick: () -> Unit,
+	modifier: Modifier = Modifier,
 	text: String,
 	textStyle: MapisodeTextStyle = MapisodeTheme.typography.titleLarge,
 	enabled: Boolean = true,
@@ -34,16 +35,16 @@ fun MapisodeFilledButton(
 ) {
 	MapisodeButton(
 		onClick = onClick,
+		modifier = Modifier
+			.then(modifier)
+			.widthIn(320.dp)
+			.heightIn(52.dp),
 		backgroundColors = if (enabled) {
 			MapisodeTheme.colorScheme.filledButtonEnableBackground
 		} else {
 			MapisodeTheme.colorScheme.filledButtonDisableBackground
 		},
 		contentColor = MapisodeTheme.colorScheme.filledButtonContent,
-		modifier = Modifier
-			.then(modifier)
-			.width(320.dp)
-			.height(52.dp),
 		enabled = enabled,
 		showBorder = false,
 		showRipple = showRipple,

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeImageButton.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeImageButton.kt
@@ -1,0 +1,65 @@
+package com.boostcamp.mapisode.designsystem.compose.button
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.boostcamp.mapisode.designsystem.R
+import com.boostcamp.mapisode.designsystem.compose.IconSize
+import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
+import com.boostcamp.mapisode.designsystem.compose.MapisodeText
+import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
+
+@Composable
+fun MapisodeImageButton(
+	modifier: Modifier = Modifier,
+	onClick: () -> Unit,
+	text: String,
+	enabled: Boolean = true,
+	showRipple: Boolean = true,
+	interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+	imageContent: @Composable () -> Unit,
+) {
+	MapisodeButton(
+		onClick = onClick,
+		backgroundColors = MapisodeTheme.colorScheme.outlineButtonBackground,
+		contentColor = MapisodeTheme.colorScheme.outlineButtonContent,
+		modifier = modifier
+			.widthIn(150.dp)
+			.heightIn(150.dp),
+		enabled = enabled,
+		showBorder = true,
+		borderColor = MapisodeTheme.colorScheme.outlineButtonStroke,
+		showRipple = showRipple,
+		interactionSource = interactionSource,
+		rounding = 8.dp,
+		contentPadding = PaddingValues(16.dp),
+	) {
+		if (enabled) {
+			Column(
+				verticalArrangement = Arrangement.Center,
+				horizontalAlignment = Alignment.CenterHorizontally,
+			) {
+				MapisodeIcon(
+					id = R.drawable.ic_image,
+					iconSize = IconSize.Large,
+					tint = MapisodeTheme.colorScheme.outlineButtonContent,
+				)
+				MapisodeText(
+					text = text,
+					color = MapisodeTheme.colorScheme.outlineButtonContent,
+					style = MapisodeTheme.typography.bodyMedium,
+				)
+			}
+		} else {
+			imageContent()
+		}
+	}
+}

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeImageButton.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeImageButton.kt
@@ -22,6 +22,7 @@ fun MapisodeImageButton(
 	modifier: Modifier = Modifier,
 	onClick: () -> Unit,
 	text: String,
+	showImage: Boolean = true,
 	enabled: Boolean = true,
 	showRipple: Boolean = true,
 	interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
@@ -42,7 +43,7 @@ fun MapisodeImageButton(
 		rounding = 8.dp,
 		contentPadding = PaddingValues(16.dp),
 	) {
-		if (enabled) {
+		if (showImage) {
 			Column(
 				verticalArrangement = Arrangement.Center,
 				horizontalAlignment = Alignment.CenterHorizontally,

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeImageButton.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeImageButton.kt
@@ -21,7 +21,7 @@ import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 fun MapisodeImageButton(
 	modifier: Modifier = Modifier,
 	onClick: () -> Unit,
-	text: String,
+	text: String = "",
 	showImage: Boolean = true,
 	enabled: Boolean = true,
 	showRipple: Boolean = true,
@@ -30,11 +30,11 @@ fun MapisodeImageButton(
 ) {
 	MapisodeButton(
 		onClick = onClick,
-		backgroundColors = MapisodeTheme.colorScheme.outlineButtonBackground,
-		contentColor = MapisodeTheme.colorScheme.outlineButtonContent,
 		modifier = modifier
 			.widthIn(150.dp)
 			.heightIn(150.dp),
+		backgroundColors = MapisodeTheme.colorScheme.outlineButtonBackground,
+		contentColor = MapisodeTheme.colorScheme.outlineButtonContent,
 		enabled = enabled,
 		showBorder = true,
 		borderColor = MapisodeTheme.colorScheme.outlineButtonStroke,
@@ -53,11 +53,13 @@ fun MapisodeImageButton(
 					iconSize = IconSize.Large,
 					tint = MapisodeTheme.colorScheme.outlineButtonContent,
 				)
-				MapisodeText(
-					text = text,
-					color = MapisodeTheme.colorScheme.outlineButtonContent,
-					style = MapisodeTheme.typography.bodyMedium,
-				)
+				if (text != "") {
+					MapisodeText(
+						text = text,
+						color = MapisodeTheme.colorScheme.outlineButtonContent,
+						style = MapisodeTheme.typography.bodyMedium,
+					)
+				}
 			}
 		} else {
 			imageContent()

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeOutlinedButton.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeOutlinedButton.kt
@@ -6,9 +6,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -32,12 +33,12 @@ fun MapisodeOutlinedButton(
 ) {
 	MapisodeButton(
 		onClick = onClick,
-		backgroundColors = MapisodeTheme.colorScheme.outlineButtonBackground,
-		contentColor = MapisodeTheme.colorScheme.outlineButtonContent,
 		modifier = Modifier
 			.then(modifier)
-			.width(320.dp)
-			.height(40.dp),
+			.widthIn(320.dp)
+			.heightIn(40.dp),
+		backgroundColors = MapisodeTheme.colorScheme.outlineButtonBackground,
+		contentColor = MapisodeTheme.colorScheme.outlineButtonContent,
 		enabled = enabled,
 		showBorder = true,
 		borderColor = MapisodeTheme.colorScheme.outlineButtonStroke,

--- a/core/designsystem/src/main/res/drawable/ic_image.xml
+++ b/core/designsystem/src/main/res/drawable/ic_image.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M19,5v14L5,19L5,5h14m0,-2L5,3c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2L21,5c0,-1.1 -0.9,-2 -2,-2zM14.14,11.86l-3,3.87L9,13.14 6,17h12l-3.86,-5.14z"/>
+    
+</vector>

--- a/feature/mygroup/build.gradle.kts
+++ b/feature/mygroup/build.gradle.kts
@@ -1,7 +1,13 @@
+import com.boostcamp.mapisode.convention.extension.implementation
+
 plugins {
 	alias(libs.plugins.mapisode.feature)
 }
 
 android {
 	namespace = "com.boostcamp.mapisode.mygroup"
+}
+
+dependencies {
+	implementation(libs.bundles.coil)
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupEditScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupEditScreen.kt
@@ -1,0 +1,82 @@
+package com.boostcamp.mapisode.mygroup
+
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalFocusManager
+import coil3.compose.AsyncImage
+import com.boostcamp.mapisode.designsystem.R
+import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
+import com.boostcamp.mapisode.designsystem.compose.MapisodeIconButton
+import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
+import com.boostcamp.mapisode.designsystem.compose.button.MapisodeImageButton
+import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
+
+@Composable
+fun GroupEditScreen() {
+	val focusManager = LocalFocusManager.current
+
+	MapisodeScaffold(
+		modifier = Modifier
+			.fillMaxSize()
+			.pointerInput(Unit) {
+				detectTapGestures(
+					onPress = {
+						focusManager.clearFocus()
+					},
+				)
+			},
+		isStatusBarPaddingExist = true,
+		topBar = {
+			TopAppBar(
+				title = "나의 그룹",
+				navigationIcon = {
+					MapisodeIconButton(
+						onClick = {
+						},
+					) {
+						MapisodeIcon(
+							id = R.drawable.ic_arrow_back_ios,
+						)
+					}
+				},
+			)
+		},
+	) {
+		var isClicked by remember { mutableStateOf(true) }
+		Column(
+			modifier = Modifier
+				.fillMaxSize()
+				.padding(it),
+			verticalArrangement = Arrangement.Center,
+			horizontalAlignment = Alignment.CenterHorizontally,
+		) {
+			MapisodeImageButton(
+				modifier = Modifier
+					.fillMaxWidth(0.8f)
+					.aspectRatio(1f),
+				onClick = { isClicked = !isClicked },
+				showImage = isClicked,
+				text = "이미지를 선택하세요",
+			) {
+				AsyncImage(
+					model = "https://m.media-amazon.com/images/I/61jyqnlyIaS.jpg",
+					contentDescription = "그룹 이미지",
+					modifier = Modifier.fillMaxSize(),
+				)
+			}
+		}
+	}
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ compose-navigation = "2.8.3"
 compose-material3 = "1.2.1"
 
 # Coil
-coil = "3.0.0-rc02"
+coil = "3.0.3"
 
 # Firebase
 firebase-bom = "33.5.1"
@@ -87,8 +87,8 @@ androidx-datastore-core = { group = "androidx.datastore", name = "datastore-core
 androidx-datatore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "androidx-datatstore" }
 
 # Coil
-coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
-coil-network-okhttp = { group = "io.coil-kt", name = "coil-network-okhttp", version.ref = "coil" }
+coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
+coil-network-okhttp = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }
 
 # Compose
 compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }


### PR DESCRIPTION
- closed #48 
- closed #60

## *📍 Work Description*

- Custom ImageButton 제작 (초기 화면은 이미지 아이콘과 문자열이 수직으로 나열되어 있습니다.)
- 코일을 결합하여 사용 및 에뮬레이터 테스트

## *📸 Screenshot*

https://github.com/user-attachments/assets/3a5e97cf-337b-4da6-a5d6-50c26fc04e13

<img src="https://github.com/user-attachments/assets/4c70863f-1a1c-48a4-9932-1e6e9ee377af" width=600>

## *📢 To Reviewers*
- 이 컴포넌트의 용도는 사진 추가할 때 이미지 피커로 전환되기 전의 엔트리 포인트 역할과, 이미지 피커에서 이미지를 선택한 후 이미지를 표시하기 위함 입니다.
- 현재는 이미지 피커가 존재하지 않기 때문에 초기에는 placeHolder 역할을 하는 아이콘과 텍스트를 띄우고, 버튼을 누르면 이미지 피커 과정을 생략하고 곧바로 imageContent (coil) 을 띄우도록 했습니다.
- coil 을 사용하는 과정에서 Maven Coordinate (라이브러리 명)의 변경과 3.x 의 major release 버전이 최근에 출시되었다는 것을 확인하고 수정했습니다.

## ⏲️Time

    - 3시간
