### PR TITLE
[UI/#57] 에피소드 생성 화면 UI 구성

### DIFF
--- a/feature/episode/build.gradle.kts
+++ b/feature/episode/build.gradle.kts
@@ -5,3 +5,9 @@ plugins {
 android {
 	namespace = "com.boostcamp.mapisode.episode"
 }
+
+dependencies {
+	implementation(project.libs.bundles.naverMap)
+	implementation(projects.core.ui)
+	implementation(projects.core.designsystem)
+}

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/EpisodeScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/EpisodeScreen.kt
@@ -12,6 +12,7 @@ import com.naver.maps.map.compose.rememberMarkerState
 internal fun EpisodeRoute() {
 	val newEpisodeNavController = rememberNavController()
 	val markerState = rememberMarkerState()
+
 	NavHost(newEpisodeNavController, startDestination = "new_episode_pics") {
 		composable("new_episode_pics") {
 			NewEpisodePicsScreen(

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/EpisodeScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/EpisodeScreen.kt
@@ -1,24 +1,41 @@
 package com.boostcamp.mapisode.episode
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.naver.maps.map.compose.ExperimentalNaverMapApi
+import com.naver.maps.map.compose.rememberMarkerState
 
+@OptIn(ExperimentalNaverMapApi::class)
 @Composable
 internal fun EpisodeRoute() {
-	EpisodeScreen()
-}
+	val newEpisodeNavController = rememberNavController()
+	val markerState = rememberMarkerState()
+	NavHost(newEpisodeNavController, startDestination = "new_episode_pics") {
+		composable("new_episode_pics") {
+			NewEpisodePicsScreen(
+				navController = newEpisodeNavController,
+			)
+		}
 
-@Composable
-private fun EpisodeScreen() {
-	Box(
-		modifier = Modifier.fillMaxSize(),
-		contentAlignment = Alignment.Center,
-	) {
-		Text(text = "EpisodeScreen", style = MaterialTheme.typography.displayMedium)
+		composable("new_episode_info") {
+			NewEpisodeInfoScreen(
+				navController = newEpisodeNavController,
+			)
+		}
+
+		composable("pick_location") {
+			PickLocationScreen(
+				markerState = markerState,
+				navController = newEpisodeNavController,
+			)
+		}
+
+		composable("new_episode_content") {
+			NewEpisodeContentScreen(
+				navController = newEpisodeNavController,
+			)
+		}
 	}
 }

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/EpisodeTextFieldGroup.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/EpisodeTextFieldGroup.kt
@@ -1,0 +1,45 @@
+package com.boostcamp.mapisode.episode
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.boostcamp.mapisode.designsystem.compose.MapisodeIconButton
+import com.boostcamp.mapisode.designsystem.compose.MapisodeText
+import com.boostcamp.mapisode.designsystem.compose.MapisodeTextField
+import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
+import com.boostcamp.mapisode.episode.common.NewEpisodeConstant.textFieldModifier
+import com.boostcamp.mapisode.episode.common.NewEpisodeConstant.textFieldVerticalArrangement
+
+@Composable
+fun EpisodeTextFieldGroup(
+	modifier: Modifier = Modifier,
+	@StringRes labelRes: Int,
+	@StringRes placeholderRes: Int,
+	value: String = "",
+	onValueChange: (String) -> Unit = { },
+	trailingIcon: @Composable (() -> Unit)? = null,
+	onTrailingIconClick: (() -> Unit)? = null,
+) {
+	Column(textFieldModifier, verticalArrangement = textFieldVerticalArrangement) {
+		MapisodeText(
+			text = stringResource(labelRes),
+			style = MapisodeTheme.typography.labelLarge,
+		)
+		MapisodeTextField(
+			modifier = modifier.fillMaxWidth(),
+			value = value,
+			placeholder = stringResource(placeholderRes),
+			onValueChange = onValueChange,
+			trailingIcon = {
+				trailingIcon?.let {
+					MapisodeIconButton(
+						onClick = onTrailingIconClick ?: {},
+					) { it() }
+				}
+			},
+		)
+	}
+}

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeContentScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeContentScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
@@ -21,7 +20,6 @@ import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
 import com.boostcamp.mapisode.designsystem.compose.MapisodeText
-import com.boostcamp.mapisode.designsystem.compose.MapisodeTextField
 import com.boostcamp.mapisode.designsystem.compose.Surface
 import com.boostcamp.mapisode.designsystem.compose.button.MapisodeFilledButton
 import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
@@ -44,32 +42,15 @@ internal fun NewEpisodeContentScreen(navController: NavController) {
 			verticalArrangement = Arrangement.SpaceBetween,
 		) {
 			Column {
-				Column(textFieldModifier, verticalArrangement = textFieldVerticalArrangement) {
-					MapisodeText(
-						text = stringResource(R.string.new_episode_content_title),
-						style = MapisodeTheme.typography.labelLarge,
-					)
-					MapisodeTextField(
-						modifier = Modifier.fillMaxWidth(),
-						value = "",
-						placeholder = stringResource(R.string.new_episode_content_placeholder_title),
-						onValueChange = {},
-					)
-				}
-				Column(textFieldModifier, verticalArrangement = textFieldVerticalArrangement) {
-					MapisodeText(
-						text = stringResource(R.string.new_episode_content_description),
-						style = MapisodeTheme.typography.labelLarge,
-					)
-					MapisodeTextField(
-						modifier = Modifier
-							.fillMaxWidth()
-							.fillMaxHeight(0.3f),
-						value = "",
-						placeholder = stringResource(R.string.new_episode_content_placeholder_description),
-						onValueChange = {},
-					)
-				}
+				EpisodeTextFieldGroup(
+					labelRes = R.string.new_episode_content_title,
+					placeholderRes = R.string.new_episode_content_placeholder_title,
+				)
+				EpisodeTextFieldGroup(
+					modifier = Modifier.fillMaxHeight(0.3f),
+					labelRes = R.string.new_episode_content_description,
+					placeholderRes = R.string.new_episode_content_placeholder_description,
+				)
 				Column(textFieldModifier, verticalArrangement = textFieldVerticalArrangement) {
 					MapisodeText(
 						text = stringResource(R.string.new_episode_content_image),

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeContentScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeContentScreen.kt
@@ -1,15 +1,26 @@
 package com.boostcamp.mapisode.episode
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
+import com.boostcamp.mapisode.designsystem.compose.MapisodeIconButton
 import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
 import com.boostcamp.mapisode.designsystem.compose.MapisodeText
+import com.boostcamp.mapisode.designsystem.compose.MapisodeTextField
+import com.boostcamp.mapisode.designsystem.compose.button.MapisodeFilledButton
 import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
+import com.boostcamp.mapisode.episode.common.NewEpisodeConstant.textFieldModifier
+import com.boostcamp.mapisode.episode.common.NewEpisodeConstant.textFieldVerticalArrangement
 
 @Composable
 internal fun NewEpisodeContentScreen(navController: NavController) {
@@ -20,18 +31,114 @@ internal fun NewEpisodeContentScreen(navController: NavController) {
 		isStatusBarPaddingExist = true,
 	)
 	{ innerPadding ->
-		Box(
-			Modifier
+		Column(
+			modifier = Modifier
+				.padding(innerPadding)
 				.fillMaxSize()
-				.padding(innerPadding),
-			contentAlignment = Alignment.Center,
+				.padding(10.dp),
+			verticalArrangement = Arrangement.SpaceBetween,
 		) {
-			MapisodeText(
-				text = "제목/내용 작성 화면",
-				style = MapisodeTheme.typography.displayMedium,
+			Column {
+				Column(textFieldModifier, verticalArrangement = textFieldVerticalArrangement) {
+					MapisodeText(
+						text = stringResource(R.string.new_episode_info_location),
+						style = MapisodeTheme.typography.labelLarge,
+					)
+					MapisodeTextField(
+						modifier = Modifier.fillMaxWidth(),
+						value = "",
+						placeholder = stringResource(R.string.new_episode_info_placeholder_location),
+						onValueChange = {},
+						trailingIcon = {
+							MapisodeIconButton(
+								onClick = {
+									navController.navigate("pick_location")
+								},
+							) { MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_location) }
+						},
+					)
+				}
+				Column(textFieldModifier, verticalArrangement = textFieldVerticalArrangement) {
+					MapisodeText(
+						text = stringResource(R.string.new_episode_info_group),
+						style = MapisodeTheme.typography.labelLarge,
+					)
+					MapisodeTextField(
+						modifier = Modifier.fillMaxWidth(),
+						value = "",
+						placeholder = stringResource(R.string.new_episode_info_placeholder_group),
+						onValueChange = {},
+						trailingIcon = {
+							MapisodeIconButton(
+								onClick = {
+								},
+							) { MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_arrow_drop_down) }
+						},
+					)
+				}
+				Column(textFieldModifier, verticalArrangement = textFieldVerticalArrangement) {
+					MapisodeText(
+						text = stringResource(R.string.new_episode_info_category),
+						style = MapisodeTheme.typography.labelLarge,
+					)
+					MapisodeTextField(
+						modifier = Modifier.fillMaxWidth(),
+						value = "",
+						placeholder = stringResource(R.string.new_episode_info_placeholder_category),
+						onValueChange = {},
+						trailingIcon = {
+							MapisodeIconButton(
+								onClick = {
+								},
+							) { MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_arrow_drop_down) }
+						},
+					)
+				}
+				Column(textFieldModifier, verticalArrangement = textFieldVerticalArrangement) {
+					MapisodeText(
+						text = stringResource(R.string.new_episode_info_tags),
+						style = MapisodeTheme.typography.labelLarge,
+					)
+					MapisodeTextField(
+						modifier = Modifier.fillMaxWidth(),
+						value = "",
+						placeholder = stringResource(R.string.new_episode_info_placeholder_tags),
+						onValueChange = {},
+					)
+				}
+				Column(textFieldModifier, verticalArrangement = textFieldVerticalArrangement) {
+					MapisodeText(
+						text = stringResource(R.string.new_episode_info_date),
+						style = MapisodeTheme.typography.labelLarge,
+					)
+					MapisodeTextField(
+						modifier = Modifier.fillMaxWidth(),
+						value = "",
+						placeholder = stringResource(R.string.new_episode_info_placeholder_date),
+						onValueChange = {},
+						trailingIcon = {
+							MapisodeIconButton(
+								onClick = {},
+							) { MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_calendar) }
+						},
+					)
+				}
+			}
+			MapisodeFilledButton(
+				modifier = textFieldModifier,
+				onClick = {
+					navController.navigate("new_episode_content")
+				},
+				text = "다음",
 			)
 		}
 	}
+}
+
+@Preview
+@Composable
+internal fun NewEpisodeContentScreenPreview() {
+	NewEpisodeContentScreen(rememberNavController())
 }
 
 

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeContentScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeContentScreen.kt
@@ -1,0 +1,37 @@
+package com.boostcamp.mapisode.episode
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavController
+import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
+import com.boostcamp.mapisode.designsystem.compose.MapisodeText
+import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
+
+@Composable
+internal fun NewEpisodeContentScreen(navController: NavController) {
+	MapisodeScaffold(
+		topBar = {
+			NewEpisodeTopbar(navController)
+		},
+		isStatusBarPaddingExist = true,
+	)
+	{ innerPadding ->
+		Box(
+			Modifier
+				.fillMaxSize()
+				.padding(innerPadding),
+			contentAlignment = Alignment.Center,
+		) {
+			MapisodeText(
+				text = "제목/내용 작성 화면",
+				style = MapisodeTheme.typography.displayMedium,
+			)
+		}
+	}
+}
+
+

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeContentScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeContentScreen.kt
@@ -35,8 +35,7 @@ internal fun NewEpisodeContentScreen(navController: NavController) {
 			NewEpisodeTopbar(navController)
 		},
 		isStatusBarPaddingExist = true,
-	)
-	{ innerPadding ->
+	) { innerPadding ->
 		Column(
 			modifier = Modifier
 				.padding(innerPadding)
@@ -84,7 +83,9 @@ internal fun NewEpisodeContentScreen(navController: NavController) {
 							Surface(Modifier.size(150.dp)) {
 								Image(
 									contentDescription = null,
-									imageVector = ImageVector.vectorResource(com.boostcamp.mapisode.designsystem.R.drawable.ic_see),
+									imageVector = ImageVector.vectorResource(
+										com.boostcamp.mapisode.designsystem.R.drawable.ic_see,
+									),
 								)
 							}
 						}
@@ -107,5 +108,3 @@ internal fun NewEpisodeContentScreen(navController: NavController) {
 internal fun NewEpisodeContentScreenPreview() {
 	NewEpisodeContentScreen(rememberNavController())
 }
-
-

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeContentScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeContentScreen.kt
@@ -1,22 +1,28 @@
 package com.boostcamp.mapisode.episode
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
-import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
-import com.boostcamp.mapisode.designsystem.compose.MapisodeIconButton
 import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
 import com.boostcamp.mapisode.designsystem.compose.MapisodeText
 import com.boostcamp.mapisode.designsystem.compose.MapisodeTextField
+import com.boostcamp.mapisode.designsystem.compose.Surface
 import com.boostcamp.mapisode.designsystem.compose.button.MapisodeFilledButton
 import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 import com.boostcamp.mapisode.episode.common.NewEpisodeConstant.textFieldModifier
@@ -41,87 +47,48 @@ internal fun NewEpisodeContentScreen(navController: NavController) {
 			Column {
 				Column(textFieldModifier, verticalArrangement = textFieldVerticalArrangement) {
 					MapisodeText(
-						text = stringResource(R.string.new_episode_info_location),
+						text = stringResource(R.string.new_episode_content_title),
 						style = MapisodeTheme.typography.labelLarge,
 					)
 					MapisodeTextField(
 						modifier = Modifier.fillMaxWidth(),
 						value = "",
-						placeholder = stringResource(R.string.new_episode_info_placeholder_location),
-						onValueChange = {},
-						trailingIcon = {
-							MapisodeIconButton(
-								onClick = {
-									navController.navigate("pick_location")
-								},
-							) { MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_location) }
-						},
-					)
-				}
-				Column(textFieldModifier, verticalArrangement = textFieldVerticalArrangement) {
-					MapisodeText(
-						text = stringResource(R.string.new_episode_info_group),
-						style = MapisodeTheme.typography.labelLarge,
-					)
-					MapisodeTextField(
-						modifier = Modifier.fillMaxWidth(),
-						value = "",
-						placeholder = stringResource(R.string.new_episode_info_placeholder_group),
-						onValueChange = {},
-						trailingIcon = {
-							MapisodeIconButton(
-								onClick = {
-								},
-							) { MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_arrow_drop_down) }
-						},
-					)
-				}
-				Column(textFieldModifier, verticalArrangement = textFieldVerticalArrangement) {
-					MapisodeText(
-						text = stringResource(R.string.new_episode_info_category),
-						style = MapisodeTheme.typography.labelLarge,
-					)
-					MapisodeTextField(
-						modifier = Modifier.fillMaxWidth(),
-						value = "",
-						placeholder = stringResource(R.string.new_episode_info_placeholder_category),
-						onValueChange = {},
-						trailingIcon = {
-							MapisodeIconButton(
-								onClick = {
-								},
-							) { MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_arrow_drop_down) }
-						},
-					)
-				}
-				Column(textFieldModifier, verticalArrangement = textFieldVerticalArrangement) {
-					MapisodeText(
-						text = stringResource(R.string.new_episode_info_tags),
-						style = MapisodeTheme.typography.labelLarge,
-					)
-					MapisodeTextField(
-						modifier = Modifier.fillMaxWidth(),
-						value = "",
-						placeholder = stringResource(R.string.new_episode_info_placeholder_tags),
+						placeholder = stringResource(R.string.new_episode_content_placeholder_title),
 						onValueChange = {},
 					)
 				}
 				Column(textFieldModifier, verticalArrangement = textFieldVerticalArrangement) {
 					MapisodeText(
-						text = stringResource(R.string.new_episode_info_date),
+						text = stringResource(R.string.new_episode_content_description),
 						style = MapisodeTheme.typography.labelLarge,
 					)
 					MapisodeTextField(
-						modifier = Modifier.fillMaxWidth(),
+						modifier = Modifier
+							.fillMaxWidth()
+							.fillMaxHeight(0.3f),
 						value = "",
-						placeholder = stringResource(R.string.new_episode_info_placeholder_date),
+						placeholder = stringResource(R.string.new_episode_content_placeholder_description),
 						onValueChange = {},
-						trailingIcon = {
-							MapisodeIconButton(
-								onClick = {},
-							) { MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_calendar) }
-						},
 					)
+				}
+				Column(textFieldModifier, verticalArrangement = textFieldVerticalArrangement) {
+					MapisodeText(
+						text = stringResource(R.string.new_episode_content_image),
+						style = MapisodeTheme.typography.labelLarge,
+					)
+					LazyRow(
+						contentPadding = PaddingValues(12.dp),
+						horizontalArrangement = Arrangement.spacedBy(10.dp),
+					) {
+						items(3) {
+							Surface(Modifier.size(150.dp)) {
+								Image(
+									contentDescription = null,
+									imageVector = ImageVector.vectorResource(com.boostcamp.mapisode.designsystem.R.drawable.ic_see),
+								)
+							}
+						}
+					}
 				}
 			}
 			MapisodeFilledButton(
@@ -129,7 +96,7 @@ internal fun NewEpisodeContentScreen(navController: NavController) {
 				onClick = {
 					navController.navigate("new_episode_content")
 				},
-				text = "다음",
+				text = stringResource(R.string.new_episode_create_episode),
 			)
 		}
 	}

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeContentScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeContentScreen.kt
@@ -41,7 +41,7 @@ internal fun NewEpisodeContentScreen(navController: NavController) {
 			modifier = Modifier
 				.padding(innerPadding)
 				.fillMaxSize()
-				.padding(10.dp),
+				.padding(20.dp),
 			verticalArrangement = Arrangement.SpaceBetween,
 		) {
 			Column {

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeInfoScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeInfoScreen.kt
@@ -1,0 +1,35 @@
+package com.boostcamp.mapisode.episode
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavController
+import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
+import com.boostcamp.mapisode.designsystem.compose.MapisodeText
+import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
+
+@Composable
+internal fun NewEpisodeInfoScreen(navController: NavController) {
+	MapisodeScaffold(
+		topBar = {
+			NewEpisodeTopbar(navController)
+		},
+		isStatusBarPaddingExist = true,
+	)
+	{ innerPadding ->
+		Box(
+			Modifier
+				.fillMaxSize()
+				.padding(innerPadding),
+			contentAlignment = Alignment.Center,
+		) {
+			MapisodeText(
+				text = "정보 입력 화면",
+				style = MapisodeTheme.typography.displayLarge,
+			)
+		}
+	}
+}

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeInfoScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeInfoScreen.kt
@@ -1,35 +1,144 @@
 package com.boostcamp.mapisode.episode
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
+import com.boostcamp.mapisode.designsystem.compose.MapisodeIconButton
 import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
 import com.boostcamp.mapisode.designsystem.compose.MapisodeText
+import com.boostcamp.mapisode.designsystem.compose.MapisodeTextField
+import com.boostcamp.mapisode.designsystem.compose.button.MapisodeFilledButton
 import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 
 @Composable
 internal fun NewEpisodeInfoScreen(navController: NavController) {
+	val textFieldModifier = Modifier
+		.fillMaxWidth()
+		.padding(vertical = 15.dp)
+	val textFieldVerticalArrangement = Arrangement.spacedBy(12.dp)
+
 	MapisodeScaffold(
 		topBar = {
 			NewEpisodeTopbar(navController)
 		},
 		isStatusBarPaddingExist = true,
-	)
-	{ innerPadding ->
-		Box(
-			Modifier
+	) { innerPadding ->
+		Column(
+			modifier = Modifier
+				.padding(innerPadding)
 				.fillMaxSize()
-				.padding(innerPadding),
-			contentAlignment = Alignment.Center,
+				.padding(10.dp),
+			verticalArrangement = Arrangement.SpaceBetween,
 		) {
-			MapisodeText(
-				text = "정보 입력 화면",
-				style = MapisodeTheme.typography.displayLarge,
+			Column {
+				Column(textFieldModifier, verticalArrangement = textFieldVerticalArrangement) {
+					MapisodeText(
+						text = stringResource(R.string.new_episode_info_location),
+						style = MapisodeTheme.typography.labelLarge,
+					)
+					MapisodeTextField(
+						modifier = Modifier.fillMaxWidth(),
+						value = "",
+						placeholder = stringResource(R.string.new_episode_info_placeholder_location),
+						onValueChange = {},
+						trailingIcon = {
+							MapisodeIconButton(
+								onClick = {
+									navController.navigate("pick_location")
+								},
+							) { MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_location) }
+						},
+					)
+				}
+				Column(textFieldModifier, verticalArrangement = textFieldVerticalArrangement) {
+					MapisodeText(
+						text = stringResource(R.string.new_episode_info_group),
+						style = MapisodeTheme.typography.labelLarge,
+					)
+					MapisodeTextField(
+						modifier = Modifier.fillMaxWidth(),
+						value = "",
+						placeholder = stringResource(R.string.new_episode_info_placeholder_group),
+						onValueChange = {},
+						trailingIcon = {
+							MapisodeIconButton(
+								onClick = {
+								},
+							) { MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_arrow_drop_down) }
+						},
+					)
+				}
+				Column(textFieldModifier, verticalArrangement = textFieldVerticalArrangement) {
+					MapisodeText(
+						text = stringResource(R.string.new_episode_info_category),
+						style = MapisodeTheme.typography.labelLarge,
+					)
+					MapisodeTextField(
+						modifier = Modifier.fillMaxWidth(),
+						value = "",
+						placeholder = stringResource(R.string.new_episode_info_placeholder_category),
+						onValueChange = {},
+						trailingIcon = {
+							MapisodeIconButton(
+								onClick = {
+								},
+							) { MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_arrow_drop_down) }
+						},
+					)
+				}
+				Column(textFieldModifier, verticalArrangement = textFieldVerticalArrangement) {
+					MapisodeText(
+						text = stringResource(R.string.new_episode_info_tags),
+						style = MapisodeTheme.typography.labelLarge,
+					)
+					MapisodeTextField(
+						modifier = Modifier.fillMaxWidth(),
+						value = "",
+						placeholder = stringResource(R.string.new_episode_info_placeholder_tags),
+						onValueChange = {},
+					)
+				}
+				Column(textFieldModifier, verticalArrangement = textFieldVerticalArrangement) {
+					MapisodeText(
+						text = stringResource(R.string.new_episode_info_date),
+						style = MapisodeTheme.typography.labelLarge,
+					)
+					MapisodeTextField(
+						modifier = Modifier.fillMaxWidth(),
+						value = "",
+						placeholder = stringResource(R.string.new_episode_info_placeholder_date),
+						onValueChange = {},
+						trailingIcon = {
+							MapisodeIconButton(
+								onClick = {},
+							) { MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_calendar) }
+						},
+					)
+				}
+			}
+			MapisodeFilledButton(
+				modifier = textFieldModifier,
+				onClick = {
+					navController.navigate("new_episode_content")
+				},
+				text = "다음",
 			)
 		}
 	}
+}
+
+@Preview
+@Composable
+internal fun NewEpisodeInfoScreenPreview() {
+	NewEpisodeInfoScreen(rememberNavController())
 }

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeInfoScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeInfoScreen.kt
@@ -19,14 +19,11 @@ import com.boostcamp.mapisode.designsystem.compose.MapisodeText
 import com.boostcamp.mapisode.designsystem.compose.MapisodeTextField
 import com.boostcamp.mapisode.designsystem.compose.button.MapisodeFilledButton
 import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
+import com.boostcamp.mapisode.episode.common.NewEpisodeConstant.textFieldModifier
+import com.boostcamp.mapisode.episode.common.NewEpisodeConstant.textFieldVerticalArrangement
 
 @Composable
 internal fun NewEpisodeInfoScreen(navController: NavController) {
-	val textFieldModifier = Modifier
-		.fillMaxWidth()
-		.padding(vertical = 15.dp)
-	val textFieldVerticalArrangement = Arrangement.spacedBy(12.dp)
-
 	MapisodeScaffold(
 		topBar = {
 			NewEpisodeTopbar(navController)

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeInfoScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeInfoScreen.kt
@@ -34,7 +34,7 @@ internal fun NewEpisodeInfoScreen(navController: NavController) {
 			modifier = Modifier
 				.padding(innerPadding)
 				.fillMaxSize()
-				.padding(10.dp),
+				.padding(20.dp),
 			verticalArrangement = Arrangement.SpaceBetween,
 		) {
 			Column {

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeInfoScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeInfoScreen.kt
@@ -3,24 +3,17 @@ package com.boostcamp.mapisode.episode
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
-import com.boostcamp.mapisode.designsystem.compose.MapisodeIconButton
 import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
-import com.boostcamp.mapisode.designsystem.compose.MapisodeText
-import com.boostcamp.mapisode.designsystem.compose.MapisodeTextField
 import com.boostcamp.mapisode.designsystem.compose.button.MapisodeFilledButton
-import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 import com.boostcamp.mapisode.episode.common.NewEpisodeConstant.textFieldModifier
-import com.boostcamp.mapisode.episode.common.NewEpisodeConstant.textFieldVerticalArrangement
 
 @Composable
 internal fun NewEpisodeInfoScreen(navController: NavController) {
@@ -38,90 +31,33 @@ internal fun NewEpisodeInfoScreen(navController: NavController) {
 			verticalArrangement = Arrangement.SpaceBetween,
 		) {
 			Column {
-				Column(textFieldModifier, verticalArrangement = textFieldVerticalArrangement) {
-					MapisodeText(
-						text = stringResource(R.string.new_episode_info_location),
-						style = MapisodeTheme.typography.labelLarge,
-					)
-					MapisodeTextField(
-						modifier = Modifier.fillMaxWidth(),
-						value = "",
-						placeholder = stringResource(R.string.new_episode_info_placeholder_location),
-						onValueChange = {},
-						trailingIcon = {
-							MapisodeIconButton(
-								onClick = {
-									navController.navigate("pick_location")
-								},
-							) { MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_location) }
-						},
-					)
-				}
-				Column(textFieldModifier, verticalArrangement = textFieldVerticalArrangement) {
-					MapisodeText(
-						text = stringResource(R.string.new_episode_info_group),
-						style = MapisodeTheme.typography.labelLarge,
-					)
-					MapisodeTextField(
-						modifier = Modifier.fillMaxWidth(),
-						value = "",
-						placeholder = stringResource(R.string.new_episode_info_placeholder_group),
-						onValueChange = {},
-						trailingIcon = {
-							MapisodeIconButton(
-								onClick = {
-								},
-							) { MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_arrow_drop_down) }
-						},
-					)
-				}
-				Column(textFieldModifier, verticalArrangement = textFieldVerticalArrangement) {
-					MapisodeText(
-						text = stringResource(R.string.new_episode_info_category),
-						style = MapisodeTheme.typography.labelLarge,
-					)
-					MapisodeTextField(
-						modifier = Modifier.fillMaxWidth(),
-						value = "",
-						placeholder = stringResource(R.string.new_episode_info_placeholder_category),
-						onValueChange = {},
-						trailingIcon = {
-							MapisodeIconButton(
-								onClick = {
-								},
-							) { MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_arrow_drop_down) }
-						},
-					)
-				}
-				Column(textFieldModifier, verticalArrangement = textFieldVerticalArrangement) {
-					MapisodeText(
-						text = stringResource(R.string.new_episode_info_tags),
-						style = MapisodeTheme.typography.labelLarge,
-					)
-					MapisodeTextField(
-						modifier = Modifier.fillMaxWidth(),
-						value = "",
-						placeholder = stringResource(R.string.new_episode_info_placeholder_tags),
-						onValueChange = {},
-					)
-				}
-				Column(textFieldModifier, verticalArrangement = textFieldVerticalArrangement) {
-					MapisodeText(
-						text = stringResource(R.string.new_episode_info_date),
-						style = MapisodeTheme.typography.labelLarge,
-					)
-					MapisodeTextField(
-						modifier = Modifier.fillMaxWidth(),
-						value = "",
-						placeholder = stringResource(R.string.new_episode_info_placeholder_date),
-						onValueChange = {},
-						trailingIcon = {
-							MapisodeIconButton(
-								onClick = {},
-							) { MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_calendar) }
-						},
-					)
-				}
+				EpisodeTextFieldGroup(
+					labelRes = R.string.new_episode_info_location,
+					placeholderRes = R.string.new_episode_info_placeholder_location,
+					trailingIcon = { MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_location) },
+					onTrailingIconClick = {
+						navController.navigate("pick_location")
+					},
+				)
+				EpisodeTextFieldGroup(
+					labelRes = R.string.new_episode_info_group,
+					placeholderRes = R.string.new_episode_info_placeholder_group,
+					trailingIcon = { MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_arrow_drop_down) }
+				)
+				EpisodeTextFieldGroup(
+					labelRes = R.string.new_episode_info_category,
+					placeholderRes = R.string.new_episode_info_placeholder_category,
+					trailingIcon = { MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_arrow_drop_down) }
+				)
+				EpisodeTextFieldGroup(
+					labelRes = R.string.new_episode_info_tags,
+					placeholderRes = R.string.new_episode_info_placeholder_tags,
+				)
+				EpisodeTextFieldGroup(
+					labelRes = R.string.new_episode_info_date,
+					placeholderRes = R.string.new_episode_info_placeholder_date,
+					trailingIcon = { MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_calendar) }
+				)
 			}
 			MapisodeFilledButton(
 				modifier = textFieldModifier,

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodePicsScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodePicsScreen.kt
@@ -33,8 +33,7 @@ internal fun NewEpisodePicsScreen(navController: NavController) {
 			)
 		},
 		isStatusBarPaddingExist = true,
-	)
-	{ innerPadding ->
+	) { innerPadding ->
 		Box(
 			Modifier
 				.fillMaxSize()

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodePicsScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodePicsScreen.kt
@@ -1,0 +1,50 @@
+package com.boostcamp.mapisode.episode
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.navigation.NavController
+import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
+import com.boostcamp.mapisode.designsystem.compose.MapisodeIconButton
+import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
+import com.boostcamp.mapisode.designsystem.compose.MapisodeText
+import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
+import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
+
+@Composable
+internal fun NewEpisodePicsScreen(navController: NavController) {
+	MapisodeScaffold(
+		topBar = {
+			TopAppBar(
+				title = stringResource(R.string.new_episode_menu_title),
+				actions = {
+					MapisodeIconButton(
+						onClick = {
+							navController.navigate("new_episode_info")
+						},
+					) {
+						MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_arrow_forward_ios)
+					}
+				},
+			)
+		},
+		isStatusBarPaddingExist = true,
+	)
+	{ innerPadding ->
+		Box(
+			Modifier
+				.fillMaxSize()
+				.padding(innerPadding),
+			contentAlignment = Alignment.Center,
+		) {
+			MapisodeText(
+				text = "사진 선택 화면",
+				style = MapisodeTheme.typography.displayLarge,
+			)
+		}
+	}
+}

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeTopbar.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeTopbar.kt
@@ -1,0 +1,33 @@
+package com.boostcamp.mapisode.episode
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import androidx.navigation.NavController
+import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
+import com.boostcamp.mapisode.designsystem.compose.MapisodeIconButton
+import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
+
+@Composable
+internal fun NewEpisodeTopbar(navController: NavController) {
+	TopAppBar(
+		title = stringResource(R.string.new_episode_menu_create_episode),
+		navigationIcon = {
+			MapisodeIconButton(
+				onClick = {
+					navController.navigateUp()
+				},
+			) {
+				MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_arrow_back_ios)
+			}
+		},
+		actions = {
+			MapisodeIconButton(
+				onClick = {
+					navController.popBackStack("new_episode_pics", false)
+				},
+			) {
+				MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_clear)
+			}
+		},
+	)
+}

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/PickLocationScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/PickLocationScreen.kt
@@ -33,7 +33,7 @@ internal fun PickLocationScreen(
 		isStatusBarPaddingExist = true,
 		topBar = {
 			TopAppBar(
-				title = "새 에피소드",
+				title = stringResource(R.string.new_episode_menu_title),
 				navigationIcon = {
 					MapisodeIconButton(onClick = { navController.navigateUp() }) {
 						MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_arrow_back_ios)
@@ -58,13 +58,11 @@ internal fun PickLocationScreen(
 			) {
 				Column(Modifier.padding(horizontal = 20.dp)) {
 					MapisodeText(
-						modifier = Modifier.padding(vertical = 10.dp),
-						text = "이 장소로 할래요",
-						style = MapisodeTheme.typography.labelLarge,
+						text = stringResource(R.string.new_episode_pick_location),
+						style = MapisodeTheme.typography.headlineSmall,
 					)
 					MapisodeText(
-						modifier = Modifier.padding(vertical = 10.dp),
-						text = "주소",
+						text = stringResource(R.string.new_episode_info_placeholder_location),
 						style = MapisodeTheme.typography.bodyLarge,
 					)
 					MapisodeFilledButton(
@@ -72,6 +70,8 @@ internal fun PickLocationScreen(
 							.padding(vertical = 10.dp)
 							.fillMaxWidth(),
 						text = "장소 선택하기",
+						modifier = Modifier.fillMaxWidth(),
+						text = stringResource(R.string.new_episode_pick_location_button),
 						onClick = { navController.navigate("new_episode_content") },
 						showRipple = true,
 					)

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/PickLocationScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/PickLocationScreen.kt
@@ -1,13 +1,15 @@
 package com.boostcamp.mapisode.episode
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
@@ -44,19 +46,23 @@ internal fun PickLocationScreen(
 	) {
 		Column {
 			NaverMap(
-				modifier = Modifier.fillMaxHeight(0.8f),
+				modifier = Modifier.fillMaxHeight(0.75f),
 				uiSettings = MapUiSettings(
 					isZoomControlEnabled = false,
 					isLocationButtonEnabled = true,
+					isLogoClickEnabled = false
 				),
 			) {
 				Marker(state = markerState)
 			}
 			Box(
-				modifier = Modifier
-					.height(420.dp),
+				modifier = Modifier.fillMaxHeight(),
+				contentAlignment = Alignment.Center,
 			) {
-				Column(Modifier.padding(horizontal = 20.dp)) {
+				Column(
+					modifier = Modifier.padding(20.dp),
+					verticalArrangement = Arrangement.spacedBy(20.dp),
+				) {
 					MapisodeText(
 						text = stringResource(R.string.new_episode_pick_location),
 						style = MapisodeTheme.typography.headlineSmall,

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/PickLocationScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/PickLocationScreen.kt
@@ -66,10 +66,6 @@ internal fun PickLocationScreen(
 						style = MapisodeTheme.typography.bodyLarge,
 					)
 					MapisodeFilledButton(
-						modifier = Modifier
-							.padding(vertical = 10.dp)
-							.fillMaxWidth(),
-						text = "장소 선택하기",
 						modifier = Modifier.fillMaxWidth(),
 						text = stringResource(R.string.new_episode_pick_location_button),
 						onClick = { navController.navigate("new_episode_content") },

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/PickLocationScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/PickLocationScreen.kt
@@ -1,0 +1,82 @@
+package com.boostcamp.mapisode.episode
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
+import com.boostcamp.mapisode.designsystem.compose.MapisodeIconButton
+import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
+import com.boostcamp.mapisode.designsystem.compose.MapisodeText
+import com.boostcamp.mapisode.designsystem.compose.button.MapisodeFilledButton
+import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
+import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
+import com.naver.maps.map.compose.ExperimentalNaverMapApi
+import com.naver.maps.map.compose.MapUiSettings
+import com.naver.maps.map.compose.Marker
+import com.naver.maps.map.compose.MarkerState
+import com.naver.maps.map.compose.NaverMap
+
+@OptIn(ExperimentalNaverMapApi::class)
+@Composable
+internal fun PickLocationScreen(
+	markerState: MarkerState,
+	navController: NavController,
+) {
+	MapisodeScaffold(
+		isStatusBarPaddingExist = true,
+		topBar = {
+			TopAppBar(
+				title = "새 에피소드",
+				navigationIcon = {
+					MapisodeIconButton(onClick = { navController.navigateUp() }) {
+						MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_arrow_back_ios)
+					}
+				},
+			)
+		},
+	) {
+		Column {
+			NaverMap(
+				modifier = Modifier.fillMaxHeight(0.8f),
+				uiSettings = MapUiSettings(
+					isZoomControlEnabled = false,
+					isLocationButtonEnabled = true,
+				),
+			) {
+				Marker(state = markerState)
+			}
+			Box(
+				modifier = Modifier
+					.height(420.dp),
+			) {
+				Column(Modifier.padding(horizontal = 20.dp)) {
+					MapisodeText(
+						modifier = Modifier.padding(vertical = 10.dp),
+						text = "이 장소로 할래요",
+						style = MapisodeTheme.typography.labelLarge,
+					)
+					MapisodeText(
+						modifier = Modifier.padding(vertical = 10.dp),
+						text = "주소",
+						style = MapisodeTheme.typography.bodyLarge,
+					)
+					MapisodeFilledButton(
+						modifier = Modifier
+							.padding(vertical = 10.dp)
+							.fillMaxWidth(),
+						text = "장소 선택하기",
+						onClick = { navController.navigate("new_episode_content") },
+						showRipple = true,
+					)
+				}
+			}
+		}
+	}
+}

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/common/NewEpisodeConstant.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/common/NewEpisodeConstant.kt
@@ -1,0 +1,14 @@
+package com.boostcamp.mapisode.episode.common
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+object NewEpisodeConstant {
+	val textFieldModifier = Modifier
+		.fillMaxWidth()
+		.padding(vertical = 15.dp)
+	val textFieldVerticalArrangement = Arrangement.spacedBy(12.dp)
+}

--- a/feature/episode/src/main/res/values/strings.xml
+++ b/feature/episode/src/main/res/values/strings.xml
@@ -14,4 +14,13 @@
 	<string name="new_episode_info_placeholder_category">카테고리를 선택해주세요</string>
 	<string name="new_episode_info_placeholder_tags">태그를 입력해주세요</string>
 	<string name="new_episode_info_placeholder_date">날짜를 입력해주세요</string>
+
+	<string name="new_episode_content_title">제목</string>
+	<string name="new_episode_content_description">내용</string>
+	<string name="new_episode_content_image">이미지</string>
+
+	<string name="new_episode_content_placeholder_title">제목을 입력해주세요</string>
+	<string name="new_episode_content_placeholder_description">내용을 입력해주세요</string>
+
+	<string name="new_episode_create_episode">생성하기</string>
 </resources>

--- a/feature/episode/src/main/res/values/strings.xml
+++ b/feature/episode/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="new_episode_menu_title">새 에피소드</string>
+	<string name="new_episode_menu_create_episode">에피소드 생성</string>
+</resources>

--- a/feature/episode/src/main/res/values/strings.xml
+++ b/feature/episode/src/main/res/values/strings.xml
@@ -2,4 +2,16 @@
 <resources>
 	<string name="new_episode_menu_title">새 에피소드</string>
 	<string name="new_episode_menu_create_episode">에피소드 생성</string>
+
+	<string name="new_episode_info_location">장소</string>
+	<string name="new_episode_info_group">그룹</string>
+	<string name="new_episode_info_category">카테고리</string>
+	<string name="new_episode_info_tags">태그</string>
+	<string name="new_episode_info_date">날짜</string>
+
+	<string name="new_episode_info_placeholder_location">장소를 선택해주세요</string>
+	<string name="new_episode_info_placeholder_group">그룹을 선택해주세요</string>
+	<string name="new_episode_info_placeholder_category">카테고리를 선택해주세요</string>
+	<string name="new_episode_info_placeholder_tags">태그를 입력해주세요</string>
+	<string name="new_episode_info_placeholder_date">날짜를 입력해주세요</string>
 </resources>

--- a/feature/episode/src/main/res/values/strings.xml
+++ b/feature/episode/src/main/res/values/strings.xml
@@ -15,6 +15,9 @@
 	<string name="new_episode_info_placeholder_tags">태그를 입력해주세요</string>
 	<string name="new_episode_info_placeholder_date">날짜를 입력해주세요</string>
 
+	<string name="new_episode_pick_location">이 장소로 할래요</string>
+	<string name="new_episode_pick_location_button">장소 선택하기</string>
+
 	<string name="new_episode_content_title">제목</string>
 	<string name="new_episode_content_description">내용</string>
 	<string name="new_episode_content_image">이미지</string>


### PR DESCRIPTION
- closed #57 

## *📍 Work Description*
- feature:episode 모듈 의존성 추가
- 에피소드 생성 화면 UI 구성

## *📸 Screenshot*
### *NewEpisodePicsScreen(추후 교체 예정)*
<img src="https://github.com/user-attachments/assets/59e88b00-04d0-460a-96b9-62540c6fbb9a" width=270 />

### *NewEpisodeInfoScreen*
<img src="https://github.com/user-attachments/assets/f47f6f8f-d2d9-44c9-b396-af294f8b78ff" width=270 />

### *PickLocationScreen*
<img src="https://github.com/user-attachments/assets/7a932174-c0f0-4f3c-b43b-5e5e5897cf6e" width=270 />

### *NewEpisodeContentScreen*
<img src="https://github.com/user-attachments/assets/f95d15bc-f107-449a-ae16-ed5b8840e954" width=270 />

## *📢 To Reviewers*
> 최대한 Figma에 정의되어 있는 UI 정의를 따라 작업했습니다! (이미지 보기의 경우 고정값인데 이 역시 피그마에 정의되어 있는 값을 그대로 사용한 것입니다.)

## ⏲️Time
    - 7 시간
