### PR TITLE
[FEAT/#66] Home / BottomSheet 구현 및 적용

### DIFF
--- a/build-logic/convention/src/main/java/com/boostcamp/mapisode/convention/AndroidComposePlugin.kt
+++ b/build-logic/convention/src/main/java/com/boostcamp/mapisode/convention/AndroidComposePlugin.kt
@@ -2,9 +2,13 @@ package com.boostcamp.mapisode.convention
 
 import com.android.build.gradle.LibraryExtension
 import com.boostcamp.mapisode.convention.extension.configureComposeAndroid
+import com.boostcamp.mapisode.convention.extension.getLibrary
+import com.boostcamp.mapisode.convention.extension.implementation
+import com.boostcamp.mapisode.convention.extension.libs
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.dependencies
 
 class AndroidComposePlugin : Plugin<Project> {
 	override fun apply(target: Project) {
@@ -16,6 +20,10 @@ class AndroidComposePlugin : Plugin<Project> {
 
 			extensions.configure<LibraryExtension> {
 				configureComposeAndroid(this)
+			}
+
+			dependencies {
+				implementation(libs.getLibrary("kotlinx.immutable"))
 			}
 		}
 	}

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeModalBottomSheet.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeModalBottomSheet.kt
@@ -1,0 +1,168 @@
+package com.boostcamp.mapisode.designsystem.compose
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.util.VelocityTracker
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
+
+@Composable
+fun MapisodeModalBottomSheet(
+	isVisible: Boolean,
+	onDismiss: () -> Unit,
+	modifier: Modifier = Modifier,
+	cornerRadius: Dp = 16.dp,
+	backgroundColor: Color = Color.White,
+	scrimColor: Color = Color.Black.copy(alpha = 0.32f),
+	dragHandle: Boolean = true,
+	sheetContent: @Composable () -> Unit,
+) {
+	val scope = rememberCoroutineScope()
+	var bottomSheetHeight by remember { mutableFloatStateOf(0f) }
+	var isDragging by remember { mutableStateOf(false) }
+	val offsetY = remember { Animatable(if (isVisible) 0f else bottomSheetHeight) }
+
+	LaunchedEffect(isVisible) {
+		if (isVisible) {
+			offsetY.animateTo(
+				targetValue = 100f,
+				animationSpec = spring(
+					dampingRatio = Spring.DampingRatioMediumBouncy,
+					stiffness = Spring.StiffnessLow,
+				),
+			)
+		} else {
+			offsetY.animateTo(
+				targetValue = bottomSheetHeight,
+				animationSpec = spring(
+					dampingRatio = Spring.DampingRatioNoBouncy,
+					stiffness = Spring.StiffnessMedium,
+				),
+			)
+		}
+	}
+
+	val backgroundAlpha by animateFloatAsState(
+		targetValue = if (isVisible) 1f else 0f,
+		animationSpec = tween(300),
+		label = "backgroundAlpha",
+	)
+
+	if (isVisible || offsetY.value < bottomSheetHeight) {
+		Box(
+			modifier = modifier.fillMaxSize(),
+		) {
+			// 스크림(어두운 배경)
+			Box(
+				modifier = Modifier
+					.fillMaxSize()
+					.alpha(backgroundAlpha)
+					.background(scrimColor)
+					.pointerInput(Unit) {
+						detectTapGestures { onDismiss() }
+					},
+			)
+
+			// 바텀시트
+			Box(
+				modifier = Modifier
+					.align(Alignment.BottomCenter)
+					.offset {
+						IntOffset(0, offsetY.value.roundToInt())
+					}
+					.clip(RoundedCornerShape(topStart = cornerRadius, topEnd = cornerRadius))
+					.background(backgroundColor)
+					.onGloballyPositioned {
+						if (bottomSheetHeight == 0f) {
+							bottomSheetHeight = it.size.height.toFloat()
+						}
+					}
+					.pointerInput(Unit) {
+						val velocityTracker = VelocityTracker()
+
+						detectVerticalDragGestures(
+							onDragStart = { isDragging = true },
+							onDragEnd = {
+								isDragging = false
+								val velocity = velocityTracker.calculateVelocity()
+
+								scope.launch {
+									if (velocity.y > 1000f || offsetY.value > bottomSheetHeight * 0.8f) {
+										onDismiss()
+									} else {
+										offsetY.animateTo(
+											targetValue = 0f,
+											animationSpec = spring(
+												dampingRatio = Spring.DampingRatioMediumBouncy,
+												stiffness = Spring.StiffnessLow,
+											),
+										)
+									}
+								}
+							},
+							onDragCancel = { isDragging = false },
+							onVerticalDrag = { change, dragAmount ->
+								velocityTracker.addPosition(
+									change.uptimeMillis,
+									change.position,
+								)
+								scope.launch {
+									offsetY.snapTo((offsetY.value + dragAmount).coerceAtLeast(0f))
+								}
+							},
+						)
+					},
+			) {
+				Column(modifier = Modifier.fillMaxWidth()) {
+					if (dragHandle) {
+						Box(
+							modifier = Modifier
+								.padding(vertical = 12.dp)
+								.align(Alignment.CenterHorizontally)
+								.width(32.dp)
+								.height(4.dp)
+								.clip(RoundedCornerShape(2.dp))
+								.background(Color.LightGray),
+						)
+					}
+					Box(modifier = Modifier.fillMaxWidth()) {
+						sheetContent()
+					}
+				}
+			}
+		}
+	}
+}

--- a/core/model/src/main/kotlin/com/boostcamp/mapisode/model/GroupItem.kt
+++ b/core/model/src/main/kotlin/com/boostcamp/mapisode/model/GroupItem.kt
@@ -1,0 +1,9 @@
+package com.boostcamp.mapisode.model
+
+data class GroupItem(
+	val name: String,
+	val imageUrl: String,
+	val description: String,
+	val createdAt: String,
+	val adminUser: String,
+)

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -10,4 +10,5 @@ android {
 
 dependencies {
 	implementation(libs.bundles.naverMap)
+	implementation(libs.bundles.coil)
 }

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeIntent.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeIntent.kt
@@ -9,4 +9,5 @@ sealed class HomeIntent {
 	data class UpdateLocationPermission(val isGranted: Boolean) : HomeIntent() // 위치 권한 설정 여부 업데이트
 	data object MarkPermissionRequested : HomeIntent() // 위치 권한 요청 기록
 	data class SelectChip(val chipType: ChipType) : HomeIntent()
+	data object ShowBottomSheet : HomeIntent()
 }

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
@@ -245,7 +245,6 @@ private fun HomeScreen(
 			},
 		)
 	}
-
 }
 
 @Preview(showBackground = true, showSystemUi = true)

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
@@ -14,10 +14,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -36,8 +32,10 @@ import com.boostcamp.mapisode.designsystem.compose.MapisodeModalBottomSheet
 import com.boostcamp.mapisode.home.common.ChipType
 import com.boostcamp.mapisode.home.common.HomeConstant.DEFAULT_ZOOM
 import com.boostcamp.mapisode.home.common.getChipIconTint
+import com.boostcamp.mapisode.home.component.GroupBottomSheetContent
 import com.boostcamp.mapisode.home.component.MapisodeChip
 import com.boostcamp.mapisode.home.component.MapisodeFabOverlayButton
+import com.boostcamp.mapisode.model.GroupItem
 import com.google.android.gms.location.LocationServices
 import com.naver.maps.geometry.LatLng
 import com.naver.maps.map.CameraPosition
@@ -49,6 +47,7 @@ import com.naver.maps.map.compose.MapUiSettings
 import com.naver.maps.map.compose.NaverMap
 import com.naver.maps.map.compose.rememberCameraPositionState
 import com.naver.maps.map.compose.rememberFusedLocationSource
+import kotlinx.collections.immutable.persistentListOf
 import timber.log.Timber
 
 @Composable
@@ -215,27 +214,38 @@ private fun HomeScreen(
 		MapisodeModalBottomSheet(
 			isVisible = state.isBottomSheetVisible,
 			onDismiss = onGroupFabClick,
-			sheetContent = { BottomSheetContent() },
+			sheetContent = {
+				GroupBottomSheetContent(
+					myProfileImage = "https://github.com/user-attachments/assets/34d47b54-1ba6-48c7-adc6-a1d3f050e131",
+					groupList = persistentListOf(
+						GroupItem(
+							adminUser = "",
+							name = "그룹1",
+							description = "그룹1 설명",
+							imageUrl = "https://github.com/user-attachments/assets/ed530b8c-a030-42b4-b22d-5c6ef9424b0b",
+							createdAt = "2021-09-01",
+						),
+						GroupItem(
+							adminUser = "",
+							name = "그룹2",
+							description = "그룹2 설명",
+							imageUrl = "https://github.com/user-attachments/assets/ed530b8c-a030-42b4-b22d-5c6ef9424b0b",
+							createdAt = "2021-09-01",
+						),
+						GroupItem(
+							adminUser = "",
+							name = "그룹3",
+							description = "그룹3 설명",
+							imageUrl = "https://github.com/user-attachments/assets/ed530b8c-a030-42b4-b22d-5c6ef9424b0b",
+							createdAt = "2021-09-01",
+						),
+					),
+					onDismiss = onGroupFabClick,
+				)
+			},
 		)
 	}
 
-}
-
-@Composable
-private fun BottomSheetContent() {
-	Column(
-		modifier = Modifier
-			.fillMaxWidth()
-			.padding(16.dp)
-			.verticalScroll(rememberScrollState()),
-	) {
-		// 바텀 시트 내용
-		Text(
-			text = "Bottom Sheet Content",
-			style = MaterialTheme.typography.displayMedium,
-			modifier = Modifier.padding(bottom = 16.dp),
-		)
-	}
 }
 
 @Preview(showBackground = true, showSystemUi = true)

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
@@ -14,6 +14,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -28,6 +32,7 @@ import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.boostcamp.mapisode.designsystem.compose.MapisodeModalBottomSheet
 import com.boostcamp.mapisode.home.common.ChipType
 import com.boostcamp.mapisode.home.common.HomeConstant.DEFAULT_ZOOM
 import com.boostcamp.mapisode.home.common.getChipIconTint
@@ -133,6 +138,9 @@ internal fun HomeRoute(
 		onChipSelected = { chipType ->
 			viewModel.onIntent(HomeIntent.SelectChip(chipType))
 		},
+		onGroupFabClick = {
+			viewModel.onIntent(HomeIntent.ShowBottomSheet)
+		},
 	)
 }
 
@@ -142,6 +150,7 @@ private fun HomeScreen(
 	state: HomeState,
 	cameraPositionState: CameraPositionState,
 	onChipSelected: (ChipType) -> Unit = {},
+	onGroupFabClick: () -> Unit = {},
 ) {
 	val context = LocalContext.current
 
@@ -197,13 +206,35 @@ private fun HomeScreen(
 				contentAlignment = Alignment.CenterEnd,
 			) {
 				MapisodeFabOverlayButton(
-					onClick = {
-						// TODO : FAB 클릭 시 동작 구현
-					},
+					onClick = onGroupFabClick,
 					modifier = Modifier.padding(end = 20.dp),
 				)
 			}
 		}
+
+		MapisodeModalBottomSheet(
+			isVisible = state.isBottomSheetVisible,
+			onDismiss = onGroupFabClick,
+			sheetContent = { BottomSheetContent() },
+		)
+	}
+
+}
+
+@Composable
+private fun BottomSheetContent() {
+	Column(
+		modifier = Modifier
+			.fillMaxWidth()
+			.padding(16.dp)
+			.verticalScroll(rememberScrollState()),
+	) {
+		// 바텀 시트 내용
+		Text(
+			text = "Bottom Sheet Content",
+			style = MaterialTheme.typography.displayMedium,
+			modifier = Modifier.padding(bottom = 16.dp),
+		)
 	}
 }
 

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
@@ -31,11 +31,11 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.boostcamp.mapisode.designsystem.compose.MapisodeModalBottomSheet
 import com.boostcamp.mapisode.home.common.ChipType
 import com.boostcamp.mapisode.home.common.HomeConstant.DEFAULT_ZOOM
+import com.boostcamp.mapisode.home.common.HomeConstant.tempGroupList
 import com.boostcamp.mapisode.home.common.getChipIconTint
 import com.boostcamp.mapisode.home.component.GroupBottomSheetContent
 import com.boostcamp.mapisode.home.component.MapisodeChip
 import com.boostcamp.mapisode.home.component.MapisodeFabOverlayButton
-import com.boostcamp.mapisode.model.GroupItem
 import com.google.android.gms.location.LocationServices
 import com.naver.maps.geometry.LatLng
 import com.naver.maps.map.CameraPosition
@@ -47,7 +47,6 @@ import com.naver.maps.map.compose.MapUiSettings
 import com.naver.maps.map.compose.NaverMap
 import com.naver.maps.map.compose.rememberCameraPositionState
 import com.naver.maps.map.compose.rememberFusedLocationSource
-import kotlinx.collections.immutable.persistentListOf
 import timber.log.Timber
 
 @Composable
@@ -216,30 +215,8 @@ private fun HomeScreen(
 			onDismiss = onGroupFabClick,
 			sheetContent = {
 				GroupBottomSheetContent(
-					myProfileImage = "https://github.com/user-attachments/assets/34d47b54-1ba6-48c7-adc6-a1d3f050e131",
-					groupList = persistentListOf(
-						GroupItem(
-							adminUser = "",
-							name = "그룹1",
-							description = "그룹1 설명",
-							imageUrl = "https://github.com/user-attachments/assets/ed530b8c-a030-42b4-b22d-5c6ef9424b0b",
-							createdAt = "2021-09-01",
-						),
-						GroupItem(
-							adminUser = "",
-							name = "그룹2",
-							description = "그룹2 설명",
-							imageUrl = "https://github.com/user-attachments/assets/ed530b8c-a030-42b4-b22d-5c6ef9424b0b",
-							createdAt = "2021-09-01",
-						),
-						GroupItem(
-							adminUser = "",
-							name = "그룹3",
-							description = "그룹3 설명",
-							imageUrl = "https://github.com/user-attachments/assets/ed530b8c-a030-42b4-b22d-5c6ef9424b0b",
-							createdAt = "2021-09-01",
-						),
-					),
+					myProfileImage = "https://avatars.githubusercontent.com/u/98825364?v=4?s=100",
+					groupList = tempGroupList,
 					onDismiss = onGroupFabClick,
 				)
 			},

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeState.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeState.kt
@@ -19,4 +19,5 @@ data class HomeState(
 	val isLocationPermissionGranted: Boolean = false, // 위치 권한이 허용되었는지 여부
 	val hasRequestedPermission: Boolean = false, // 위치 권한을 요청한 적이 있는지 여부
 	val selectedChip: ChipType? = null,
+	val isBottomSheetVisible: Boolean = false,
 ) : UiState

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeViewModel.kt
@@ -38,6 +38,10 @@ class HomeViewModel : BaseViewModel<HomeState, HomeSideEffect>(HomeState()) {
 			is HomeIntent.SelectChip -> {
 				setSelectedChip(intent.chipType)
 			}
+
+			is HomeIntent.ShowBottomSheet -> {
+				toggleBottomSheet()
+			}
 		}
 	}
 
@@ -66,6 +70,12 @@ class HomeViewModel : BaseViewModel<HomeState, HomeSideEffect>(HomeState()) {
 	private fun updateLocationPermission(isGranted: Boolean) {
 		intent {
 			copy(isLocationPermissionGranted = isGranted)
+		}
+	}
+
+	private fun toggleBottomSheet() {
+		intent {
+			copy(isBottomSheetVisible = !isBottomSheetVisible)
 		}
 	}
 }

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/common/HomeConstant.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/common/HomeConstant.kt
@@ -1,5 +1,31 @@
 package com.boostcamp.mapisode.home.common
 
+import com.boostcamp.mapisode.model.GroupItem
+import kotlinx.collections.immutable.persistentListOf
+
 object HomeConstant {
 	const val DEFAULT_ZOOM = 16.0
+	val tempGroupList = persistentListOf(
+		GroupItem(
+			adminUser = "",
+			name = "그룹1",
+			description = "그룹1 설명",
+			imageUrl = "https://avatars.githubusercontent.com/u/98825364?v=4?s=100",
+			createdAt = "2021-09-01",
+		),
+		GroupItem(
+			adminUser = "",
+			name = "그룹2",
+			description = "그룹2 설명",
+			imageUrl = "https://avatars.githubusercontent.com/u/98825364?v=4?s=100",
+			createdAt = "2021-09-01",
+		),
+		GroupItem(
+			adminUser = "",
+			name = "그룹3",
+			description = "그룹3 설명",
+			imageUrl = "https://avatars.githubusercontent.com/u/98825364?v=4?s=100",
+			createdAt = "2021-09-01",
+		),
+	)
 }

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/component/GroupBottomSheetContent.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/component/GroupBottomSheetContent.kt
@@ -1,0 +1,114 @@
+package com.boostcamp.mapisode.home.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.boostcamp.mapisode.designsystem.R
+import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
+import com.boostcamp.mapisode.designsystem.compose.MapisodeIconButton
+import com.boostcamp.mapisode.designsystem.compose.MapisodeText
+import com.boostcamp.mapisode.designsystem.theme.AppTypography
+import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
+import com.boostcamp.mapisode.model.GroupItem
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.persistentListOf
+
+@Composable
+fun GroupBottomSheetContent(
+	myProfileImage: String,
+	groupList: PersistentList<GroupItem>,
+	modifier: Modifier = Modifier,
+	onDismiss: () -> Unit = {},
+) {
+	Column(
+		modifier = modifier.fillMaxWidth(),
+	) {
+		Box(
+			modifier = Modifier.fillMaxWidth(),
+			contentAlignment = Alignment.Center,
+		) {
+			MapisodeText(
+				text = stringResource(com.boostcamp.mapisode.home.R.string.group_bottomsheet_title),
+				color = MapisodeTheme.colorScheme.textContent,
+				style = AppTypography.titleLarge.copy(fontWeight = FontWeight.Normal),
+			)
+
+			MapisodeIconButton(
+				onClick = onDismiss,
+				modifier = Modifier
+					.align(Alignment.CenterEnd)
+					.padding(end = 24.dp),
+			) {
+				MapisodeIcon(id = R.drawable.ic_clear)
+			}
+		}
+
+		LazyVerticalGrid(
+			columns = GridCells.Fixed(2),
+			modifier = Modifier.fillMaxWidth(),
+			contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+			verticalArrangement = Arrangement.spacedBy(20.dp),
+			horizontalArrangement = Arrangement.Center,
+		) {
+			item {
+				GroupCard(
+					groupImage = myProfileImage,
+					groupName = stringResource(com.boostcamp.mapisode.home.R.string.group_my_episode_name),
+				)
+			}
+
+			items(groupList) { group ->
+				GroupCard(
+					groupImage = group.imageUrl,
+					groupName = group.name,
+				)
+			}
+		}
+	}
+}
+
+@Preview(showBackground = true)
+@Composable
+fun GroupBottomSheetContentPreview() {
+	MapisodeTheme {
+		GroupBottomSheetContent(
+			myProfileImage = "",
+			groupList = persistentListOf(
+				GroupItem(
+					adminUser = "",
+					name = "그룹1",
+					description = "그룹1 설명",
+					imageUrl = "https://github.com/user-attachments/assets/ed530b8c-a030-42b4-b22d-5c6ef9424b0b",
+					createdAt = "2021-09-01",
+				),
+				GroupItem(
+					adminUser = "",
+					name = "그룹2",
+					description = "그룹2 설명",
+					imageUrl = "https://github.com/user-attachments/assets/ed530b8c-a030-42b4-b22d-5c6ef9424b0b",
+					createdAt = "2021-09-01",
+				),
+				GroupItem(
+					adminUser = "",
+					name = "그룹3",
+					description = "그룹3 설명",
+					imageUrl = "https://github.com/user-attachments/assets/ed530b8c-a030-42b4-b22d-5c6ef9424b0b",
+					createdAt = "2021-09-01",
+				),
+			),
+		)
+	}
+}

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/component/GroupBottomSheetContent.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/component/GroupBottomSheetContent.kt
@@ -22,9 +22,9 @@ import com.boostcamp.mapisode.designsystem.compose.MapisodeIconButton
 import com.boostcamp.mapisode.designsystem.compose.MapisodeText
 import com.boostcamp.mapisode.designsystem.theme.AppTypography
 import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
+import com.boostcamp.mapisode.home.common.HomeConstant.tempGroupList
 import com.boostcamp.mapisode.model.GroupItem
 import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 fun GroupBottomSheetContent(
@@ -86,29 +86,7 @@ fun GroupBottomSheetContentPreview() {
 	MapisodeTheme {
 		GroupBottomSheetContent(
 			myProfileImage = "",
-			groupList = persistentListOf(
-				GroupItem(
-					adminUser = "",
-					name = "그룹1",
-					description = "그룹1 설명",
-					imageUrl = "https://github.com/user-attachments/assets/ed530b8c-a030-42b4-b22d-5c6ef9424b0b",
-					createdAt = "2021-09-01",
-				),
-				GroupItem(
-					adminUser = "",
-					name = "그룹2",
-					description = "그룹2 설명",
-					imageUrl = "https://github.com/user-attachments/assets/ed530b8c-a030-42b4-b22d-5c6ef9424b0b",
-					createdAt = "2021-09-01",
-				),
-				GroupItem(
-					adminUser = "",
-					name = "그룹3",
-					description = "그룹3 설명",
-					imageUrl = "https://github.com/user-attachments/assets/ed530b8c-a030-42b4-b22d-5c6ef9424b0b",
-					createdAt = "2021-09-01",
-				),
-			),
+			groupList = tempGroupList,
 		)
 	}
 }

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/component/GroupCard.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/component/GroupCard.kt
@@ -1,0 +1,68 @@
+package com.boostcamp.mapisode.home.component
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import com.boostcamp.mapisode.designsystem.compose.MapisodeText
+import com.boostcamp.mapisode.designsystem.theme.AppTypography
+
+@Composable
+fun GroupCard(
+	groupImage: String,
+	groupName: String,
+	modifier: Modifier = Modifier,
+	onClick: () -> Unit = {},
+) {
+	Column(
+		modifier = modifier
+			.fillMaxWidth()
+			.clickable(onClick = onClick),
+		horizontalAlignment = Alignment.CenterHorizontally,
+	) {
+		Box(
+			modifier = Modifier
+				.size(120.dp)
+				.clip(RoundedCornerShape(16.dp)),
+			contentAlignment = Alignment.Center,
+		) {
+			// TODO: PlaceHolder 및 에러 이미지 추가 필요
+			AsyncImage(
+				model = groupImage,
+				contentDescription = groupName,
+				contentScale = ContentScale.Crop,
+				modifier = Modifier.fillMaxSize(),
+			)
+		}
+
+		Spacer(modifier = Modifier.size(4.dp))
+
+		MapisodeText(
+			text = groupName,
+			style = AppTypography.bodyMedium,
+		)
+
+		// TODO : 업데이트 일자 텍스트 추가 예정
+	}
+}
+
+@Preview(showBackground = true)
+@Composable
+fun GroupCardPreview() {
+	GroupCard(
+		groupImage = "https://github.com/user-attachments/assets/34d47b54-1ba6-48c7-adc6-a1d3f050e131",
+		groupName = "그룹 이름",
+	)
+}

--- a/feature/home/src/main/res/values/strings.xml
+++ b/feature/home/src/main/res/values/strings.xml
@@ -6,4 +6,6 @@
 	<string name="home_chip_see">볼거리</string>
 	<string name="home_chip_other">나머지</string>
 	<string name="home_exit_alert">한 번 더 누르시면 앱이 종료됩니다.</string>
+	<string name="group_my_episode_name">👑 나의 에피소드</string>
+	<string name="group_bottomsheet_title">그룹 선택</string>
 </resources>


### PR DESCRIPTION
- closed #66 

## *📍 Work Description*
- 커스텀 바텀 시트 구현
- 바텀 시트 콘텐츠 UI 구현
- ComposePlugin(빌드로직)에 kotlinx-immutable 추가
- Group 모델 추가 (core:model)

## *📸 Screenshot*

<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->

https://github.com/user-attachments/assets/5e98a6a9-1e7d-4e8a-864e-8b933535b105


## *📢 To Reviewers*
- MapisodeText에 textAlign 속성을 제어할 수 없어서, 현재 LazyVerticalGrid 셀의 텍스트가 가운데에 위치하고 있습니다. 이거 추가 부탁드립니다 @TaewoongR 
- 피그마에 보면 해당 그룹에서 마지막으로 업데이트 된 것이 언제인지 (x일전 업데이트) 이런 텍스트가 있습니다. FireStore에 이 정보가 추가되어야 할 것 같습니다 @Ameri-Kano 
- core:model의 GroupItem은 현재 홈에서만 쓰일 예정입니다. 다른 곳에서 같이 공유하기를 희망한다면 조율요청을 해주세요. 
- 바텀시트 애니메이션에 spring 효과가 저희 앱과 맞지 않다면 삭제가 가능합니다. 이 부분 얘기해보아요. 

## ⏲️Time

    - 4
