### PR TITLE
[FEAT/#65] Custom Dialog 선언

### DIFF
--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeDialog.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeDialog.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -21,7 +22,6 @@ import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 
 @Composable
 fun MapisodeDialog(
-	modifier: Modifier = Modifier,
 	onResultRequest: (Boolean) -> Unit,
 	onDismissRequest: () -> Unit,
 	titleText: String,
@@ -41,17 +41,16 @@ fun MapisodeDialog(
 	) {
 		Surface(
 			color = MapisodeTheme.colorScheme.dialogBackground,
+			rounding = 8.dp,
 		) {
-			Column(
-				modifier = Modifier
-					.fillMaxWidth()
-					.padding(16.dp),
-			) {
-				MapisodeText(titleText, style = MapisodeTheme.typography.titleLarge)
-
-				MapisodeText(contentText)
+			Column(modifier = Modifier.padding(24.dp)) {
+				MapisodeText(titleText, style = MapisodeTheme.typography.headlineSmall)
 
 				Spacer(modifier = Modifier.height(16.dp))
+
+				MapisodeText(contentText, style = MapisodeTheme.typography.titleMedium)
+
+				Spacer(modifier = Modifier.height(20.dp))
 
 				Row(
 					modifier = Modifier.fillMaxWidth(),
@@ -67,8 +66,11 @@ fun MapisodeDialog(
 							},
 							indication = MapisodeRippleBIndication,
 							interactionSource = remember { MutableInteractionSource() },
-						)
+						),
+						color = MapisodeTheme.colorScheme.dialogDismiss,
+						style = MapisodeTheme.typography.labelLarge,
 					)
+					Spacer(modifier = Modifier.width(24.dp))
 					MapisodeText(
 						text = confirmText,
 						modifier = Modifier.clickable(
@@ -79,7 +81,9 @@ fun MapisodeDialog(
 							},
 							indication = MapisodeRippleBIndication,
 							interactionSource = remember { MutableInteractionSource() },
-						)
+						),
+						color = MapisodeTheme.colorScheme.dialogConfirm,
+						style = MapisodeTheme.typography.labelLarge,
 					)
 				}
 			}

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeDialog.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeDialog.kt
@@ -1,0 +1,89 @@
+package com.boostcamp.mapisode.designsystem.compose
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.compose.ui.window.SecureFlagPolicy
+import com.boostcamp.mapisode.designsystem.compose.ripple.MapisodeRippleBIndication
+import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
+
+@Composable
+fun MapisodeDialog(
+	modifier: Modifier = Modifier,
+	onResultRequest: (Boolean) -> Unit,
+	onDismissRequest: () -> Unit,
+	titleText: String,
+	contentText: String,
+	cancelText: String,
+	confirmText: String,
+) {
+	Dialog(
+		onDismissRequest = {
+			onDismissRequest()
+		},
+		properties = DialogProperties(
+			dismissOnBackPress = true,
+			dismissOnClickOutside = false,
+			securePolicy = SecureFlagPolicy.Inherit,
+		),
+	) {
+		Surface(
+			color = MapisodeTheme.colorScheme.dialogBackground,
+		) {
+			Column(
+				modifier = Modifier
+					.fillMaxWidth()
+					.padding(16.dp),
+			) {
+				MapisodeText(titleText, style = MapisodeTheme.typography.titleLarge)
+
+				MapisodeText(contentText)
+
+				Spacer(modifier = Modifier.height(16.dp))
+
+				Row(
+					modifier = Modifier.fillMaxWidth(),
+					horizontalArrangement = Arrangement.End,
+				) {
+					MapisodeText(
+						text = cancelText,
+						modifier = Modifier.clickable(
+							enabled = true,
+							onClick = {
+								onResultRequest(false)
+								onDismissRequest()
+							},
+							indication = MapisodeRippleBIndication,
+							interactionSource = remember { MutableInteractionSource() },
+						)
+					)
+					MapisodeText(
+						text = confirmText,
+						modifier = Modifier.clickable(
+							enabled = true,
+							onClick = {
+								onResultRequest(false)
+								onDismissRequest()
+							},
+							indication = MapisodeRippleBIndication,
+							interactionSource = remember { MutableInteractionSource() },
+						)
+					)
+				}
+			}
+		}
+	}
+
+}

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeDialog.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeDialog.kt
@@ -76,7 +76,7 @@ fun MapisodeDialog(
 						modifier = Modifier.clickable(
 							enabled = true,
 							onClick = {
-								onResultRequest(false)
+								onResultRequest(true)
 								onDismissRequest()
 							},
 							indication = MapisodeRippleBIndication,

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupCreationScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupCreationScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.boostcamp.mapisode.designsystem.R
+import com.boostcamp.mapisode.designsystem.compose.MapisodeDialog
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIconButton
 import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
@@ -42,7 +43,9 @@ fun GroupCreationScreen(onBack: () -> Unit) {
 		},
 	) {
 		Column(
-			modifier = Modifier.fillMaxSize().padding(it),
+			modifier = Modifier
+				.fillMaxSize()
+				.padding(it),
 			verticalArrangement = Arrangement.spacedBy(16.dp),
 			horizontalAlignment = Alignment.CenterHorizontally,
 		) {
@@ -51,6 +54,31 @@ fun GroupCreationScreen(onBack: () -> Unit) {
 				text = "네비게이션 아이콘 활성/비활성화",
 				showRipple = true,
 			)
+			DialogExample()
 		}
+	}
+}
+
+@Composable
+fun DialogExample() {
+	var showDialog by remember { mutableStateOf(false) }
+
+	MapisodeFilledButton(onClick = { showDialog = true }, text = "다이얼로그 열기")
+
+	if (showDialog) {
+		MapisodeDialog(
+			onDismissRequest = { showDialog = false },
+			onResultRequest = { result ->
+				if (result) {
+					// TODO: 삭제 버튼 클릭 시 처리
+				} else {
+					// TODO: 취소 버튼 클릭 시 처리
+				}
+			},
+			titleText = "정말 삭제하시겠습니까?",
+			contentText = "영구적으로 삭제됩니다.",
+			cancelText = "취소",
+			confirmText = "확인",
+		)
 	}
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupEditScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupEditScreen.kt
@@ -25,7 +25,7 @@ import com.boostcamp.mapisode.designsystem.compose.button.MapisodeImageButton
 import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
 
 @Composable
-fun GroupEditScreen() {
+fun GroupEditScreen(onBack: () -> Unit) {
 	val focusManager = LocalFocusManager.current
 
 	MapisodeScaffold(
@@ -44,8 +44,7 @@ fun GroupEditScreen() {
 				title = "나의 그룹",
 				navigationIcon = {
 					MapisodeIconButton(
-						onClick = {
-						},
+						onClick = { onBack() },
 					) {
 						MapisodeIcon(
 							id = R.drawable.ic_arrow_back_ios,

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -31,17 +32,18 @@ import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 
 @Composable
 internal fun GroupRoute() {
-	var isGroupCreationScreenVisible by remember { mutableStateOf(false) }
+	var isGroupCreationScreenVisible by remember { mutableIntStateOf(0) }
 
-	if (isGroupCreationScreenVisible) {
-		GroupDetailScreen(onBack = { isGroupCreationScreenVisible = false })
-	} else {
-		GroupScreen(onAddGroupClick = { isGroupCreationScreenVisible = true })
+	when (isGroupCreationScreenVisible) {
+		0 -> GroupScreen(onMove = { isGroupCreationScreenVisible = it })
+		1 -> GroupDetailScreen(onBack = { isGroupCreationScreenVisible = 0 })
+		2 -> GroupEditScreen(onBack = { isGroupCreationScreenVisible = 0 })
+		3 -> GroupCreationScreen(onBack = { isGroupCreationScreenVisible = 0 })
 	}
 }
 
 @Composable
-private fun GroupScreen(onAddGroupClick: () -> Unit) {
+private fun GroupScreen(onMove: (Int) -> Unit) {
 	val focusManager = LocalFocusManager.current
 	var isMenuPoppedUp by remember { mutableStateOf(false) }
 
@@ -74,21 +76,21 @@ private fun GroupScreen(onAddGroupClick: () -> Unit) {
 							offset = DpOffset(0.dp, 0.dp).minus(DpOffset(41.dp, 0.dp)),
 						) {
 							MapisodeDropdownMenuItem(
-								onClick = onAddGroupClick,
+								onClick = { onMove(1) },
 							) {
 								MapisodeText(
-									text = "그룹 생성",
+									text = "그룹 상세",
 								)
 							}
 							MapisodeDropdownMenuItem(
-								onClick = { },
+								onClick = { onMove(2) },
 							) {
 								MapisodeText(
-									text = "그룹 생성",
+									text = "나의 그룹",
 								)
 							}
 							MapisodeDropdownMenuItem(
-								onClick = { },
+								onClick = { onMove(3) },
 							) {
 								MapisodeText(
 									text = "그룹 생성",


### PR DESCRIPTION
- closed #65 

## *📍 Work Description*

- Dialog() 함수를 이용하여 커스텀 다이얼로그 생성
- 기획 디자인에 따라 수정

## *📸 Screenshot*

https://github.com/user-attachments/assets/04dea9a7-6ecf-4b0d-ab2f-bab4bc5af6fb

## *📢 To Reviewers*
- Dialog 함수 인자입니다.
<img src="https://github.com/user-attachments/assets/64e1f610-f5e6-4de6-9fd2-abb3ab81ca4d" width=300>

- 사용 예시입니다.
<img src="https://github.com/user-attachments/assets/acbae2ee-e3eb-4ae9-869d-da6ca20ffdc3" width=500>

- 기존 compose에 존재하는 Dialog 함수를 사용하여 생각보다 빨리 구성했습니다.

## ⏲️Time

    - 3시간
