### PR TITLE
[FIX/#72] Custom Text 컴포넌트 TextAlign 인자 추가

### DIFF
--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeText.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeText.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import com.boostcamp.mapisode.designsystem.theme.AppTypography
@@ -20,6 +21,7 @@ import com.boostcamp.mapisode.designsystem.theme.MapisodeTextStyle
 fun MapisodeText(
 	text: String,
 	modifier: Modifier = Modifier,
+	textAlignment: TextAlignment = TextAlignment.Start,
 	color: Color = Color.Unspecified,
 	onTextLayout: (TextLayoutResult) -> Unit = {},
 	style: MapisodeTextStyle = LocalTextStyle.current,
@@ -37,7 +39,14 @@ fun MapisodeText(
 		color
 	}
 
-	val mergedStyle = style.copy(color = textColor).toTextStyle()
+	val mergedStyle = style.copy(
+		color = textColor,
+		textAlign = when(textAlignment) {
+			TextAlignment.Start -> TextAlign.Start
+			TextAlignment.Center -> TextAlign.Center
+			TextAlignment.End -> TextAlign.End
+		}
+	).toTextStyle()
 
 	BasicText(
 		text = text,
@@ -56,6 +65,10 @@ val LocalTextStyle = compositionLocalOf { MapisodeTextStyle.Default }
 fun ProvideTextStyle(value: MapisodeTextStyle, content: @Composable () -> Unit) {
 	val mergedStyle = LocalTextStyle.current.merge(value)
 	CompositionLocalProvider(LocalTextStyle provides mergedStyle, content = content)
+}
+
+enum class TextAlignment {
+	Start, Center, End
 }
 
 @Preview(showBackground = true)

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeText.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeText.kt
@@ -29,7 +29,7 @@ fun MapisodeText(
 	maxLines: Int = Int.MAX_VALUE,
 	minLines: Int = 1,
 ) {
-	val textColor = if (color == Color.Unspecified) {
+	val textColor = if (color==Color.Unspecified) {
 		if (isSystemInDarkTheme()) {
 			LocalMapisodeDarkContentColor.current
 		} else {
@@ -41,11 +41,11 @@ fun MapisodeText(
 
 	val mergedStyle = style.copy(
 		color = textColor,
-		textAlign = when(textAlignment) {
+		textAlign = when (textAlignment) {
 			TextAlignment.Start -> TextAlign.Start
 			TextAlignment.Center -> TextAlign.Center
 			TextAlignment.End -> TextAlign.End
-		}
+		},
 	).toTextStyle()
 
 	BasicText(
@@ -68,7 +68,9 @@ fun ProvideTextStyle(value: MapisodeTextStyle, content: @Composable () -> Unit) 
 }
 
 enum class TextAlignment {
-	Start, Center, End
+	Start,
+	Center,
+	End,
 }
 
 @Preview(showBackground = true)

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeText.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeText.kt
@@ -29,7 +29,7 @@ fun MapisodeText(
 	maxLines: Int = Int.MAX_VALUE,
 	minLines: Int = 1,
 ) {
-	val textColor = if (color==Color.Unspecified) {
+	val textColor = if (color == Color.Unspecified) {
 		if (isSystemInDarkTheme()) {
 			LocalMapisodeDarkContentColor.current
 		} else {

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/component/GroupCard.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/component/GroupCard.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -51,6 +52,7 @@ fun GroupCard(
 
 		MapisodeText(
 			text = groupName,
+			modifier = Modifier.width(120.dp),
 			style = AppTypography.bodyMedium,
 		)
 


### PR DESCRIPTION
- closed #72 

## *📍 Work Description*

- text align 인자 추가

## *📸 Screenshot*

<img src="https://github.com/user-attachments/assets/1f0ae5cc-9791-4d3b-a03f-b0d0cfe46c70" width=500>

<img src="https://github.com/user-attachments/assets/408fec51-7bbe-4990-a215-bcf9283d020c" width=500>

## *📢 To Reviewers*
- 너비의 기본값은 텍스트 너비와 같습니다.
- 너비를 넓히면 textAlign 이 기본값으로 설정한 Start임을 확인할 수 있습니다.

## ⏲️Time

    - 1시간
