### PR TITLE
[FIX/#74] Scaffold 바텀 네비게이션 바 숨김 기능

### DIFF
--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeScaffold.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeScaffold.kt
@@ -5,6 +5,10 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.SubcomposeLayout
@@ -20,6 +24,23 @@ import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 
 private enum class ScaffoldLayoutContent { TopBar, MainContent, Snackbar, BottomBar }
 
+val LocalMapisodeShowBotBar = compositionLocalOf<BottomBarController> {
+	error("No BottomBarController provided")
+}
+
+object BottomBarController {
+	private var _isVisible by mutableStateOf(true)
+	val isVisible: Boolean get() = _isVisible
+
+	fun off() {
+		_isVisible = false
+	}
+
+	fun on() {
+		_isVisible = true
+	}
+}
+
 @Composable
 fun MapisodeScaffold(
 	modifier: Modifier = Modifier,
@@ -33,6 +54,8 @@ fun MapisodeScaffold(
 	contentColor: Color = MapisodeTheme.colorScheme.textContent,
 	content: @Composable (PaddingValues) -> Unit,
 ) {
+	val showBottomNavBar = LocalMapisodeShowBotBar.current
+
 	Surface(
 		modifier = modifier,
 		color = backgroundColor,
@@ -40,9 +63,17 @@ fun MapisodeScaffold(
 	) {
 		ScaffoldLayout(
 			isStatusBarPaddingExist = isStatusBarPaddingExist,
-			isNavigationBarPaddingExist = isNavigationBarPaddingExist,
+			isNavigationBarPaddingExist = if (showBottomNavBar.isVisible) {
+				isNavigationBarPaddingExist
+			} else {
+				true
+			},
 			topBar = topBar,
-			bottomBar = bottomBar,
+			bottomBar = if (showBottomNavBar.isVisible) {
+				bottomBar
+			} else {
+				{}
+			},
 			toast = { toastHost(toastHostState) },
 			content = content,
 		)

--- a/feature/main/src/main/java/com/boostcamp/mapisode/main/MainActivity.kt
+++ b/feature/main/src/main/java/com/boostcamp/mapisode/main/MainActivity.kt
@@ -4,6 +4,9 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.runtime.CompositionLocalProvider
+import com.boostcamp.mapisode.designsystem.compose.BottomBarController
+import com.boostcamp.mapisode.designsystem.compose.LocalMapisodeShowBotBar
 import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -17,8 +20,10 @@ class MainActivity : ComponentActivity() {
 		setContent {
 			val navigator: MainNavigator = rememberMainNavigator()
 
-			MapisodeTheme {
-				MainScreen(navigator = navigator)
+			CompositionLocalProvider(LocalMapisodeShowBotBar provides BottomBarController) {
+				MapisodeTheme {
+					MainScreen(navigator = navigator)
+				}
 			}
 		}
 	}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupEditScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupEditScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
 import coil3.compose.AsyncImage
 import com.boostcamp.mapisode.designsystem.R
+import com.boostcamp.mapisode.designsystem.compose.LocalMapisodeShowBotBar
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIconButton
 import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
@@ -27,6 +28,8 @@ import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
 @Composable
 fun GroupEditScreen(onBack: () -> Unit) {
 	val focusManager = LocalFocusManager.current
+	val bottomBarController = LocalMapisodeShowBotBar.current
+	bottomBarController.off()
 
 	MapisodeScaffold(
 		modifier = Modifier
@@ -44,7 +47,10 @@ fun GroupEditScreen(onBack: () -> Unit) {
 				title = "나의 그룹",
 				navigationIcon = {
 					MapisodeIconButton(
-						onClick = { onBack() },
+						onClick = {
+							bottomBarController.on()
+							onBack()
+						},
 					) {
 						MapisodeIcon(
 							id = R.drawable.ic_arrow_back_ios,


### PR DESCRIPTION
- closed #74 

## *📍 Work Description*

- 버튼 컨트롤러 object 선언 : on/off 메서드
- 버튼 컨트롤러 CompositionalLocal 변수 선언
- Scaffold 내부에 버튼 컨트롤러 제너릭의 CompositionalLocal을 사용하여 리컴포지션 설정
- MainActivity에서 버튼 컨트롤러 CompositionalLocal를 CompositionLocalProvider 를 사용하여 하위 컴포저블에 전파
- 특정 컴포저블에서 버튼 컨트롤러를 사용하여 바텀 네비게이션 바를 숨기고 다시 나타내는 기능 적용

## *📸 Screenshot*

https://github.com/user-attachments/assets/f06eeb6f-9fe7-4768-a7df-efe497386576

https://github.com/user-attachments/assets/2c3ad0c6-1ecb-49b8-a7d1-9b8b99b4ffa5

- 사용방법 입니다.

<img src="https://github.com/user-attachments/assets/10942970-8b46-4878-9a46-40083b912977" width=600>
<img src="https://github.com/user-attachments/assets/7e8aa201-245a-4834-8d8f-77b49ede3e8d" width=300>



## *📢 To Reviewers*
- 첫번째 영상은 버튼 컨트롤러에서 Boolean 값을 반대로 전환하는 메서드를 하나만 설정하여서 발생한 문제입니다. 
  - showBotAppBar 가 false로 바뀔 때 리컴포지션이 일어나는데, 그 과정에서 다시 버튼 컨트롤러 메서드가 호출되어 반복적으로 리컴포지션이 일어나게 되었습니다.
  
- 연쇄 리컴포지션을 방지하기 위해 메서드를 두가지로 선언하여  showBotAppBar의 값을 고정값으로 재할당하여 리컴포지션 이후 다시한번 메서드가 호출된다 해도 리컴포지션이 발생하지 않도록 했습니다.
## ⏲️Time

    - 2시간
