### PR TITLE
[FEAT/#71] 에피소드 생성 화면 최소 기능 구현

### DIFF
--- a/feature/episode/build.gradle.kts
+++ b/feature/episode/build.gradle.kts
@@ -8,6 +8,5 @@ android {
 
 dependencies {
 	implementation(project.libs.bundles.naverMap)
-	implementation(projects.core.ui)
-	implementation(projects.core.designsystem)
+	implementation(projects.domain.episode)
 }

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/EpisodeScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/EpisodeScreen.kt
@@ -65,7 +65,12 @@ internal fun EpisodeRoute(
 
 		composable("new_episode_content") {
 			NewEpisodeContentScreen(
+				state = uiState,
 				navController = newEpisodeNavController,
+				submitEpisode = { episodeContent ->
+					viewModel.onIntent(NewEpisodeIntent.SetEpisodeContent(episodeContent))
+					viewModel.onIntent(NewEpisodeIntent.CreateNewEpisode)
+				},
 			)
 		}
 	}

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/EpisodeScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/EpisodeScreen.kt
@@ -1,17 +1,28 @@
 package com.boostcamp.mapisode.episode
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.boostcamp.mapisode.episode.intent.NewEpisodeIntent
+import com.boostcamp.mapisode.episode.intent.NewEpisodeViewModel
+import com.naver.maps.map.compose.CameraPositionState
 import com.naver.maps.map.compose.ExperimentalNaverMapApi
-import com.naver.maps.map.compose.rememberMarkerState
+import com.naver.maps.map.compose.rememberCameraPositionState
 
 @OptIn(ExperimentalNaverMapApi::class)
 @Composable
-internal fun EpisodeRoute() {
+internal fun EpisodeRoute(
+	viewModel: NewEpisodeViewModel = hiltViewModel(),
+) {
+	val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 	val newEpisodeNavController = rememberNavController()
-	val markerState = rememberMarkerState()
+	val cameraPositionState: CameraPositionState = rememberCameraPositionState {
+		position = uiState.cameraPosition
+	}
 
 	NavHost(newEpisodeNavController, startDestination = "new_episode_pics") {
 		composable("new_episode_pics") {
@@ -23,13 +34,32 @@ internal fun EpisodeRoute() {
 		composable("new_episode_info") {
 			NewEpisodeInfoScreen(
 				navController = newEpisodeNavController,
+				state = uiState,
+				updateEpisodeInfo = { episodeInfo ->
+					viewModel.onIntent(NewEpisodeIntent.SetEpisodeInfo(episodeInfo))
+				},
+				updateGroup = { group ->
+					viewModel.onIntent(NewEpisodeIntent.SetEpisodeGroup(group))
+				},
+				updateCategory = { category ->
+					viewModel.onIntent(NewEpisodeIntent.SetEpisodeCategory(category))
+				},
+				updateTags = { tags ->
+					viewModel.onIntent(NewEpisodeIntent.SetEpisodeTags(tags))
+				},
+				updateDate = { date ->
+					viewModel.onIntent(NewEpisodeIntent.SetEpisodeDate(date))
+				},
 			)
 		}
 
 		composable("pick_location") {
 			PickLocationScreen(
-				markerState = markerState,
+				cameraPositionState = cameraPositionState,
 				navController = newEpisodeNavController,
+				updateLocation = { latLng ->
+					viewModel.onIntent(NewEpisodeIntent.SetEpisodeLocation(latLng))
+				},
 			)
 		}
 

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/EpisodeTextFieldGroup.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/EpisodeTextFieldGroup.kt
@@ -20,8 +20,11 @@ fun EpisodeTextFieldGroup(
 	@StringRes placeholderRes: Int,
 	value: String = "",
 	onValueChange: (String) -> Unit = { },
+	readOnly: Boolean = false,
 	trailingIcon: @Composable (() -> Unit)? = null,
 	onTrailingIconClick: (() -> Unit)? = null,
+	isError: Boolean = false,
+	onSubmitInput: (String) -> Unit = {},
 ) {
 	Column(textFieldModifier, verticalArrangement = textFieldVerticalArrangement) {
 		MapisodeText(
@@ -33,6 +36,7 @@ fun EpisodeTextFieldGroup(
 			value = value,
 			placeholder = stringResource(placeholderRes),
 			onValueChange = onValueChange,
+			readOnly = readOnly,
 			trailingIcon = {
 				trailingIcon?.let {
 					MapisodeIconButton(
@@ -40,6 +44,8 @@ fun EpisodeTextFieldGroup(
 					) { it() }
 				}
 			},
+			isError = isError,
+			onSubmitInput = onSubmitInput,
 		)
 	}
 }

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeContentScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeContentScreen.kt
@@ -9,7 +9,12 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
@@ -25,9 +30,18 @@ import com.boostcamp.mapisode.designsystem.compose.button.MapisodeFilledButton
 import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 import com.boostcamp.mapisode.episode.common.NewEpisodeConstant.textFieldModifier
 import com.boostcamp.mapisode.episode.common.NewEpisodeConstant.textFieldVerticalArrangement
+import com.boostcamp.mapisode.episode.intent.NewEpisodeContent
+import com.boostcamp.mapisode.episode.intent.NewEpisodeState
 
 @Composable
-internal fun NewEpisodeContentScreen(navController: NavController) {
+internal fun NewEpisodeContentScreen(
+	state: NewEpisodeState,
+	navController: NavController,
+	submitEpisode: (NewEpisodeContent) -> Unit = {},
+) {
+	var titleValue by remember { mutableStateOf(state.episodeContent.title) }
+	var descriptionValue by remember { mutableStateOf(state.episodeContent.description) }
+
 	MapisodeScaffold(
 		topBar = {
 			NewEpisodeTopbar(navController)
@@ -45,11 +59,15 @@ internal fun NewEpisodeContentScreen(navController: NavController) {
 				EpisodeTextFieldGroup(
 					labelRes = R.string.new_episode_content_title,
 					placeholderRes = R.string.new_episode_content_placeholder_title,
+					value = titleValue,
+					onValueChange = { titleValue = it },
 				)
 				EpisodeTextFieldGroup(
 					modifier = Modifier.fillMaxHeight(0.3f),
 					labelRes = R.string.new_episode_content_description,
 					placeholderRes = R.string.new_episode_content_placeholder_description,
+					value = descriptionValue,
+					onValueChange = { descriptionValue = it },
 				)
 				Column(textFieldModifier, verticalArrangement = textFieldVerticalArrangement) {
 					MapisodeText(
@@ -60,7 +78,8 @@ internal fun NewEpisodeContentScreen(navController: NavController) {
 						contentPadding = PaddingValues(12.dp),
 						horizontalArrangement = Arrangement.spacedBy(10.dp),
 					) {
-						items(3) {
+						items(state.episodeContent.images) { imageUri ->
+							// TODO: 이미지 URI를 바탕으로 컴포넌트 생성하기
 							Surface(Modifier.size(150.dp)) {
 								Image(
 									contentDescription = null,
@@ -76,7 +95,8 @@ internal fun NewEpisodeContentScreen(navController: NavController) {
 			MapisodeFilledButton(
 				modifier = textFieldModifier,
 				onClick = {
-					navController.navigate("new_episode_content")
+					submitEpisode(NewEpisodeContent(titleValue, descriptionValue))
+					navController.popBackStack("new_episode_pics", inclusive = false)
 				},
 				text = stringResource(R.string.new_episode_create_episode),
 			)
@@ -87,5 +107,8 @@ internal fun NewEpisodeContentScreen(navController: NavController) {
 @Preview
 @Composable
 internal fun NewEpisodeContentScreenPreview() {
-	NewEpisodeContentScreen(rememberNavController())
+	NewEpisodeContentScreen(
+		state = NewEpisodeState(),
+		navController = rememberNavController(),
+	)
 }

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeInfoScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeInfoScreen.kt
@@ -6,6 +6,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerColors
+import androidx.compose.material3.DatePickerDefaults
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -20,14 +25,17 @@ import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
 import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
 import com.boostcamp.mapisode.designsystem.compose.MapisodeText
 import com.boostcamp.mapisode.designsystem.compose.button.MapisodeFilledButton
+import com.boostcamp.mapisode.designsystem.compose.button.MapisodeOutlinedButton
 import com.boostcamp.mapisode.designsystem.compose.menu.MapisodeDropdownMenu
 import com.boostcamp.mapisode.designsystem.compose.menu.MapisodeDropdownMenuItem
+import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 import com.boostcamp.mapisode.episode.common.NewEpisodeConstant.categoryMap
 import com.boostcamp.mapisode.episode.common.NewEpisodeConstant.groupMap
 import com.boostcamp.mapisode.episode.common.NewEpisodeConstant.textFieldModifier
 import com.boostcamp.mapisode.episode.intent.NewEpisodeInfo
 import com.boostcamp.mapisode.episode.intent.NewEpisodeState
 import com.naver.maps.geometry.LatLng
+import timber.log.Timber
 import java.util.Date
 import java.util.Locale
 
@@ -46,7 +54,8 @@ internal fun NewEpisodeInfoScreen(
 	var isGroupBlank by remember { mutableStateOf(false) }
 	var isCategoryBlank by remember { mutableStateOf(false) }
 	var tagValue by remember { mutableStateOf(state.episodeInfo.tags) }
-	val dateValue by remember { mutableStateOf(Date()) }
+	var showDatePickerDialog by remember { mutableStateOf(false) }
+	val datePickerState = rememberDatePickerState()
 
 	MapisodeScaffold(
 		topBar = {
@@ -61,6 +70,41 @@ internal fun NewEpisodeInfoScreen(
 				.padding(20.dp),
 			verticalArrangement = Arrangement.SpaceBetween,
 		) {
+			if (showDatePickerDialog) {
+				DatePickerDialog(
+					onDismissRequest = {
+						showDatePickerDialog = false
+					},
+					confirmButton = {
+						MapisodeOutlinedButton(
+							modifier = Modifier.padding(top = 8.dp),
+							onClick = {
+								showDatePickerDialog = false
+								datePickerState.selectedDateMillis?.let {
+									Timber.d(it.toString())
+									updateDate(Date(it))
+								}
+							},
+							text = "확인",
+						)
+					},
+					dismissButton = {
+						MapisodeOutlinedButton(
+							onClick = {
+								showDatePickerDialog = false
+							},
+							text = "취소",
+						)
+					},
+					colors = DatePickerDialogColors(),
+				) {
+					DatePicker(
+						state = datePickerState,
+						colors = DatePickerDialogColors(),
+						showModeToggle = false,
+					)
+				}
+			}
 			Column {
 				EpisodeTextFieldGroup(
 					labelRes = R.string.new_episode_info_location,
@@ -151,6 +195,9 @@ internal fun NewEpisodeInfoScreen(
 					trailingIcon = {
 						MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_calendar)
 					},
+					onTrailingIconClick = {
+						showDatePickerDialog = true
+					},
 				)
 			}
 			MapisodeFilledButton(
@@ -164,7 +211,6 @@ internal fun NewEpisodeInfoScreen(
 					updateEpisodeInfo(
 						state.episodeInfo.copy(
 							tags = tagValue,
-							date = dateValue,
 						),
 					)
 					navController.navigate("new_episode_content")
@@ -174,6 +220,15 @@ internal fun NewEpisodeInfoScreen(
 		}
 	}
 }
+
+@Composable
+private fun DatePickerDialogColors(): DatePickerColors =
+	DatePickerDefaults.colors().copy(
+		containerColor = MapisodeTheme.colorScheme.dialogBackground,
+		selectedYearContainerColor = MapisodeTheme.colorScheme.dialogConfirm,
+		selectedDayContainerColor = MapisodeTheme.colorScheme.dialogConfirm,
+		todayDateBorderColor = MapisodeTheme.colorScheme.dialogConfirm,
+	)
 
 private fun latLngString(latLng: LatLng): String =
 	String.format(Locale.getDefault(), "%.6f, %.6f", latLng.latitude, latLng.longitude)

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeInfoScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeInfoScreen.kt
@@ -122,7 +122,9 @@ internal fun NewEpisodeInfoScreen(
 						placeholderRes = R.string.new_episode_info_placeholder_group,
 						value = state.episodeInfo.group,
 						readOnly = true,
-						trailingIcon = { MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_arrow_drop_down) },
+						trailingIcon = {
+							MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_arrow_drop_down)
+						},
 						onTrailingIconClick = {
 							isGroupDropdownExpanded = !isGroupDropdownExpanded
 						},
@@ -154,7 +156,9 @@ internal fun NewEpisodeInfoScreen(
 						placeholderRes = R.string.new_episode_info_placeholder_category,
 						value = state.episodeInfo.category,
 						readOnly = true,
-						trailingIcon = { MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_arrow_drop_down) },
+						trailingIcon = {
+							MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_arrow_drop_down)
+						},
 						onTrailingIconClick = {
 							isCategoryDropdownExpanded = !isCategoryDropdownExpanded
 						},

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeInfoScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeInfoScreen.kt
@@ -210,6 +210,7 @@ internal fun NewEpisodeInfoScreen(
 					}
 					updateEpisodeInfo(
 						state.episodeInfo.copy(
+							location = state.cameraPosition.target,
 							tags = tagValue,
 						),
 					)

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeInfoScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeInfoScreen.kt
@@ -1,10 +1,16 @@
 package com.boostcamp.mapisode.episode
 
+import android.text.format.DateFormat
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -12,11 +18,36 @@ import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
 import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
+import com.boostcamp.mapisode.designsystem.compose.MapisodeText
 import com.boostcamp.mapisode.designsystem.compose.button.MapisodeFilledButton
+import com.boostcamp.mapisode.designsystem.compose.menu.MapisodeDropdownMenu
+import com.boostcamp.mapisode.designsystem.compose.menu.MapisodeDropdownMenuItem
+import com.boostcamp.mapisode.episode.common.NewEpisodeConstant.categoryMap
+import com.boostcamp.mapisode.episode.common.NewEpisodeConstant.groupMap
 import com.boostcamp.mapisode.episode.common.NewEpisodeConstant.textFieldModifier
+import com.boostcamp.mapisode.episode.intent.NewEpisodeInfo
+import com.boostcamp.mapisode.episode.intent.NewEpisodeState
+import com.naver.maps.geometry.LatLng
+import java.util.Date
+import java.util.Locale
 
 @Composable
-internal fun NewEpisodeInfoScreen(navController: NavController) {
+internal fun NewEpisodeInfoScreen(
+	state: NewEpisodeState,
+	navController: NavController,
+	updateGroup: (String) -> Unit,
+	updateCategory: (String) -> Unit,
+	updateTags: (String) -> Unit,
+	updateDate: (Date) -> Unit,
+	updateEpisodeInfo: (NewEpisodeInfo) -> Unit,
+) {
+	var isGroupDropdownExpanded by remember { mutableStateOf(false) }
+	var isCategoryDropdownExpanded by remember { mutableStateOf(false) }
+	var isGroupBlank by remember { mutableStateOf(false) }
+	var isCategoryBlank by remember { mutableStateOf(false) }
+	var tagValue by remember { mutableStateOf(state.episodeInfo.tags) }
+	val dateValue by remember { mutableStateOf(Date()) }
+
 	MapisodeScaffold(
 		topBar = {
 			NewEpisodeTopbar(navController)
@@ -34,34 +65,108 @@ internal fun NewEpisodeInfoScreen(navController: NavController) {
 				EpisodeTextFieldGroup(
 					labelRes = R.string.new_episode_info_location,
 					placeholderRes = R.string.new_episode_info_placeholder_location,
+					value = latLngString(state.cameraPosition.target),
+					readOnly = true,
 					trailingIcon = { MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_location) },
 					onTrailingIconClick = {
 						navController.navigate("pick_location")
 					},
 				)
-				EpisodeTextFieldGroup(
-					labelRes = R.string.new_episode_info_group,
-					placeholderRes = R.string.new_episode_info_placeholder_group,
-					trailingIcon = { MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_arrow_drop_down) },
-				)
-				EpisodeTextFieldGroup(
-					labelRes = R.string.new_episode_info_category,
-					placeholderRes = R.string.new_episode_info_placeholder_category,
-					trailingIcon = { MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_arrow_drop_down) },
-				)
+				Column {
+					EpisodeTextFieldGroup(
+						labelRes = R.string.new_episode_info_group,
+						placeholderRes = R.string.new_episode_info_placeholder_group,
+						value = state.episodeInfo.group,
+						readOnly = true,
+						trailingIcon = { MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_arrow_drop_down) },
+						onTrailingIconClick = {
+							isGroupDropdownExpanded = !isGroupDropdownExpanded
+						},
+						isError = isGroupBlank,
+					)
+					MapisodeDropdownMenu(
+						expanded = isGroupDropdownExpanded,
+						onDismissRequest = {
+							isGroupDropdownExpanded = !isGroupDropdownExpanded
+							isGroupBlank = state.episodeInfo.category.isBlank()
+						},
+						modifier = Modifier.fillMaxWidth(0.9f),
+					) {
+						for (group in groupMap.keys) {
+							MapisodeDropdownMenuItem(
+								onClick = {
+									isGroupDropdownExpanded = !isGroupDropdownExpanded
+									updateGroup(group)
+								},
+							) {
+								MapisodeText(text = group)
+							}
+						}
+					}
+				}
+				Column {
+					EpisodeTextFieldGroup(
+						labelRes = R.string.new_episode_info_category,
+						placeholderRes = R.string.new_episode_info_placeholder_category,
+						value = state.episodeInfo.category,
+						readOnly = true,
+						trailingIcon = { MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_arrow_drop_down) },
+						onTrailingIconClick = {
+							isCategoryDropdownExpanded = !isCategoryDropdownExpanded
+						},
+						isError = isCategoryBlank,
+					)
+					MapisodeDropdownMenu(
+						expanded = isCategoryDropdownExpanded,
+						onDismissRequest = {
+							isCategoryDropdownExpanded = !isCategoryDropdownExpanded
+							isCategoryBlank = state.episodeInfo.category.isBlank()
+						},
+						modifier = Modifier.fillMaxWidth(0.9f),
+					) {
+						for (category in categoryMap.keys) {
+							MapisodeDropdownMenuItem(
+								onClick = {
+									isCategoryDropdownExpanded = !isCategoryDropdownExpanded
+									updateCategory(category)
+								},
+							) {
+								MapisodeText(text = category)
+							}
+						}
+					}
+				}
 				EpisodeTextFieldGroup(
 					labelRes = R.string.new_episode_info_tags,
 					placeholderRes = R.string.new_episode_info_placeholder_tags,
+					value = tagValue,
+					onValueChange = { tagValue = it },
+					onSubmitInput = { tagValue = it },
 				)
 				EpisodeTextFieldGroup(
 					labelRes = R.string.new_episode_info_date,
 					placeholderRes = R.string.new_episode_info_placeholder_date,
-					trailingIcon = { MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_calendar) },
+					value = dateString(state.episodeInfo.date),
+					readOnly = true,
+					trailingIcon = {
+						MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_calendar)
+					},
 				)
 			}
 			MapisodeFilledButton(
 				modifier = textFieldModifier,
 				onClick = {
+					if (state.episodeInfo.group.isBlank() || state.episodeInfo.category.isBlank()) {
+						isGroupBlank = state.episodeInfo.group.isBlank()
+						isCategoryBlank = state.episodeInfo.category.isBlank()
+						return@MapisodeFilledButton
+					}
+					updateEpisodeInfo(
+						state.episodeInfo.copy(
+							tags = tagValue,
+							date = dateValue,
+						),
+					)
 					navController.navigate("new_episode_content")
 				},
 				text = "다음",
@@ -70,8 +175,22 @@ internal fun NewEpisodeInfoScreen(navController: NavController) {
 	}
 }
 
+private fun latLngString(latLng: LatLng): String =
+	String.format(Locale.getDefault(), "%.6f, %.6f", latLng.latitude, latLng.longitude)
+
+private fun dateString(date: Date): String =
+	DateFormat.format("yyyy. MM. dd", date).toString()
+
 @Preview
 @Composable
 internal fun NewEpisodeInfoScreenPreview() {
-	NewEpisodeInfoScreen(rememberNavController())
+	NewEpisodeInfoScreen(
+		state = NewEpisodeState(),
+		navController = rememberNavController(),
+		updateEpisodeInfo = {},
+		updateCategory = {},
+		updateGroup = {},
+		updateTags = {},
+		updateDate = {},
+	)
 }

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/PickLocationScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/PickLocationScreen.kt
@@ -19,18 +19,27 @@ import com.boostcamp.mapisode.designsystem.compose.MapisodeText
 import com.boostcamp.mapisode.designsystem.compose.button.MapisodeFilledButton
 import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
 import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
+import com.naver.maps.geometry.LatLng
+import com.naver.maps.map.compose.CameraPositionState
 import com.naver.maps.map.compose.ExperimentalNaverMapApi
+import com.naver.maps.map.compose.LocationTrackingMode
+import com.naver.maps.map.compose.MapProperties
 import com.naver.maps.map.compose.MapUiSettings
 import com.naver.maps.map.compose.Marker
-import com.naver.maps.map.compose.MarkerState
 import com.naver.maps.map.compose.NaverMap
+import com.naver.maps.map.compose.rememberFusedLocationSource
+import com.naver.maps.map.compose.rememberMarkerState
 
 @OptIn(ExperimentalNaverMapApi::class)
 @Composable
 internal fun PickLocationScreen(
-	markerState: MarkerState,
+	cameraPositionState: CameraPositionState,
 	navController: NavController,
+	updateLocation: (LatLng) -> Unit,
 ) {
+	val episodeMarkerState = rememberMarkerState()
+	episodeMarkerState.position = cameraPositionState.position.target
+
 	MapisodeScaffold(
 		isStatusBarPaddingExist = true,
 		topBar = {
@@ -47,13 +56,18 @@ internal fun PickLocationScreen(
 		Column {
 			NaverMap(
 				modifier = Modifier.fillMaxHeight(0.75f),
+				cameraPositionState = cameraPositionState,
+				properties = MapProperties(
+					locationTrackingMode = LocationTrackingMode.Follow,
+				),
 				uiSettings = MapUiSettings(
 					isZoomControlEnabled = false,
 					isLocationButtonEnabled = true,
 					isLogoClickEnabled = false,
 				),
+				locationSource = rememberFusedLocationSource(),
 			) {
-				Marker(state = markerState)
+				Marker(state = episodeMarkerState)
 			}
 			Box(
 				modifier = Modifier.fillMaxHeight(),
@@ -74,7 +88,10 @@ internal fun PickLocationScreen(
 					MapisodeFilledButton(
 						modifier = Modifier.fillMaxWidth(),
 						text = stringResource(R.string.new_episode_pick_location_button),
-						onClick = { navController.navigate("new_episode_content") },
+						onClick = {
+							updateLocation(episodeMarkerState.position)
+							navController.popBackStack("new_episode_info", false)
+						},
 						showRipple = true,
 					)
 				}

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/common/NewEpisodeConstant.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/common/NewEpisodeConstant.kt
@@ -14,5 +14,16 @@ object NewEpisodeConstant {
 		.padding(vertical = 15.dp)
 	val textFieldVerticalArrangement = Arrangement.spacedBy(12.dp)
 	val groupMap = mapOf("나의 에피소드" to "my_episode")
-	val categoryMap = mapOf("먹을 것" to "EAT", "볼 것" to "SEE", "나머지" to "OTHER")
+
+	private const val CATEGORY_NAME_EAT = "먹을 것"
+	private const val CATEGORY_NAME_SEE = "볼 것"
+	private const val CATEGORY_NAME_OTHER = "나머지"
+	private const val CATEGORY_VALUE_EAT = "EAT"
+	private const val CATEGORY_VALUE_SEE = "SEE"
+	private const val CATEGORY_VALUE_OTHER = "OTHER"
+	val categoryMap = mapOf(
+		CATEGORY_NAME_EAT to CATEGORY_VALUE_EAT,
+		CATEGORY_NAME_SEE to CATEGORY_VALUE_SEE,
+		CATEGORY_NAME_OTHER to CATEGORY_VALUE_OTHER,
+	)
 }

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/common/NewEpisodeConstant.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/common/NewEpisodeConstant.kt
@@ -7,8 +7,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
 object NewEpisodeConstant {
+	const val MAP_DEFAULT_ZOOM = 16.0
+
 	val textFieldModifier = Modifier
 		.fillMaxWidth()
 		.padding(vertical = 15.dp)
 	val textFieldVerticalArrangement = Arrangement.spacedBy(12.dp)
+	val groupMap = mapOf("나의 에피소드" to "my_episode")
+	val categoryMap = mapOf("먹을 것" to "EAT", "볼 것" to "SEE", "나머지" to "OTHER")
 }

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/intent/NewEpisodeIntent.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/intent/NewEpisodeIntent.kt
@@ -10,4 +10,6 @@ sealed class NewEpisodeIntent {
 	data class SetEpisodeTags(val tags: String) : NewEpisodeIntent()
 	data class SetEpisodeDate(val date: Date) : NewEpisodeIntent()
 	data class SetEpisodeInfo(val episodeInfo: NewEpisodeInfo) : NewEpisodeIntent()
+	data class SetEpisodeContent(val episodeContent: NewEpisodeContent) : NewEpisodeIntent()
+	data object CreateNewEpisode : NewEpisodeIntent()
 }

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/intent/NewEpisodeIntent.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/intent/NewEpisodeIntent.kt
@@ -1,0 +1,13 @@
+package com.boostcamp.mapisode.episode.intent
+
+import com.naver.maps.geometry.LatLng
+import java.util.Date
+
+sealed class NewEpisodeIntent {
+	data class SetEpisodeLocation(val latLng: LatLng) : NewEpisodeIntent()
+	data class SetEpisodeGroup(val group: String) : NewEpisodeIntent()
+	data class SetEpisodeCategory(val category: String) : NewEpisodeIntent()
+	data class SetEpisodeTags(val tags: String) : NewEpisodeIntent()
+	data class SetEpisodeDate(val date: Date) : NewEpisodeIntent()
+	data class SetEpisodeInfo(val episodeInfo: NewEpisodeInfo) : NewEpisodeIntent()
+}

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/intent/NewEpisodeSideEffect.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/intent/NewEpisodeSideEffect.kt
@@ -2,5 +2,4 @@ package com.boostcamp.mapisode.episode.intent
 
 import com.boostcamp.mapisode.ui.base.SideEffect
 
-sealed class NewEpisodeSideEffect : SideEffect {
-}
+sealed class NewEpisodeSideEffect : SideEffect

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/intent/NewEpisodeSideEffect.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/intent/NewEpisodeSideEffect.kt
@@ -1,0 +1,6 @@
+package com.boostcamp.mapisode.episode.intent
+
+import com.boostcamp.mapisode.ui.base.SideEffect
+
+sealed class NewEpisodeSideEffect : SideEffect {
+}

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/intent/NewEpisodeState.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/intent/NewEpisodeState.kt
@@ -1,0 +1,26 @@
+package com.boostcamp.mapisode.episode.intent
+
+import com.boostcamp.mapisode.episode.common.NewEpisodeConstant.MAP_DEFAULT_ZOOM
+import com.boostcamp.mapisode.ui.base.UiState
+import com.naver.maps.geometry.LatLng
+import com.naver.maps.map.CameraPosition
+import java.util.Date
+
+data class NewEpisodeState(
+	val cameraPosition: CameraPosition = CameraPosition(
+		LatLng(
+			37.49083317052349,
+			127.03343085967185,
+		),
+		MAP_DEFAULT_ZOOM,
+	),
+	val episodeInfo: NewEpisodeInfo = NewEpisodeInfo(),
+) : UiState
+
+data class NewEpisodeInfo(
+	val location: LatLng = LatLng(0.0, 0.0),
+	val group: String = "",
+	val category: String = "",
+	val tags: String = "",
+	val date: Date = Date(),
+)

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/intent/NewEpisodeState.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/intent/NewEpisodeState.kt
@@ -1,6 +1,9 @@
 package com.boostcamp.mapisode.episode.intent
 
+import android.net.Uri
 import com.boostcamp.mapisode.episode.common.NewEpisodeConstant.MAP_DEFAULT_ZOOM
+import com.boostcamp.mapisode.model.EpisodeLatLng
+import com.boostcamp.mapisode.model.EpisodeModel
 import com.boostcamp.mapisode.ui.base.UiState
 import com.naver.maps.geometry.LatLng
 import com.naver.maps.map.CameraPosition
@@ -15,7 +18,20 @@ data class NewEpisodeState(
 		MAP_DEFAULT_ZOOM,
 	),
 	val episodeInfo: NewEpisodeInfo = NewEpisodeInfo(),
-) : UiState
+	val episodeContent: NewEpisodeContent = NewEpisodeContent(),
+) : UiState {
+	fun toDomainModel() = EpisodeModel(
+		title = episodeContent.title,
+		content = episodeContent.description,
+		imageUrls = episodeContent.images.map { it.toString() },
+		location = EpisodeLatLng(episodeInfo.location.latitude, episodeInfo.location.longitude),
+		group = episodeInfo.group,
+		category = episodeInfo.category,
+		tags = episodeInfo.tags.split(","),
+		memoryDate = episodeInfo.date,
+		createdBy = "AndroidDessertClub",
+	)
+}
 
 data class NewEpisodeInfo(
 	val location: LatLng = LatLng(0.0, 0.0),
@@ -23,4 +39,10 @@ data class NewEpisodeInfo(
 	val category: String = "",
 	val tags: String = "",
 	val date: Date = Date(),
+)
+
+data class NewEpisodeContent(
+	val title: String = "",
+	val description: String = "",
+	val images: List<Uri> = emptyList(),
 )

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/intent/NewEpisodeViewModel.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/intent/NewEpisodeViewModel.kt
@@ -1,0 +1,63 @@
+package com.boostcamp.mapisode.episode.intent
+
+import com.boostcamp.mapisode.episode.common.NewEpisodeConstant.MAP_DEFAULT_ZOOM
+import com.boostcamp.mapisode.ui.base.BaseViewModel
+import com.naver.maps.map.CameraPosition
+import timber.log.Timber
+
+class NewEpisodeViewModel
+	: BaseViewModel<NewEpisodeState, NewEpisodeSideEffect>(NewEpisodeState()) {
+
+	fun onIntent(intent: NewEpisodeIntent) {
+		when (intent) {
+			is NewEpisodeIntent.SetEpisodeLocation -> {
+				intent {
+					copy(
+						cameraPosition = CameraPosition(intent.latLng, MAP_DEFAULT_ZOOM),
+					)
+				}
+			}
+
+			is NewEpisodeIntent.SetEpisodeInfo -> {
+				intent {
+					copy(
+						episodeInfo = intent.episodeInfo,
+					)
+				}
+			}
+
+			is NewEpisodeIntent.SetEpisodeGroup -> {
+				intent {
+					copy(
+						episodeInfo = episodeInfo.copy(group = intent.group),
+					)
+				}
+			}
+
+			is NewEpisodeIntent.SetEpisodeCategory -> {
+				intent {
+					copy(
+						episodeInfo = episodeInfo.copy(category = intent.category),
+					)
+				}
+			}
+
+			is NewEpisodeIntent.SetEpisodeTags -> {
+				intent {
+					copy(
+						episodeInfo = episodeInfo.copy(tags = intent.tags),
+					)
+				}
+			}
+
+			is NewEpisodeIntent.SetEpisodeDate -> {
+				intent {
+					copy(
+						episodeInfo = episodeInfo.copy(date = intent.date),
+					)
+				}
+			}
+		}
+		Timber.d(uiState.value.toString())
+	}
+}


### PR DESCRIPTION
- closed #71

## *📍 Work Description*
- 에피소드 생성 화면의 날짜 선택 Dialog 추가 (슬프게도 머터리얼 사용)
- 에피소드 생성 후 DB에 업로드

## *📸 Screenshot*
[71-1.webm](https://github.com/user-attachments/assets/9570a021-1e3d-49ab-b4ab-82136a5b7181)

## *📢 To Reviewers*
> 배포를 위한 최소의 최소한의 기능만 구현되어 상당히 러프합니다!!! 부족한 부분은 대략 알고 있지만 보시기에 부족한 부분은 책임없는 리뷰공격 부탁드립니다! (수정 사항들은 이후 PR에서 수정하여 기능 개선할 예정)

> 현재 인지하고 있는 필요한 추가 기능은 다음과 같습니다.
> * 이미지 업로드 + 에피소드에 포함
> * 에피소드 내용(제목, 내용)이 비어있는지 확인
 

## ⏲️Time
    - 12 시간
