### PR TITLE
[FEAT/#63] DataStore / 기능 구현

### DIFF
--- a/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/DataStoreModule.kt
+++ b/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/DataStoreModule.kt
@@ -19,11 +19,9 @@ object DataStoreModule {
 	@Singleton
 	fun providePreferencesDataStore(
 		@ApplicationContext context: Context,
-	): DataStore<Preferences> {
-		return PreferenceDataStoreFactory.create(
-			produceFile = { context.preferencesDataStoreFile("user_preferences") },
-		)
-	}
+	): DataStore<Preferences> = PreferenceDataStoreFactory.create(
+		produceFile = { context.preferencesDataStoreFile("user_preferences") },
+	)
 
 	@Provides
 	@Singleton

--- a/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/DataStoreModule.kt
+++ b/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/DataStoreModule.kt
@@ -1,0 +1,33 @@
+package com.boostcamp.mapisode.datastore
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStoreFile
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DataStoreModule {
+	@Provides
+	@Singleton
+	fun providePreferencesDataStore(
+		@ApplicationContext context: Context,
+	): DataStore<Preferences> {
+		return PreferenceDataStoreFactory.create(
+			produceFile = { context.preferencesDataStoreFile("user_preferences") },
+		)
+	}
+
+	@Provides
+	@Singleton
+	fun providePreferenceStorage(
+		dataStore: DataStore<Preferences>,
+	): UserPreferenceDataStore = UserPreferenceDataStoreImpl(dataStore)
+}

--- a/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/DataStoreModule.kt
+++ b/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/DataStoreModule.kt
@@ -29,5 +29,5 @@ object DataStoreModule {
 	@Singleton
 	fun providePreferenceStorage(
 		dataStore: DataStore<Preferences>,
-	): UserPreferenceDataStore = UserPreferenceDataStoreImpl(dataStore)
+	): UserPreferenceDataStore = UserPreferencesDataStoreImpl(dataStore)
 }

--- a/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/PreferenceKeys.kt
+++ b/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/PreferenceKeys.kt
@@ -1,0 +1,14 @@
+package com.boostcamp.mapisode.datastore
+
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+
+internal object PreferenceKeys {
+	val USER_ID = stringPreferencesKey("user_id")
+	val USERNAME = stringPreferencesKey("username")
+	val IS_FIRST_LAUNCH = booleanPreferencesKey("is_first_launch")
+	val IS_LOGGED_IN = booleanPreferencesKey("is_logged_in")
+	val PROFILE_URL = stringPreferencesKey("profile_url")
+	val AUTH_TOKEN = stringPreferencesKey("auth_token")
+	val RECENT_SELECTED_CATEGORY = stringPreferencesKey("recent_selected_category")
+}

--- a/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/PreferenceKeys.kt
+++ b/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/PreferenceKeys.kt
@@ -10,5 +10,5 @@ internal object PreferenceKeys {
 	val IS_LOGGED_IN = booleanPreferencesKey("is_logged_in")
 	val PROFILE_URL = stringPreferencesKey("profile_url")
 	val CREDENTIAL_ID_TOKEN = stringPreferencesKey("credential_id_token")
-	val RECENT_SELECTED_CATEGORY = stringPreferencesKey("recent_selected_category")
+	val RECENT_SELECTED_GROUP = stringPreferencesKey("recent_selected_group")
 }

--- a/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/PreferenceKeys.kt
+++ b/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/PreferenceKeys.kt
@@ -9,6 +9,6 @@ internal object PreferenceKeys {
 	val IS_FIRST_LAUNCH = booleanPreferencesKey("is_first_launch")
 	val IS_LOGGED_IN = booleanPreferencesKey("is_logged_in")
 	val PROFILE_URL = stringPreferencesKey("profile_url")
-	val AUTH_TOKEN = stringPreferencesKey("auth_token")
+	val CREDENTIAL_ID_TOKEN = stringPreferencesKey("credential_id_token")
 	val RECENT_SELECTED_CATEGORY = stringPreferencesKey("recent_selected_category")
 }

--- a/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/UserPreferenceDataStore.kt
+++ b/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/UserPreferenceDataStore.kt
@@ -1,0 +1,17 @@
+package com.boostcamp.mapisode.datastore
+
+import kotlinx.coroutines.flow.Flow
+
+interface UserPreferenceDataStore {
+	fun getUserPreferencesFlow(): Flow<UserPreferences>
+
+	suspend fun updateUserId(userId: String)
+	suspend fun updateUsername(username: String)
+	suspend fun updateIsFirstLaunch()
+	suspend fun updateIsLoggedIn(isLoggedIn: Boolean)
+	suspend fun updateProfileUrl(profileUrl: String)
+	suspend fun updateAuthToken(authToken: String)
+	suspend fun updateRecentSelectedGroup(group: String)
+
+	suspend fun clearUserData()
+}

--- a/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/UserPreferenceDataStore.kt
+++ b/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/UserPreferenceDataStore.kt
@@ -10,7 +10,7 @@ interface UserPreferenceDataStore {
 	suspend fun updateIsFirstLaunch()
 	suspend fun updateIsLoggedIn(isLoggedIn: Boolean)
 	suspend fun updateProfileUrl(profileUrl: String)
-	suspend fun updateAuthToken(authToken: String)
+	suspend fun updateCredentialIdToken(authToken: String)
 	suspend fun updateRecentSelectedGroup(group: String)
 
 	suspend fun clearUserData()

--- a/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/UserPreferenceDataStore.kt
+++ b/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/UserPreferenceDataStore.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.flow.Flow
 
 interface UserPreferenceDataStore {
 	fun getUserPreferencesFlow(): Flow<UserPreferences>
+	fun getUserId(): Flow<String?>
 
 	suspend fun updateUserId(userId: String)
 	suspend fun updateUsername(username: String)

--- a/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/UserPreferences.kt
+++ b/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/UserPreferences.kt
@@ -6,6 +6,6 @@ data class UserPreferences(
 	val isFirstLaunch: Boolean = true,
 	val isLoggedIn: Boolean = false,
 	val profileUrl: String?,
-	val authToken: String?,
+	val credentialIDToken: String?,
 	val recentSelectedGroup: String?,
 )

--- a/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/UserPreferences.kt
+++ b/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/UserPreferences.kt
@@ -1,0 +1,11 @@
+package com.boostcamp.mapisode.datastore
+
+data class UserPreferences(
+	val userId: String?,
+	val username: String?,
+	val isFirstLaunch: Boolean = true,
+	val isLoggedIn: Boolean = false,
+	val profileUrl: String?,
+	val authToken: String?,
+	val recentSelectedGroup: String?,
+)

--- a/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/UserPreferencesDataStoreImpl.kt
+++ b/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/UserPreferencesDataStoreImpl.kt
@@ -29,9 +29,10 @@ class UserPreferencesDataStoreImpl @Inject constructor(
 				isFirstLaunch = preferences[PreferenceKeys.IS_FIRST_LAUNCH] ?: true,
 				isLoggedIn = preferences[PreferenceKeys.IS_LOGGED_IN] ?: false,
 				profileUrl = preferences[PreferenceKeys.PROFILE_URL],
-				authToken = preferences[PreferenceKeys.AUTH_TOKEN],
+				credentialIDToken = preferences[PreferenceKeys.CREDENTIAL_ID_TOKEN],
 				recentSelectedGroup = preferences[PreferenceKeys.RECENT_SELECTED_CATEGORY],
-			)
+
+				)
 		}
 
 	override suspend fun updateUserId(userId: String) {
@@ -64,9 +65,9 @@ class UserPreferencesDataStoreImpl @Inject constructor(
 		}
 	}
 
-	override suspend fun updateAuthToken(authToken: String) {
+	override suspend fun updateCredentialIdToken(credentialIdToken: String) {
 		dataStore.edit { preferences ->
-			preferences[PreferenceKeys.AUTH_TOKEN] = authToken
+			preferences[PreferenceKeys.CREDENTIAL_ID_TOKEN] = credentialIdToken
 		}
 	}
 
@@ -82,7 +83,7 @@ class UserPreferencesDataStoreImpl @Inject constructor(
 			preferences.remove(PreferenceKeys.USERNAME)
 			preferences.remove(PreferenceKeys.IS_LOGGED_IN)
 			preferences.remove(PreferenceKeys.PROFILE_URL)
-			preferences.remove(PreferenceKeys.AUTH_TOKEN)
+			preferences.remove(PreferenceKeys.CREDENTIAL_ID_TOKEN)
 			preferences.remove(PreferenceKeys.RECENT_SELECTED_CATEGORY)
 		}
 	}

--- a/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/UserPreferencesDataStoreImpl.kt
+++ b/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/UserPreferencesDataStoreImpl.kt
@@ -82,12 +82,6 @@ class UserPreferencesDataStoreImpl @Inject constructor(
 
 	override suspend fun clearUserData() {
 		dataStore.edit { preferences ->
-			preferences.remove(PreferenceKeys.USER_ID)
-			preferences.remove(PreferenceKeys.USERNAME)
-			preferences.remove(PreferenceKeys.IS_LOGGED_IN)
-			preferences.remove(PreferenceKeys.PROFILE_URL)
-			preferences.remove(PreferenceKeys.CREDENTIAL_ID_TOKEN)
-			preferences.remove(PreferenceKeys.RECENT_SELECTED_GROUP)
 			preferences.clear()
 		}
 	}

--- a/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/UserPreferencesDataStoreImpl.kt
+++ b/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/UserPreferencesDataStoreImpl.kt
@@ -35,6 +35,11 @@ class UserPreferencesDataStoreImpl @Inject constructor(
 				)
 		}
 
+	override fun getUserId(): Flow<String?> = dataStore.data.map { preferences ->
+		preferences[PreferenceKeys.USER_ID]
+	}
+
+
 	override suspend fun updateUserId(userId: String) {
 		dataStore.edit { preferences ->
 			preferences[PreferenceKeys.USER_ID] = userId

--- a/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/UserPreferencesDataStoreImpl.kt
+++ b/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/UserPreferencesDataStoreImpl.kt
@@ -31,14 +31,12 @@ class UserPreferencesDataStoreImpl @Inject constructor(
 				profileUrl = preferences[PreferenceKeys.PROFILE_URL],
 				credentialIDToken = preferences[PreferenceKeys.CREDENTIAL_ID_TOKEN],
 				recentSelectedGroup = preferences[PreferenceKeys.RECENT_SELECTED_CATEGORY],
-
-				)
+			)
 		}
 
 	override fun getUserId(): Flow<String?> = dataStore.data.map { preferences ->
 		preferences[PreferenceKeys.USER_ID]
 	}
-
 
 	override suspend fun updateUserId(userId: String) {
 		dataStore.edit { preferences ->

--- a/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/UserPreferencesDataStoreImpl.kt
+++ b/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/UserPreferencesDataStoreImpl.kt
@@ -1,0 +1,89 @@
+package com.boostcamp.mapisode.datastore
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.IOException
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class UserPreferenceDataStoreImpl @Inject constructor(
+	private val dataStore: DataStore<Preferences>,
+) : UserPreferenceDataStore {
+
+	override fun getUserPreferencesFlow(): Flow<UserPreferences> = dataStore.data
+		.catch { exception ->
+			if (exception is IOException) {
+				emit(emptyPreferences())
+			} else {
+				throw exception
+			}
+		}
+		.map { preferences ->
+			UserPreferences(
+				userId = preferences[PreferenceKeys.USER_ID],
+				username = preferences[PreferenceKeys.USERNAME],
+				isFirstLaunch = preferences[PreferenceKeys.IS_FIRST_LAUNCH] ?: true,
+				isLoggedIn = preferences[PreferenceKeys.IS_LOGGED_IN] ?: false,
+				profileUrl = preferences[PreferenceKeys.PROFILE_URL],
+				authToken = preferences[PreferenceKeys.AUTH_TOKEN],
+				recentSelectedGroup = preferences[PreferenceKeys.RECENT_SELECTED_CATEGORY],
+			)
+		}
+
+	override suspend fun updateUserId(userId: String) {
+		dataStore.edit { preferences ->
+			preferences[PreferenceKeys.USER_ID] = userId
+		}
+	}
+
+	override suspend fun updateUsername(username: String) {
+		dataStore.edit { preferences ->
+			preferences[PreferenceKeys.USERNAME] = username
+		}
+	}
+
+	override suspend fun updateIsFirstLaunch() {
+		dataStore.edit { preferences ->
+			preferences[PreferenceKeys.IS_FIRST_LAUNCH] = false
+		}
+	}
+
+	override suspend fun updateIsLoggedIn(isLoggedIn: Boolean) {
+		dataStore.edit { preferences ->
+			preferences[PreferenceKeys.IS_LOGGED_IN] = isLoggedIn
+		}
+	}
+
+	override suspend fun updateProfileUrl(profileUrl: String) {
+		dataStore.edit { preferences ->
+			preferences[PreferenceKeys.PROFILE_URL] = profileUrl
+		}
+	}
+
+	override suspend fun updateAuthToken(authToken: String) {
+		dataStore.edit { preferences ->
+			preferences[PreferenceKeys.AUTH_TOKEN] = authToken
+		}
+	}
+
+	override suspend fun updateRecentSelectedGroup(group: String) {
+		dataStore.edit { preferences ->
+			preferences[PreferenceKeys.RECENT_SELECTED_CATEGORY] = group
+		}
+	}
+
+	override suspend fun clearUserData() {
+		dataStore.edit { preferences ->
+			preferences.remove(PreferenceKeys.USER_ID)
+			preferences.remove(PreferenceKeys.USERNAME)
+			preferences.remove(PreferenceKeys.IS_LOGGED_IN)
+			preferences.remove(PreferenceKeys.PROFILE_URL)
+			preferences.remove(PreferenceKeys.AUTH_TOKEN)
+			preferences.remove(PreferenceKeys.RECENT_SELECTED_CATEGORY)
+		}
+	}
+}

--- a/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/UserPreferencesDataStoreImpl.kt
+++ b/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/UserPreferencesDataStoreImpl.kt
@@ -10,9 +10,8 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
-class UserPreferenceDataStoreImpl @Inject constructor(
-	private val dataStore: DataStore<Preferences>,
-) : UserPreferenceDataStore {
+class UserPreferencesDataStoreImpl @Inject constructor(private val dataStore: DataStore<Preferences>) :
+	UserPreferenceDataStore {
 
 	override fun getUserPreferencesFlow(): Flow<UserPreferences> = dataStore.data
 		.catch { exception ->

--- a/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/UserPreferencesDataStoreImpl.kt
+++ b/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/UserPreferencesDataStoreImpl.kt
@@ -10,8 +10,9 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
-class UserPreferencesDataStoreImpl @Inject constructor(private val dataStore: DataStore<Preferences>) :
-	UserPreferenceDataStore {
+class UserPreferencesDataStoreImpl @Inject constructor(
+	private val dataStore: DataStore<Preferences>,
+) : UserPreferenceDataStore {
 
 	override fun getUserPreferencesFlow(): Flow<UserPreferences> = dataStore.data
 		.catch { exception ->

--- a/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/UserPreferencesDataStoreImpl.kt
+++ b/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/UserPreferencesDataStoreImpl.kt
@@ -30,7 +30,7 @@ class UserPreferencesDataStoreImpl @Inject constructor(
 				isLoggedIn = preferences[PreferenceKeys.IS_LOGGED_IN] ?: false,
 				profileUrl = preferences[PreferenceKeys.PROFILE_URL],
 				credentialIDToken = preferences[PreferenceKeys.CREDENTIAL_ID_TOKEN],
-				recentSelectedGroup = preferences[PreferenceKeys.RECENT_SELECTED_CATEGORY],
+				recentSelectedGroup = preferences[PreferenceKeys.RECENT_SELECTED_GROUP],
 			)
 		}
 
@@ -76,7 +76,7 @@ class UserPreferencesDataStoreImpl @Inject constructor(
 
 	override suspend fun updateRecentSelectedGroup(group: String) {
 		dataStore.edit { preferences ->
-			preferences[PreferenceKeys.RECENT_SELECTED_CATEGORY] = group
+			preferences[PreferenceKeys.RECENT_SELECTED_GROUP] = group
 		}
 	}
 
@@ -87,7 +87,8 @@ class UserPreferencesDataStoreImpl @Inject constructor(
 			preferences.remove(PreferenceKeys.IS_LOGGED_IN)
 			preferences.remove(PreferenceKeys.PROFILE_URL)
 			preferences.remove(PreferenceKeys.CREDENTIAL_ID_TOKEN)
-			preferences.remove(PreferenceKeys.RECENT_SELECTED_CATEGORY)
+			preferences.remove(PreferenceKeys.RECENT_SELECTED_GROUP)
+			preferences.clear()
 		}
 	}
 }


### PR DESCRIPTION
- closed #63 
- #87 의 커밋 컨벤션이 잘못 되어 다시 올립니다. 

## *📍 Work Description*

- UserPreference를 정의했습니다. 이는 DataStore에 저장될 값의 data class입니다. 추가하고 싶은 값이 있다면 UserPreference와 PreferenceKeys에 값을 추가하시고 진행하시면 됩니다.
- DataStore는 UserPreference를 Flow로 반환하는 함수(`getUserPreferencesFlow()`)와, 값들에 대한 update 함수들과, clear함수(`clearUserData()`)로 이루어져 있습니다.
- DataStore는 인터페이스와 구현체로 구분되어 있습니다.

## *📸 Screenshot*
<img src="https://github.com/user-attachments/assets/d68b698b-2b1c-4c7a-8c13-805e86d39cde" width=270/>


## *📢 To Reviewers*
- 위의 스크린샷은 DataStore를 실험한 결과입니다. 프로세스를 종료시킨 후에도 값이 저장되어 있습니다. update 함수도 정상 작동합니다. 
- UserPreferences의 속성은 nullable하게 만들었습니다(Boolean 제외). getUserPreferencesFlow() 함수를 이용해서 Flow<UserPreferences>를 받았을 때, 특정 속성 값이 null인 경우 초기화되지 않았다는 것을 표시하기 위함입니다. 대부분의 경우, null을 반환하지는 않을 것으로 보입니다. 

## ⏲️Time

    - 6 h
