### PR TITLE
[FEAT/#86] Group / Navigation 설정

### DIFF
--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/BottomAppBar.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/BottomAppBar.kt
@@ -25,20 +25,20 @@ fun BottomBar(
 	contentColor: Color = MapisodeTheme.colorScheme.navUnselectedItem,
 	content: @Composable RowScope.() -> Unit,
 ) {
-	Surface(
-		color = backgroundColor,
-		contentColor = contentColor,
-		modifier = modifier
-			.fillMaxWidth()
-			.height(68.dp),
+	AnimatedVisibility(
+		visible = visible,
+		enter = fadeIn(),
+		exit = fadeOut(),
 	) {
-		Column {
-			MapisodeDivider(thickness = Thickness.Thin)
-			AnimatedVisibility(
-				visible = visible,
-				enter = fadeIn(),
-				exit = fadeOut(),
-			) {
+		Surface(
+			color = backgroundColor,
+			contentColor = contentColor,
+			modifier = modifier
+				.fillMaxWidth()
+				.height(68.dp),
+		) {
+			Column {
+				MapisodeDivider(thickness = Thickness.Thin)
 				Row(
 					Modifier
 						.selectableGroup(),

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeScaffold.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeScaffold.kt
@@ -24,23 +24,6 @@ import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 
 private enum class ScaffoldLayoutContent { TopBar, MainContent, Snackbar, BottomBar }
 
-val LocalMapisodeShowBotBar = compositionLocalOf<BottomBarController> {
-	error("No BottomBarController provided")
-}
-
-object BottomBarController {
-	private var _isVisible by mutableStateOf(true)
-	val isVisible: Boolean get() = _isVisible
-
-	fun off() {
-		_isVisible = false
-	}
-
-	fun on() {
-		_isVisible = true
-	}
-}
-
 @Composable
 fun MapisodeScaffold(
 	modifier: Modifier = Modifier,
@@ -54,8 +37,6 @@ fun MapisodeScaffold(
 	contentColor: Color = MapisodeTheme.colorScheme.textContent,
 	content: @Composable (PaddingValues) -> Unit,
 ) {
-	val showBottomNavBar = LocalMapisodeShowBotBar.current
-
 	Surface(
 		modifier = modifier,
 		color = backgroundColor,
@@ -63,17 +44,9 @@ fun MapisodeScaffold(
 	) {
 		ScaffoldLayout(
 			isStatusBarPaddingExist = isStatusBarPaddingExist,
-			isNavigationBarPaddingExist = if (showBottomNavBar.isVisible) {
-				isNavigationBarPaddingExist
-			} else {
-				true
-			},
+			isNavigationBarPaddingExist = isNavigationBarPaddingExist,
 			topBar = topBar,
-			bottomBar = if (showBottomNavBar.isVisible) {
-				bottomBar
-			} else {
-				{}
-			},
+			bottomBar = bottomBar,
 			toast = { toastHost(toastHostState) },
 			content = content,
 		)

--- a/core/navigation/src/main/java/com/boostcamp/mapisode/navigation/GroupRoute.kt
+++ b/core/navigation/src/main/java/com/boostcamp/mapisode/navigation/GroupRoute.kt
@@ -1,0 +1,17 @@
+package com.boostcamp.mapisode.navigation
+
+import kotlinx.serialization.Serializable
+
+sealed interface GroupRoute : Route {
+	@Serializable
+	data object Join : GroupRoute
+
+	@Serializable
+	data object Detail : GroupRoute
+
+	@Serializable
+	data object Creation : GroupRoute
+
+	@Serializable
+	data object Edit : GroupRoute
+}

--- a/feature/main/src/main/java/com/boostcamp/mapisode/main/MainActivity.kt
+++ b/feature/main/src/main/java/com/boostcamp/mapisode/main/MainActivity.kt
@@ -4,9 +4,6 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.runtime.CompositionLocalProvider
-import com.boostcamp.mapisode.designsystem.compose.BottomBarController
-import com.boostcamp.mapisode.designsystem.compose.LocalMapisodeShowBotBar
 import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -20,10 +17,8 @@ class MainActivity : ComponentActivity() {
 		setContent {
 			val navigator: MainNavigator = rememberMainNavigator()
 
-			CompositionLocalProvider(LocalMapisodeShowBotBar provides BottomBarController) {
-				MapisodeTheme {
-					MainScreen(navigator = navigator)
-				}
+			MapisodeTheme {
+				MainScreen(navigator = navigator)
 			}
 		}
 	}

--- a/feature/main/src/main/java/com/boostcamp/mapisode/main/MainNavigator.kt
+++ b/feature/main/src/main/java/com/boostcamp/mapisode/main/MainNavigator.kt
@@ -9,6 +9,10 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navOptions
+import com.boostcamp.mapisode.mygroup.navigation.navigateGroupCreation
+import com.boostcamp.mapisode.mygroup.navigation.navigateGroupDetail
+import com.boostcamp.mapisode.mygroup.navigation.navigateGroupEdit
+import com.boostcamp.mapisode.mygroup.navigation.navigateGroupJoin
 import com.boostcamp.mapisode.navigation.MainRoute
 
 internal class MainNavigator(
@@ -40,6 +44,22 @@ internal class MainNavigator(
 			MainNavTab.GROUP -> navController.navigate(MainNavTab.GROUP.route, navOptions)
 			MainNavTab.MYPAGE -> navController.navigate(MainNavTab.MYPAGE.route, navOptions)
 		}
+	}
+
+	fun navigateGroupJoin() {
+		navController.navigateGroupJoin()
+	}
+
+	fun navigateGroupDetail() {
+		navController.navigateGroupDetail()
+	}
+
+	fun navigateGroupCreation() {
+		navController.navigateGroupCreation()
+	}
+
+	fun navigateGroupEdit() {
+		navController.navigateGroupEdit()
 	}
 
 	private fun popBackStack() {

--- a/feature/main/src/main/java/com/boostcamp/mapisode/main/component/MainNavHost.kt
+++ b/feature/main/src/main/java/com/boostcamp/mapisode/main/component/MainNavHost.kt
@@ -25,7 +25,13 @@ internal fun MainNavHost(
 		) {
 			addHomeNavGraph()
 			addEpisodeNavGraph()
-			addGroupNavGraph()
+			addGroupNavGraph(
+				onBackClick = navigator::popBackStackIfNotHome,
+				onGroupJoinClick = navigator::navigateGroupJoin,
+				onGroupDetailClick = navigator::navigateGroupDetail,
+				onGroupCreationClick = navigator::navigateGroupCreation,
+				onGroupEditClick = navigator::navigateGroupEdit,
+			)
 			addMyPageNavGraph()
 		}
 	}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupCreationScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupCreationScreen.kt
@@ -21,7 +21,7 @@ import com.boostcamp.mapisode.designsystem.compose.button.MapisodeFilledButton
 import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
 
 @Composable
-fun GroupCreationScreen(onBack: () -> Unit) {
+fun GroupCreationScreen(onBackClick: () -> Unit) {
 	var isNavigationIconEnabled by remember { mutableStateOf(true) }
 
 	MapisodeScaffold(
@@ -31,7 +31,7 @@ fun GroupCreationScreen(onBack: () -> Unit) {
 				title = "그룹 생성",
 				navigationIcon = {
 					MapisodeIconButton(
-						onClick = { onBack() },
+						onClick = { onBackClick() },
 						enabled = isNavigationIconEnabled,
 					) {
 						MapisodeIcon(

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupDetailScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupDetailScreen.kt
@@ -23,7 +23,10 @@ import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
 import kotlinx.coroutines.launch
 
 @Composable
-fun GroupDetailScreen(onBack: () -> Unit) {
+fun GroupDetailScreen(
+	onBackClick: () -> Unit,
+	onEditClick: () -> Unit,
+) {
 	val pagerState = rememberPagerState(pageCount = { 2 })
 	val list = listOf("그룹 상세", "에피소드")
 	val scope = rememberCoroutineScope()
@@ -35,7 +38,7 @@ fun GroupDetailScreen(onBack: () -> Unit) {
 				title = "그룹 상세",
 				navigationIcon = {
 					MapisodeIconButton(
-						onClick = { onBack() },
+						onClick = { onBackClick() },
 					) {
 						MapisodeIcon(
 							id = R.drawable.ic_arrow_back_ios,

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupEditScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupEditScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
 import coil3.compose.AsyncImage
 import com.boostcamp.mapisode.designsystem.R
-import com.boostcamp.mapisode.designsystem.compose.LocalMapisodeShowBotBar
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIconButton
 import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
@@ -31,8 +30,6 @@ fun GroupEditScreen(
 	// onEpisodeClick: () -> Unit,
 ) {
 	val focusManager = LocalFocusManager.current
-	val bottomBarController = LocalMapisodeShowBotBar.current
-	bottomBarController.off()
 
 	MapisodeScaffold(
 		modifier = Modifier
@@ -51,7 +48,6 @@ fun GroupEditScreen(
 				navigationIcon = {
 					MapisodeIconButton(
 						onClick = {
-							bottomBarController.on()
 							onBackClick()
 						},
 					) {

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupEditScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupEditScreen.kt
@@ -26,7 +26,10 @@ import com.boostcamp.mapisode.designsystem.compose.button.MapisodeImageButton
 import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
 
 @Composable
-fun GroupEditScreen(onBack: () -> Unit) {
+fun GroupEditScreen(
+	onBackClick: () -> Unit,
+	// onEpisodeClick: () -> Unit,
+) {
 	val focusManager = LocalFocusManager.current
 	val bottomBarController = LocalMapisodeShowBotBar.current
 	bottomBarController.off()
@@ -49,7 +52,7 @@ fun GroupEditScreen(onBack: () -> Unit) {
 					MapisodeIconButton(
 						onClick = {
 							bottomBarController.on()
-							onBack()
+							onBackClick()
 						},
 					) {
 						MapisodeIcon(

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupJoinScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupJoinScreen.kt
@@ -1,11 +1,11 @@
 package com.boostcamp.mapisode.mygroup
 
 import androidx.compose.runtime.Composable
+import com.boostcamp.mapisode.designsystem.R
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIconButton
 import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
 import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
-import com.boostcamp.mapisode.designsystem.R
 
 @Composable
 fun GroupJoinScreen(

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupJoinScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupJoinScreen.kt
@@ -1,0 +1,10 @@
+package com.boostcamp.mapisode.mygroup
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun GroupJoinScreen(
+	onBackClick: () -> Unit,
+) {
+
+}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupJoinScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupJoinScreen.kt
@@ -1,10 +1,33 @@
 package com.boostcamp.mapisode.mygroup
 
 import androidx.compose.runtime.Composable
+import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
+import com.boostcamp.mapisode.designsystem.compose.MapisodeIconButton
+import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
+import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
+import com.boostcamp.mapisode.designsystem.R
 
 @Composable
 fun GroupJoinScreen(
 	onBackClick: () -> Unit,
 ) {
-
+	MapisodeScaffold(
+		isNavigationBarPaddingExist = true,
+		isStatusBarPaddingExist = true,
+		topBar = {
+			TopAppBar(
+				title = "그룹 참여",
+				navigationIcon = {
+					MapisodeIconButton(
+						onClick = onBackClick,
+					) {
+						MapisodeIcon(
+							id = R.drawable.ic_arrow_back_ios,
+							contentDescription = "Back",
+						)
+					}
+				},
+			)
+		},
+	) {}
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -31,19 +30,24 @@ import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
 import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 
 @Composable
-internal fun GroupRoute() {
-	var isGroupCreationScreenVisible by remember { mutableIntStateOf(0) }
-
-	when (isGroupCreationScreenVisible) {
-		0 -> GroupScreen(onMove = { isGroupCreationScreenVisible = it })
-		1 -> GroupDetailScreen(onBack = { isGroupCreationScreenVisible = 0 })
-		2 -> GroupEditScreen(onBack = { isGroupCreationScreenVisible = 0 })
-		3 -> GroupCreationScreen(onBack = { isGroupCreationScreenVisible = 0 })
-	}
+internal fun MainGroupRoute(
+	onGroupJoinClick: () -> Unit,
+	onGroupDetailClick: () -> Unit,
+	onGroupCreationClick: () -> Unit,
+) {
+	GroupScreen(
+		onGroupJoinClick = onGroupJoinClick,
+		onGroupDetailClick = onGroupDetailClick,
+		onGroupCreationClick = onGroupCreationClick,
+	)
 }
 
 @Composable
-private fun GroupScreen(onMove: (Int) -> Unit) {
+private fun GroupScreen(
+	onGroupJoinClick: () -> Unit,
+	onGroupDetailClick: () -> Unit,
+	onGroupCreationClick: () -> Unit,
+) {
 	val focusManager = LocalFocusManager.current
 	var isMenuPoppedUp by remember { mutableStateOf(false) }
 
@@ -76,21 +80,14 @@ private fun GroupScreen(onMove: (Int) -> Unit) {
 							offset = DpOffset(0.dp, 0.dp).minus(DpOffset(41.dp, 0.dp)),
 						) {
 							MapisodeDropdownMenuItem(
-								onClick = { onMove(1) },
+								onClick = { onGroupJoinClick() },
 							) {
 								MapisodeText(
-									text = "그룹 상세",
+									text = "그룹 참여",
 								)
 							}
 							MapisodeDropdownMenuItem(
-								onClick = { onMove(2) },
-							) {
-								MapisodeText(
-									text = "나의 그룹",
-								)
-							}
-							MapisodeDropdownMenuItem(
-								onClick = { onMove(3) },
+								onClick = { onGroupCreationClick() },
 							) {
 								MapisodeText(
 									text = "그룹 생성",

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/navigation/GroupNavigation.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/navigation/GroupNavigation.kt
@@ -4,17 +4,75 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
-import com.boostcamp.mapisode.mygroup.GroupRoute
+import com.boostcamp.mapisode.mygroup.GroupCreationScreen
+import com.boostcamp.mapisode.mygroup.GroupDetailScreen
+import com.boostcamp.mapisode.mygroup.GroupEditScreen
+import com.boostcamp.mapisode.mygroup.GroupJoinScreen
+import com.boostcamp.mapisode.mygroup.MainGroupRoute
+import com.boostcamp.mapisode.navigation.GroupRoute
 import com.boostcamp.mapisode.navigation.MainRoute
 
-fun NavController.navigateGroup(
+fun NavController.navigateGroupJoin(
 	navOptions: NavOptions? = null,
 ) {
-	navigate(MainRoute.Group, navOptions)
+	navigate(GroupRoute.Join, navOptions)
 }
 
-fun NavGraphBuilder.addGroupNavGraph() {
+fun NavController.navigateGroupDetail(
+	navOptions: NavOptions? = null,
+) {
+	navigate(GroupRoute.Detail, navOptions)
+}
+
+fun NavController.navigateGroupCreation(
+	navOptions: NavOptions? = null,
+) {
+	navigate(GroupRoute.Creation, navOptions)
+}
+
+fun NavController.navigateGroupEdit(
+	navOptions: NavOptions? = null,
+) {
+	navigate(GroupRoute.Edit, navOptions)
+}
+
+fun NavGraphBuilder.addGroupNavGraph(
+	onBackClick: () -> Unit,
+	onGroupJoinClick: () -> Unit,
+	onGroupDetailClick: () -> Unit,
+	onGroupCreationClick: () -> Unit,
+	onGroupEditClick: () -> Unit,
+) {
 	composable<MainRoute.Group> {
-		GroupRoute()
+		MainGroupRoute(
+			onGroupJoinClick = onGroupJoinClick,
+			onGroupDetailClick = onGroupDetailClick,
+			onGroupCreationClick = onGroupCreationClick,
+		)
+	}
+
+	composable<GroupRoute.Join> {
+		GroupJoinScreen(
+			onBackClick = onBackClick,
+		)
+	}
+
+	composable<GroupRoute.Detail> {
+		GroupDetailScreen(
+			onBackClick = onBackClick,
+			onEditClick = onGroupEditClick,
+		)
+	}
+
+	composable<GroupRoute.Creation> {
+		GroupCreationScreen(
+			onBackClick = onBackClick,
+		)
+	}
+
+	composable<GroupRoute.Edit> {
+		GroupEditScreen(
+			onBackClick = onBackClick,
+		)
 	}
 }


### PR DESCRIPTION
- closed #86

## *📍 Work Description*

- type-safe Navigation 선언
- Naigator, NavGraphBuilder 설정
- 이동 화면들 Scaffold 및 하위 컴포넌트 설정
- CompositionalLocal 를 통해 바텀앱바 사라지는 기능 삭제
- BotAppBar 컴포넌트 수정

## *📸 Screenshot*

https://github.com/user-attachments/assets/e62a0602-361f-471a-8a9b-b3e76f7ed898

## *📢 To Reviewers*
- type-safe 를 이용한 네비게이션을 설정하기 위해 sealed interface 와 Serializable 어노테이션을 사용하여 문자열이 아닌 타입 참조를 통해 화면간 이동이 가능하게끔 했습니다.

- sealed interface 내부에서 정의한 각 화면 타입들을 NavGraphBuilder 에 추가하기 위해 composable 함수를 사용했습니다.
  <br>
  - 일반적인 네비게이션 방식에서 인자에 문자열을 넣는 방식과 다르게 제너릭에 화면 타입을 선언합니다.

    <img src="https://github.com/user-attachments/assets/1a61ff0a-ad1b-4bd4-aad5-871dbfe10010" width=600>
  
  - content 컴포저블 콜백에 이동할 컴포저블 함수를 선언합니다.

- NavGraphBuilder의 확장함수에 화면이동 콜백을 정의했습니다.
  - 뒤로가기
  - 그룹 참여
  - 그룹 생성
  - 그룹 디테일(특정 그룹)
  - 그룹 편집

- 이전에 제가 추가한 바텀앱바 사라지게 하는 기능 컨트롤러는 삭제했습니다. 리컴포지션 문제가 있어서 오히려 관리하기가 힘들었을 겁니다.

- Bot App Bar 가 사라질 때 네비게이션 구분선이 포함이 안된 상태로 사라져서 포함시켰습니다.

태희님이 말씀하신 shouldShowBottomBar 함수는 현재 바텀네비게이션 4개의 아이템에 대응되는 4 화면을 제외하면 전부 Bottom Navigation Bar 가 사라지도록 되어있어서 참고하시면 되겠습니다.

나중에 필요하다면 shouldShowBottomBar 함수로직을 변경해서 다른 화면에서도 바텀 네비게이션이 뜨도록 할 수 있을것 같습니다.

## ⏲️Time

    - 4시간
