### PR TITLE
[FEAT/#93] Group / mvi 적용

### DIFF
--- a/core/model/src/main/kotlin/com/boostcamp/mapisode/model/GroupItem.kt
+++ b/core/model/src/main/kotlin/com/boostcamp/mapisode/model/GroupItem.kt
@@ -6,4 +6,5 @@ data class GroupItem(
 	val description: String,
 	val createdAt: String,
 	val adminUser: String,
+	val users: List<User> = listOf(),	// 태희님이 이 클래스 쓰시고 계셔서 초기값 부여해서 사용중입니다. - 태웅
 )

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/component/GroupCard.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/component/GroupCard.kt
@@ -9,12 +9,18 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import coil3.annotation.ExperimentalCoilApi
 import coil3.compose.AsyncImage
+import coil3.compose.AsyncImagePreviewHandler
+import coil3.compose.LocalAsyncImagePreviewHandler
+import coil3.test.FakeImage
 import com.boostcamp.mapisode.designsystem.compose.MapisodeText
 import com.boostcamp.mapisode.designsystem.compose.ripple.MapisodeRippleAIndication
 import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
@@ -60,5 +66,23 @@ fun GroupCard(
 				style = MapisodeTheme.typography.labelMedium,
 			)
 		}
+	}
+}
+
+@OptIn(ExperimentalCoilApi::class)
+@Preview
+@Composable
+fun GroupCardPreview() {
+	val previewHandler = AsyncImagePreviewHandler {
+		FakeImage(color = 0x99FFFFFF.toInt())
+	}
+
+	CompositionLocalProvider(LocalAsyncImagePreviewHandler provides previewHandler) {
+		GroupCard(
+			onGroupDetailClick = {},
+			imageUrl = "https://avatars.githubusercontent.com/u/127717111?v=4",
+			title = "그룹 이름",
+			content = "멤버 수",
+		)
 	}
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/component/GroupCard.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/component/GroupCard.kt
@@ -1,0 +1,51 @@
+package com.boostcamp.mapisode.mygroup.component
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import com.boostcamp.mapisode.designsystem.compose.MapisodeText
+import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
+
+@Composable
+fun GroupCard(
+	imageUrl: String,
+	title: String,
+	content: String
+) {
+	Column(
+		modifier = Modifier
+			.wrapContentSize()
+	) {
+		AsyncImage(
+			model = imageUrl,
+			contentDescription = title,
+			modifier = Modifier
+				.size(140.dp)
+				.clip(RoundedCornerShape(16.dp)),
+			contentScale = ContentScale.Crop
+		)
+		Spacer(modifier = Modifier.height(4.dp))
+		Column(
+			horizontalAlignment = Alignment.Start
+		) {
+			MapisodeText(
+				text = title,
+				style = MapisodeTheme.typography.labelLarge,
+			)
+			MapisodeText(
+				text = content,
+				style = MapisodeTheme.typography.labelMedium,
+			)
+		}
+	}
+}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/component/GroupCard.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/component/GroupCard.kt
@@ -19,12 +19,6 @@ import com.boostcamp.mapisode.designsystem.compose.MapisodeText
 import com.boostcamp.mapisode.designsystem.compose.ripple.MapisodeRippleAIndication
 import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 
-data class ItemData(
-	val imageUrl: String,
-	val title: String,
-	val content: String,
-)
-
 @Composable
 fun GroupCard(
 	onGroupDetailClick: () -> Unit,

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/component/GroupCard.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/component/GroupCard.kt
@@ -16,6 +16,12 @@ import coil3.compose.AsyncImage
 import com.boostcamp.mapisode.designsystem.compose.MapisodeText
 import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 
+data class ItemData(
+	val imageUrl: String,
+	val title: String,
+	val content: String,
+)
+
 @Composable
 fun GroupCard(
 	imageUrl: String,

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/component/GroupCard.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/component/GroupCard.kt
@@ -1,8 +1,10 @@
 package com.boostcamp.mapisode.mygroup.component
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -14,6 +16,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.boostcamp.mapisode.designsystem.compose.MapisodeText
+import com.boostcamp.mapisode.designsystem.compose.ripple.MapisodeRippleAIndication
 import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 
 data class ItemData(
@@ -24,13 +27,21 @@ data class ItemData(
 
 @Composable
 fun GroupCard(
+	onGroupDetailClick: () -> Unit,
 	imageUrl: String,
 	title: String,
-	content: String
+	content: String,
 ) {
 	Column(
 		modifier = Modifier
+			.padding(vertical = 10.dp)
 			.wrapContentSize()
+			.clip(RoundedCornerShape(16.dp))
+			.clickable(
+				interactionSource = null,
+				indication = MapisodeRippleAIndication,
+				onClick = onGroupDetailClick,
+			),
 	) {
 		AsyncImage(
 			model = imageUrl,
@@ -38,11 +49,13 @@ fun GroupCard(
 			modifier = Modifier
 				.size(140.dp)
 				.clip(RoundedCornerShape(16.dp)),
-			contentScale = ContentScale.Crop
+			contentScale = ContentScale.Crop,
 		)
 		Spacer(modifier = Modifier.height(4.dp))
 		Column(
-			horizontalAlignment = Alignment.Start
+			modifier = Modifier
+				.padding(start = 4.dp),
+			horizontalAlignment = Alignment.Start,
 		) {
 			MapisodeText(
 				text = title,

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupIntent.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupIntent.kt
@@ -1,0 +1,8 @@
+package com.boostcamp.mapisode.mygroup.intent
+
+import androidx.compose.runtime.Immutable
+
+@Immutable
+sealed class GroupIntent {
+	data object LoadGroups : GroupIntent()
+}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupIntent.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupIntent.kt
@@ -5,4 +5,5 @@ import androidx.compose.runtime.Immutable
 @Immutable
 sealed class GroupIntent {
 	data object LoadGroups : GroupIntent()
+	data object EndLoadingGroups : GroupIntent()
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupSideEffect.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupSideEffect.kt
@@ -1,0 +1,9 @@
+package com.boostcamp.mapisode.mygroup.intent
+
+import androidx.compose.runtime.Immutable
+import com.boostcamp.mapisode.ui.base.SideEffect
+
+@Immutable
+sealed class GroupSideEffect : SideEffect {
+	data class ShowToast(val messageResId: Int) : GroupSideEffect()
+}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupState.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupState.kt
@@ -1,0 +1,12 @@
+package com.boostcamp.mapisode.mygroup.intent
+
+import androidx.compose.runtime.Immutable
+import com.boostcamp.mapisode.model.GroupModel
+import com.boostcamp.mapisode.ui.base.UiState
+
+@Immutable
+data class GroupState(
+	val areGroupsLoading: Boolean,
+	val areGroupsVisible: Boolean,
+	val groups: List<GroupModel>,
+) : UiState

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupState.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupState.kt
@@ -7,6 +7,5 @@ import com.boostcamp.mapisode.ui.base.UiState
 @Immutable
 data class GroupState(
 	val areGroupsLoading: Boolean = false,
-	val areGroupsVisible: Boolean = false,
 	val groups: List<GroupItem> = listOf(),
 ) : UiState

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupState.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupState.kt
@@ -1,12 +1,12 @@
 package com.boostcamp.mapisode.mygroup.intent
 
 import androidx.compose.runtime.Immutable
-import com.boostcamp.mapisode.model.GroupModel
+import com.boostcamp.mapisode.model.GroupItem
 import com.boostcamp.mapisode.ui.base.UiState
 
 @Immutable
 data class GroupState(
-	val areGroupsLoading: Boolean,
-	val areGroupsVisible: Boolean,
-	val groups: List<GroupModel>,
+	val areGroupsLoading: Boolean = false,
+	val areGroupsVisible: Boolean = false,
+	val groups: List<GroupItem> = listOf(),
 ) : UiState

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupState.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupState.kt
@@ -3,9 +3,11 @@ package com.boostcamp.mapisode.mygroup.intent
 import androidx.compose.runtime.Immutable
 import com.boostcamp.mapisode.model.GroupItem
 import com.boostcamp.mapisode.ui.base.UiState
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.persistentListOf
 
 @Immutable
 data class GroupState(
 	val areGroupsLoading: Boolean = false,
-	val groups: List<GroupItem> = listOf(),
+	val groups: PersistentList<GroupItem> = persistentListOf(),
 ) : UiState

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupState.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupState.kt
@@ -2,12 +2,35 @@ package com.boostcamp.mapisode.mygroup.intent
 
 import androidx.compose.runtime.Immutable
 import com.boostcamp.mapisode.model.GroupItem
+import com.boostcamp.mapisode.model.User
 import com.boostcamp.mapisode.ui.base.UiState
-import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
 
 @Immutable
 data class GroupState(
 	val areGroupsLoading: Boolean = false,
-	val groups: PersistentList<GroupItem> = persistentListOf(),
+	val groups: ImmutableList<GroupItemUiModel> = persistentListOf(),
 ) : UiState
+
+@Immutable
+data class GroupItemUiModel(
+	val name: String,
+	val imageUrl: String,
+	val description: String,
+	val createdAt: String,
+	val adminUser: String,
+	val users: ImmutableList<User> = persistentListOf(),
+)
+
+fun GroupItem.toUiModel(): GroupItemUiModel = GroupItemUiModel(
+	name = name,
+	imageUrl = imageUrl,
+	description = description,
+	createdAt = createdAt,
+	adminUser = adminUser,
+	users = users.toPersistentList(),
+)
+
+fun List<GroupItem>.toUiModels(): List<GroupItemUiModel> = this.map { it.toUiModel() }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/navigation/GroupNavigation.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/navigation/GroupNavigation.kt
@@ -4,11 +4,11 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
-import com.boostcamp.mapisode.mygroup.GroupCreationScreen
-import com.boostcamp.mapisode.mygroup.GroupDetailScreen
-import com.boostcamp.mapisode.mygroup.GroupEditScreen
-import com.boostcamp.mapisode.mygroup.GroupJoinScreen
-import com.boostcamp.mapisode.mygroup.MainGroupRoute
+import com.boostcamp.mapisode.mygroup.screen.GroupCreationScreen
+import com.boostcamp.mapisode.mygroup.screen.GroupDetailScreen
+import com.boostcamp.mapisode.mygroup.screen.GroupEditScreen
+import com.boostcamp.mapisode.mygroup.screen.GroupJoinScreen
+import com.boostcamp.mapisode.mygroup.screen.MainGroupRoute
 import com.boostcamp.mapisode.navigation.GroupRoute
 import com.boostcamp.mapisode.navigation.MainRoute
 

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupCreationScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupCreationScreen.kt
@@ -1,4 +1,4 @@
-package com.boostcamp.mapisode.mygroup
+package com.boostcamp.mapisode.mygroup.screen
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupDetailScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupDetailScreen.kt
@@ -1,4 +1,4 @@
-package com.boostcamp.mapisode.mygroup
+package com.boostcamp.mapisode.mygroup.screen
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupEditScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupEditScreen.kt
@@ -1,4 +1,4 @@
-package com.boostcamp.mapisode.mygroup
+package com.boostcamp.mapisode.mygroup.screen
 
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupJoinScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupJoinScreen.kt
@@ -1,4 +1,4 @@
-package com.boostcamp.mapisode.mygroup
+package com.boostcamp.mapisode.mygroup.screen
 
 import androidx.compose.runtime.Composable
 import com.boostcamp.mapisode.designsystem.R

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -56,9 +57,17 @@ private fun GroupScreen(
 	val focusManager = LocalFocusManager.current
 	var isMenuPoppedUp by remember { mutableStateOf(false) }
 
-	viewModel.onIntent(GroupIntent.LoadGroups)
-
-	val groups = uiState.value.groups
+	LaunchedEffect(uiState) {
+		if (uiState.value.areGroupsLoading) {
+			if (uiState.value.groups.isEmpty()) {
+				viewModel.onIntent(GroupIntent.LoadGroups)
+			} else {
+				viewModel.confirmGroupsLoaded()
+			}
+		} else {
+			viewModel.onIntent(GroupIntent.LoadGroups)
+		}
+	}
 
 	MapisodeScaffold(
 		modifier = Modifier
@@ -117,7 +126,7 @@ private fun GroupScreen(
 				end = 30.dp,
 			),
 		) {
-			groups.forEach { group ->
+			uiState.value.groups.forEach { group ->
 				item {
 					GroupCard(
 						onGroupDetailClick = onGroupDetailClick,

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupScreen.kt
@@ -115,6 +115,7 @@ private fun GroupScreen(
 			repeat(20) {
 				item {
 					GroupCard(
+						onGroupDetailClick = onGroupDetailClick,
 						imageUrl = mockItem.imageUrl,
 						title = mockItem.title,
 						content = mockItem.content,

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupScreen.kt
@@ -64,8 +64,6 @@ private fun GroupScreen(
 			} else {
 				viewModel.confirmGroupsLoaded()
 			}
-		} else {
-			viewModel.onIntent(GroupIntent.LoadGroups)
 		}
 	}
 

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupScreen.kt
@@ -58,7 +58,7 @@ private fun GroupScreen(
 	var isMenuPoppedUp by remember { mutableStateOf(false) }
 
 	LaunchedEffect(uiState) {
-		if (uiState.value.areGroupsLoading) {
+		if (uiState.value.areGroupsLoading && !uiState.value.areGroupsVisible) {
 			if (uiState.value.groups.isEmpty()) {
 				viewModel.onIntent(GroupIntent.LoadGroups)
 			} else {

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupScreen.kt
@@ -16,6 +16,8 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.boostcamp.mapisode.designsystem.R
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIconButton
@@ -25,18 +27,21 @@ import com.boostcamp.mapisode.designsystem.compose.menu.MapisodeDropdownMenu
 import com.boostcamp.mapisode.designsystem.compose.menu.MapisodeDropdownMenuItem
 import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
 import com.boostcamp.mapisode.mygroup.component.GroupCard
-import com.boostcamp.mapisode.mygroup.component.ItemData
+import com.boostcamp.mapisode.mygroup.intent.GroupIntent
+import com.boostcamp.mapisode.mygroup.viewmodel.GroupViewModel
 
 @Composable
 internal fun MainGroupRoute(
 	onGroupJoinClick: () -> Unit,
 	onGroupDetailClick: () -> Unit,
 	onGroupCreationClick: () -> Unit,
+	viewModel: GroupViewModel = hiltViewModel(),
 ) {
 	GroupScreen(
 		onGroupJoinClick = onGroupJoinClick,
 		onGroupDetailClick = onGroupDetailClick,
 		onGroupCreationClick = onGroupCreationClick,
+		viewModel = viewModel,
 	)
 }
 
@@ -45,9 +50,15 @@ private fun GroupScreen(
 	onGroupJoinClick: () -> Unit,
 	onGroupDetailClick: () -> Unit,
 	onGroupCreationClick: () -> Unit,
+	viewModel: GroupViewModel,
 ) {
+	val uiState = viewModel.uiState.collectAsStateWithLifecycle()
 	val focusManager = LocalFocusManager.current
 	var isMenuPoppedUp by remember { mutableStateOf(false) }
+
+	viewModel.onIntent(GroupIntent.LoadGroups)
+
+	val groups = uiState.value.groups
 
 	MapisodeScaffold(
 		modifier = Modifier
@@ -97,12 +108,6 @@ private fun GroupScreen(
 			)
 		},
 	) {
-		val mockItem = ItemData(
-			imageUrl = "https://avatars.githubusercontent.com/u/127717111?v=4",
-			title = "나의 에피소드",
-			content = "개인용",
-		)
-
 		LazyVerticalGrid(
 			modifier = Modifier
 				.padding(it),
@@ -112,13 +117,13 @@ private fun GroupScreen(
 				end = 30.dp,
 			),
 		) {
-			repeat(20) {
+			groups.forEach { group ->
 				item {
 					GroupCard(
 						onGroupDetailClick = onGroupDetailClick,
-						imageUrl = mockItem.imageUrl,
-						title = mockItem.title,
-						content = mockItem.content,
+						imageUrl = group.imageUrl,
+						title = group.name,
+						content = group.users.size.toString(),
 					)
 				}
 			}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupScreen.kt
@@ -1,16 +1,16 @@
 package com.boostcamp.mapisode.mygroup.screen
 
 import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
@@ -21,13 +21,11 @@ import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIconButton
 import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
 import com.boostcamp.mapisode.designsystem.compose.MapisodeText
-import com.boostcamp.mapisode.designsystem.compose.MapisodeTextField
-import com.boostcamp.mapisode.designsystem.compose.button.MapisodeFilledButton
-import com.boostcamp.mapisode.designsystem.compose.button.MapisodeOutlinedButton
 import com.boostcamp.mapisode.designsystem.compose.menu.MapisodeDropdownMenu
 import com.boostcamp.mapisode.designsystem.compose.menu.MapisodeDropdownMenuItem
 import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
-import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
+import com.boostcamp.mapisode.mygroup.component.GroupCard
+import com.boostcamp.mapisode.mygroup.component.ItemData
 
 @Composable
 internal fun MainGroupRoute(
@@ -99,65 +97,30 @@ private fun GroupScreen(
 			)
 		},
 	) {
-		Column(
+		val mockItem = ItemData(
+			imageUrl = "https://avatars.githubusercontent.com/u/127717111?v=4",
+			title = "나의 에피소드",
+			content = "개인용",
+		)
+
+		LazyVerticalGrid(
 			modifier = Modifier
-				.fillMaxSize()
-				.padding(it)
-				.padding(horizontal = 46.dp),
-			verticalArrangement = Arrangement.spacedBy(16.dp),
-			horizontalAlignment = Alignment.CenterHorizontally,
+				.padding(it),
+			columns = GridCells.Fixed(2),
+			contentPadding = PaddingValues(
+				start = 30.dp,
+				end = 30.dp,
+			),
 		) {
-			var inputText by remember { mutableStateOf("") }
-			var submittedText by remember { mutableStateOf("") }
-
-			MapisodeFilledButton(
-				onClick = {
-					submittedText = "활성화 버튼"
-					focusManager.clearFocus()
-				},
-				text = "활성화 버튼",
-				showRipple = true,
-			)
-
-			MapisodeFilledButton(
-				onClick = { },
-				text = "비활성화 버튼",
-				enabled = false,
-			)
-
-			MapisodeOutlinedButton(
-				onClick = { submittedText = "아웃라인 버튼 클릭" },
-				text = "아웃라인 버튼",
-				showRipple = true,
-			)
-
-			MapisodeTextField(
-				value = inputText,
-				onValueChange = { text -> inputText = text },
-				placeholder = "텍스트 필드",
-				onSubmitInput = { text ->
-					submittedText = text
-				},
-			)
-
-			MapisodeText(
-				text = submittedText,
-				style = MapisodeTheme.typography.bodyLarge,
-			)
-
-			MapisodeTextField(
-				value = inputText,
-				onValueChange = { text -> inputText = text },
-				placeholder = "위치를 입력하세요",
-				onSubmitInput = { text ->
-					submittedText = text
-				},
-				trailingIcon = {
-					MapisodeIcon(
-						id = R.drawable.ic_location,
+			repeat(20) {
+				item {
+					GroupCard(
+						imageUrl = mockItem.imageUrl,
+						title = mockItem.title,
+						content = mockItem.content,
 					)
-				},
-			)
+				}
+			}
 		}
 	}
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupScreen.kt
@@ -57,13 +57,12 @@ private fun GroupScreen(
 	val focusManager = LocalFocusManager.current
 	var isMenuPoppedUp by remember { mutableStateOf(false) }
 
-	LaunchedEffect(uiState) {
-		if (uiState.value.areGroupsLoading && !uiState.value.areGroupsVisible) {
-			if (uiState.value.groups.isEmpty()) {
-				viewModel.onIntent(GroupIntent.LoadGroups)
-			} else {
-				viewModel.confirmGroupsLoaded()
-			}
+	LaunchedEffect(uiState.value) {
+		if (uiState.value.groups.isEmpty()) {
+			viewModel.onIntent(GroupIntent.LoadGroups)
+		}
+		if (uiState.value.areGroupsLoading && uiState.value.groups.isNotEmpty()) {
+			viewModel.onIntent(GroupIntent.EndLoadingGroups)
 		}
 	}
 

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupScreen.kt
@@ -1,4 +1,4 @@
-package com.boostcamp.mapisode.mygroup
+package com.boostcamp.mapisode.mygroup.screen
 
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupViewModel.kt
@@ -18,6 +18,10 @@ class GroupViewModel @Inject constructor() :
 			is GroupIntent.LoadGroups -> {
 				loadGroups()
 			}
+
+			is GroupIntent.EndLoadingGroups -> {
+				confirmGroupsLoaded()
+			}
 		}
 	}
 
@@ -30,11 +34,10 @@ class GroupViewModel @Inject constructor() :
 		}
 	}
 
-	fun confirmGroupsLoaded() {
+	private fun confirmGroupsLoaded() {
 		intent {
 			copy(
 				areGroupsLoading = false,
-				areGroupsVisible = true,
 			)
 		}
 	}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupViewModel.kt
@@ -1,0 +1,49 @@
+package com.boostcamp.mapisode.mygroup.viewmodel
+
+import com.boostcamp.mapisode.model.GroupItem
+import com.boostcamp.mapisode.model.User
+import com.boostcamp.mapisode.mygroup.intent.GroupIntent
+import com.boostcamp.mapisode.mygroup.intent.GroupSideEffect
+import com.boostcamp.mapisode.mygroup.intent.GroupState
+import com.boostcamp.mapisode.ui.base.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class GroupViewModel @Inject constructor() :
+	BaseViewModel<GroupState, GroupSideEffect>(GroupState()) {
+
+	fun onIntent(intent: GroupIntent) {
+		when (intent) {
+			is GroupIntent.LoadGroups -> {
+				loadGroups()
+			}
+		}
+	}
+
+	private fun loadGroups() {
+		intent {
+			copy(
+				areGroupsLoading = true,
+				groups = mockItems,
+			)
+		}
+	}
+}
+
+val mockItem = GroupItem(
+	name = "Group 1",
+	imageUrl = "https://avatars.githubusercontent.com/u/127717111?v=4",
+	description = "Description for Group 1",
+	createdAt = "2021-08-01",
+	adminUser = "Admin 1",
+	users = listOf(
+		User(
+			id = "User1",
+			displayName = "DisplayName1",
+			idToken = "Token1",
+		),
+	),
+)
+
+private val mockItems: List<GroupItem> = List(20) { mockItem }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupViewModel.kt
@@ -1,13 +1,14 @@
 package com.boostcamp.mapisode.mygroup.viewmodel
 
-import com.boostcamp.mapisode.model.GroupItem
 import com.boostcamp.mapisode.model.User
 import com.boostcamp.mapisode.mygroup.intent.GroupIntent
+import com.boostcamp.mapisode.mygroup.intent.GroupItemUiModel
 import com.boostcamp.mapisode.mygroup.intent.GroupSideEffect
 import com.boostcamp.mapisode.mygroup.intent.GroupState
 import com.boostcamp.mapisode.ui.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import javax.inject.Inject
 
 @HiltViewModel
@@ -30,7 +31,7 @@ class GroupViewModel @Inject constructor() :
 		intent {
 			copy(
 				areGroupsLoading = true,
-				groups = mockItems.toPersistentList(),
+				groups = mockItems.toImmutableList(),
 			)
 		}
 	}
@@ -44,13 +45,13 @@ class GroupViewModel @Inject constructor() :
 	}
 }
 
-val mockItem = GroupItem(
+val mockItem = GroupItemUiModel(
 	name = "Group 1",
 	imageUrl = "https://avatars.githubusercontent.com/u/127717111?v=4",
 	description = "Description for Group 1",
 	createdAt = "2021-08-01",
 	adminUser = "Admin 1",
-	users = listOf(
+	users = persistentListOf(
 		User(
 			id = "User1",
 			displayName = "DisplayName1",
@@ -59,4 +60,4 @@ val mockItem = GroupItem(
 	),
 )
 
-private val mockItems: List<GroupItem> = List(20) { mockItem }
+private val mockItems: List<GroupItemUiModel> = List(20) { mockItem }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupViewModel.kt
@@ -29,6 +29,15 @@ class GroupViewModel @Inject constructor() :
 			)
 		}
 	}
+
+	fun confirmGroupsLoaded() {
+		intent {
+			copy(
+				areGroupsLoading = false,
+				areGroupsVisible = true,
+			)
+		}
+	}
 }
 
 val mockItem = GroupItem(

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupViewModel.kt
@@ -7,6 +7,7 @@ import com.boostcamp.mapisode.mygroup.intent.GroupSideEffect
 import com.boostcamp.mapisode.mygroup.intent.GroupState
 import com.boostcamp.mapisode.ui.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.toPersistentList
 import javax.inject.Inject
 
 @HiltViewModel
@@ -29,7 +30,7 @@ class GroupViewModel @Inject constructor() :
 		intent {
 			copy(
 				areGroupsLoading = true,
-				groups = mockItems,
+				groups = mockItems.toPersistentList(),
 			)
 		}
 	}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -93,6 +93,7 @@ androidx-credential = { group = "androidx.credentials", name = "credentials", ve
 # Coil
 coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
 coil-network-okhttp = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }
+coil-test = { group = "io.coil-kt.coil3", name = "coil-test", version.ref = "coil" }
 
 # Compose
 compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }
@@ -210,7 +211,8 @@ coroutines = [
 # Coil Libraries
 coil = [
 	"coil-compose",
-	"coil-network-okhttp"
+	"coil-network-okhttp",
+	"coil-test"
 ]
 
 # Datastore


### PR DESCRIPTION
- closed #93 

## *📍 Work Description*

- Group Card 생성
- 그룹 화면에 LazyGrid 2열로 Group Card 배치
- mvi 주요 세가지 state, event(intent로 명명), sideEffect 선언
- viewmodel 선언

## *📸 Screenshot*

https://github.com/user-attachments/assets/69cc7091-08eb-4977-b89f-89196a9c3f17

## *📢 To Reviewers*
- 태희님이 적용한 mvi 코드와 [A robust MVI implementation with Jetpack Compose](https://proandroiddev.com/a-robust-mvi-with-jetpack-compose-e08882d2c4ff) 블로그 글을 보며 적용했습니다.
- 현재 그룹들을 로딩하는 event(intent) 와 로딩중,로딩완료, 그룹들 세가지를 포함하는 state를 정의하여 사용했습니다.
  - sideEffect는 현재 사용하지 않고 있습니다.
- state, event(intent), sideEffect 클래스는 전부 @Immutable 를 붙혀서 불변으로 설정했습니다.
- Screen에서는 LaunchedEffect를 사용해 uiState를 키로 하여 그룹들을 로딩하고 업데이트된 상태를 받는 로직을 설정했습니다.

## ⏲️Time

    - 4시간
