### PR TITLE
[FIX/#96] Designsystem / FilledButton 비활성화 텍스트 별도 표시

### DIFF
--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeFilledButton.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeFilledButton.kt
@@ -26,6 +26,7 @@ fun MapisodeFilledButton(
 	onClick: () -> Unit,
 	modifier: Modifier = Modifier,
 	text: String,
+	disabledText: String = text,
 	textStyle: MapisodeTextStyle = MapisodeTheme.typography.titleLarge,
 	enabled: Boolean = true,
 	@DrawableRes leftIcon: Int? = null,
@@ -61,7 +62,7 @@ fun MapisodeFilledButton(
 		}
 
 		MapisodeText(
-			text = text,
+			text = if (enabled) text else disabledText,
 			color = MapisodeTheme.colorScheme.filledButtonContent,
 			style = textStyle,
 		)


### PR DESCRIPTION
- closed #96

## *📍 Work Description*

- 기존에 사용하는 곳에서 영향을 안주기 위해 비활성화 때 나타나는 텍스트 인자를 추가하고 기본값을 기존에 띄우는 텍스트 인자로 설정

## *📸 Screenshot*

<img src="https://github.com/user-attachments/assets/a756c2d3-b525-4f1d-b547-8de5f9a7df25" width=600>

## *📢 To Reviewers*
- 버튼을 비활성화할 때 텍스트 별도로 띄우는 기능 추가했습니다.

## ⏲️Time

    - 0.4시간
