### PR TITLE
[FEAT/#100] 에피소드 생성 시 이미지 첨부 및 장소 선택 시 디바운스 처리

### DIFF
--- a/core/firebase/src/main/java/com/boostcamp/mapisode/firebase/firestore/StorageConstants.kt
+++ b/core/firebase/src/main/java/com/boostcamp/mapisode/firebase/firestore/StorageConstants.kt
@@ -1,0 +1,5 @@
+package com.boostcamp.mapisode.firebase.firestore
+
+object StorageConstants {
+	const val PATH_IMAGES = "images"
+}

--- a/data/episode/build.gradle.kts
+++ b/data/episode/build.gradle.kts
@@ -12,4 +12,5 @@ dependencies {
 	implementation(projects.core.firebase)
 	implementation(platform(libs.firebase.bom))
 	implementation(libs.firebase.firestore)
+	implementation(libs.firebase.storage)
 }

--- a/data/episode/src/main/java/com/boostcamp/mapisode/episode/EpisodeRepositoryImpl.kt
+++ b/data/episode/src/main/java/com/boostcamp/mapisode/episode/EpisodeRepositoryImpl.kt
@@ -113,9 +113,7 @@ class EpisodeRepositoryImpl @Inject constructor(
 
 	override suspend fun createEpisode(episodeModel: EpisodeModel): String {
 		val newEpisodeId = UUID.randomUUID().toString().replace("-", "")
-		Timber.d(episodeModel.imageUrls.toString())
 		val uploadedImageUrls = uploadImagesToStorage(newEpisodeId, episodeModel.imageUrls)
-		Timber.d(uploadedImageUrls.toString())
 		return try {
 			episodeCollection
 				.document(newEpisodeId)
@@ -142,14 +140,13 @@ class EpisodeRepositoryImpl @Inject constructor(
 					if (task.isSuccessful) {
 						CoroutineScope(Dispatchers.IO).launch {
 							val downloadUrl = imageRef.downloadUrl.await()
-							Timber.d("Image URL: $downloadUrl")
+							imageStorageUrls.add(downloadUrl.toString())
 						}
 					} else {
 						Timber.e(task.exception)
 						throw task.exception ?: RuntimeException("Image upload failed")
 					}
 				}.await()
-			imageStorageUrls.add(imageRef.downloadUrl.await().toString())
 		}
 
 		return imageStorageUrls

--- a/data/episode/src/main/java/com/boostcamp/mapisode/episode/di/DataModule.kt
+++ b/data/episode/src/main/java/com/boostcamp/mapisode/episode/di/DataModule.kt
@@ -3,6 +3,8 @@ package com.boostcamp.mapisode.episode.di
 import com.google.firebase.Firebase
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.firestore
+import com.google.firebase.storage.FirebaseStorage
+import com.google.firebase.storage.storage
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -13,4 +15,7 @@ import dagger.hilt.components.SingletonComponent
 object DataModule {
 	@Provides
 	fun provideFirebaseFirestore(): FirebaseFirestore = Firebase.firestore
+
+	@Provides
+	fun provideFirebaseStorage(): FirebaseStorage = Firebase.storage
 }

--- a/data/episode/src/main/java/com/boostcamp/mapisode/episode/model/ModelConverter.kt
+++ b/data/episode/src/main/java/com/boostcamp/mapisode/episode/model/ModelConverter.kt
@@ -5,7 +5,10 @@ import com.google.firebase.Timestamp
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.GeoPoint
 
-internal fun EpisodeModel.toFirestoreModel(database: FirebaseFirestore): EpisodeFirestoreModel =
+internal fun EpisodeModel.toFirestoreModel(
+	database: FirebaseFirestore,
+	imageUrls: List<String>,
+): EpisodeFirestoreModel =
 	EpisodeFirestoreModel(
 		category = category,
 		content = content,

--- a/feature/episode/build.gradle.kts
+++ b/feature/episode/build.gradle.kts
@@ -8,5 +8,6 @@ android {
 
 dependencies {
 	implementation(project.libs.bundles.naverMap)
+	implementation(project.libs.bundles.coil)
 	implementation(projects.domain.episode)
 }

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/EpisodeScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/EpisodeScreen.kt
@@ -28,6 +28,9 @@ internal fun EpisodeRoute(
 		composable("new_episode_pics") {
 			NewEpisodePicsScreen(
 				navController = newEpisodeNavController,
+				updatePics = { uris ->
+					viewModel.onIntent(NewEpisodeIntent.SetEpisodePics(uris))
+				},
 			)
 		}
 

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeContentScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeContentScreen.kt
@@ -12,7 +12,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -37,8 +37,8 @@ internal fun NewEpisodeContentScreen(
 	navController: NavController,
 	submitEpisode: (NewEpisodeContent) -> Unit = {},
 ) {
-	var titleValue by remember { mutableStateOf(state.episodeContent.title) }
-	var descriptionValue by remember { mutableStateOf(state.episodeContent.description) }
+	var titleValue by rememberSaveable { mutableStateOf(state.episodeContent.title) }
+	var descriptionValue by rememberSaveable { mutableStateOf(state.episodeContent.description) }
 
 	MapisodeScaffold(
 		topBar = {
@@ -97,6 +97,8 @@ internal fun NewEpisodeContentScreen(
 							state.episodeContent.images,
 						),
 					)
+					titleValue = ""
+					descriptionValue = ""
 					navController.popBackStack("new_episode_pics", inclusive = false)
 				},
 				text = stringResource(R.string.new_episode_create_episode),

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeContentScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeContentScreen.kt
@@ -1,6 +1,5 @@
 package com.boostcamp.mapisode.episode
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -16,13 +15,12 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
+import coil3.compose.AsyncImage
 import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
 import com.boostcamp.mapisode.designsystem.compose.MapisodeText
 import com.boostcamp.mapisode.designsystem.compose.Surface
@@ -79,13 +77,10 @@ internal fun NewEpisodeContentScreen(
 						horizontalArrangement = Arrangement.spacedBy(10.dp),
 					) {
 						items(state.episodeContent.images) { imageUri ->
-							// TODO: 이미지 URI를 바탕으로 컴포넌트 생성하기
 							Surface(Modifier.size(150.dp)) {
-								Image(
+								AsyncImage(
+									model = imageUri,
 									contentDescription = null,
-									imageVector = ImageVector.vectorResource(
-										com.boostcamp.mapisode.designsystem.R.drawable.ic_see,
-									),
 								)
 							}
 						}

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeContentScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeContentScreen.kt
@@ -16,6 +16,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
@@ -37,8 +39,12 @@ internal fun NewEpisodeContentScreen(
 	navController: NavController,
 	submitEpisode: (NewEpisodeContent) -> Unit = {},
 ) {
-	var titleValue by rememberSaveable { mutableStateOf(state.episodeContent.title) }
-	var descriptionValue by rememberSaveable { mutableStateOf(state.episodeContent.description) }
+	var titleValue by rememberSaveable(stateSaver = TextFieldValue.Saver) {
+		mutableStateOf(TextFieldValue(state.episodeContent.title))
+	}
+	var descriptionValue by rememberSaveable(stateSaver = TextFieldValue.Saver) {
+		mutableStateOf(TextFieldValue(state.episodeContent.description))
+	}
 
 	MapisodeScaffold(
 		topBar = {
@@ -57,15 +63,15 @@ internal fun NewEpisodeContentScreen(
 				EpisodeTextFieldGroup(
 					labelRes = R.string.new_episode_content_title,
 					placeholderRes = R.string.new_episode_content_placeholder_title,
-					value = titleValue,
-					onValueChange = { titleValue = it },
+					value = titleValue.text,
+					onValueChange = { titleValue = TextFieldValue(it, TextRange(it.length)) },
 				)
 				EpisodeTextFieldGroup(
 					modifier = Modifier.fillMaxHeight(0.3f),
 					labelRes = R.string.new_episode_content_description,
 					placeholderRes = R.string.new_episode_content_placeholder_description,
-					value = descriptionValue,
-					onValueChange = { descriptionValue = it },
+					value = descriptionValue.text,
+					onValueChange = { descriptionValue = TextFieldValue(it, TextRange(it.length)) },
 				)
 				Column(textFieldModifier, verticalArrangement = textFieldVerticalArrangement) {
 					MapisodeText(
@@ -92,13 +98,13 @@ internal fun NewEpisodeContentScreen(
 				onClick = {
 					submitEpisode(
 						NewEpisodeContent(
-							titleValue,
-							descriptionValue,
+							titleValue.text,
+							descriptionValue.text,
 							state.episodeContent.images,
 						),
 					)
-					titleValue = ""
-					descriptionValue = ""
+					titleValue = TextFieldValue("")
+					descriptionValue = TextFieldValue("")
 					navController.popBackStack("new_episode_pics", inclusive = false)
 				},
 				text = stringResource(R.string.new_episode_create_episode),

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeContentScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeContentScreen.kt
@@ -90,7 +90,13 @@ internal fun NewEpisodeContentScreen(
 			MapisodeFilledButton(
 				modifier = textFieldModifier,
 				onClick = {
-					submitEpisode(NewEpisodeContent(titleValue, descriptionValue))
+					submitEpisode(
+						NewEpisodeContent(
+							titleValue,
+							descriptionValue,
+							state.episodeContent.images,
+						),
+					)
 					navController.popBackStack("new_episode_pics", inclusive = false)
 				},
 				text = stringResource(R.string.new_episode_create_episode),

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeInfoScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeInfoScreen.kt
@@ -243,7 +243,7 @@ private fun DatePickerDialogColors(): DatePickerColors =
 
 private const val DATE_STRING_FORMAT = "yyyy. MM. dd"
 
-private fun latLngString(latLng: LatLng): String =
+internal fun latLngString(latLng: LatLng): String =
 	String.format(Locale.getDefault(), "%.6f, %.6f", latLng.latitude, latLng.longitude)
 
 private fun dateString(date: Date): String =

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeInfoScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeInfoScreen.kt
@@ -39,7 +39,6 @@ import com.boostcamp.mapisode.episode.common.NewEpisodeConstant.textFieldModifie
 import com.boostcamp.mapisode.episode.intent.NewEpisodeInfo
 import com.boostcamp.mapisode.episode.intent.NewEpisodeState
 import com.naver.maps.geometry.LatLng
-import timber.log.Timber
 import java.util.Date
 import java.util.Locale
 
@@ -87,7 +86,6 @@ internal fun NewEpisodeInfoScreen(
 							onClick = {
 								showDatePickerDialog = false
 								datePickerState.selectedDateMillis?.let {
-									Timber.d(it.toString())
 									updateDate(Date(it))
 								}
 							},

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeInfoScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeInfoScreen.kt
@@ -235,11 +235,13 @@ private fun DatePickerDialogColors(): DatePickerColors =
 		todayDateBorderColor = MapisodeTheme.colorScheme.dialogConfirm,
 	)
 
+private const val DATE_STRING_FORMAT = "yyyy. MM. dd"
+
 private fun latLngString(latLng: LatLng): String =
 	String.format(Locale.getDefault(), "%.6f, %.6f", latLng.latitude, latLng.longitude)
 
 private fun dateString(date: Date): String =
-	DateFormat.format("yyyy. MM. dd", date).toString()
+	DateFormat.format(DATE_STRING_FORMAT, date).toString()
 
 @Preview
 @Composable

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeInfoScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeInfoScreen.kt
@@ -15,8 +15,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
@@ -51,9 +54,11 @@ internal fun NewEpisodeInfoScreen(
 ) {
 	var isGroupDropdownExpanded by remember { mutableStateOf(false) }
 	var isCategoryDropdownExpanded by remember { mutableStateOf(false) }
-	var isGroupBlank by remember { mutableStateOf(false) }
-	var isCategoryBlank by remember { mutableStateOf(false) }
-	var tagValue by remember { mutableStateOf(state.episodeInfo.tags) }
+	var isGroupBlank by rememberSaveable { mutableStateOf(false) }
+	var isCategoryBlank by rememberSaveable { mutableStateOf(false) }
+	var tagValue by rememberSaveable(stateSaver = TextFieldValue.Saver) {
+		mutableStateOf(TextFieldValue(state.episodeInfo.tags))
+	}
 	var showDatePickerDialog by remember { mutableStateOf(false) }
 	val datePickerState = rememberDatePickerState()
 
@@ -187,9 +192,9 @@ internal fun NewEpisodeInfoScreen(
 				EpisodeTextFieldGroup(
 					labelRes = R.string.new_episode_info_tags,
 					placeholderRes = R.string.new_episode_info_placeholder_tags,
-					value = tagValue,
-					onValueChange = { tagValue = it },
-					onSubmitInput = { tagValue = it },
+					value = tagValue.text,
+					onValueChange = { tagValue = TextFieldValue(it, TextRange(it.length)) },
+					onSubmitInput = { tagValue = TextFieldValue(it, TextRange(it.length)) },
 				)
 				EpisodeTextFieldGroup(
 					labelRes = R.string.new_episode_info_date,
@@ -215,7 +220,7 @@ internal fun NewEpisodeInfoScreen(
 					updateEpisodeInfo(
 						state.episodeInfo.copy(
 							location = state.cameraPosition.target,
-							tags = tagValue,
+							tags = tagValue.text,
 						),
 					)
 					navController.navigate("new_episode_content")

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeInfoScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeInfoScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
@@ -225,7 +226,7 @@ internal fun NewEpisodeInfoScreen(
 					)
 					navController.navigate("new_episode_content")
 				},
-				text = "다음",
+				text = stringResource(R.string.new_episode_info_next),
 			)
 		}
 	}

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodePicsScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodePicsScreen.kt
@@ -17,7 +17,6 @@ import com.boostcamp.mapisode.designsystem.compose.MapisodeIconButton
 import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
 import com.boostcamp.mapisode.designsystem.compose.button.MapisodeFilledButton
 import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
-import timber.log.Timber
 
 @Composable
 internal fun NewEpisodePicsScreen(
@@ -65,7 +64,6 @@ fun PickEpisodePhotoButton(
 	val photoPickLauncher = rememberLauncherForActivityResult(
 		contract = ActivityResultContracts.PickMultipleVisualMedia(4),
 		onResult = { uris ->
-			Timber.d(uris.toString())
 			onPickPhotos(uris)
 		},
 	)

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodePicsScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodePicsScreen.kt
@@ -76,6 +76,6 @@ fun PickEpisodePhotoButton(
 				PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly),
 			)
 		},
-		text = "사진 추가",
+		text = stringResource(R.string.new_episode_menu_add_pictures),
 	)
 }

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodePicsScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodePicsScreen.kt
@@ -33,6 +33,7 @@ internal fun NewEpisodePicsScreen(
 						onClick = {
 							navController.navigate("new_episode_info")
 						},
+						enabled = false,
 					) {
 						MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_arrow_forward_ios)
 					}
@@ -49,7 +50,9 @@ internal fun NewEpisodePicsScreen(
 		) {
 			PickEpisodePhotoButton { uris ->
 				updatePics(uris)
-				navController.navigate("new_episode_info")
+				if (uris.isNotEmpty()) {
+					navController.navigate("new_episode_info")
+				}
 			}
 		}
 	}

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodePicsScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodePicsScreen.kt
@@ -17,11 +17,13 @@ import com.boostcamp.mapisode.designsystem.compose.MapisodeIconButton
 import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
 import com.boostcamp.mapisode.designsystem.compose.button.MapisodeFilledButton
 import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
 
 @Composable
 internal fun NewEpisodePicsScreen(
 	navController: NavController,
-	updatePics: (List<Uri>) -> Unit,
+	updatePics: (PersistentList<Uri>) -> Unit,
 ) {
 	MapisodeScaffold(
 		topBar = {
@@ -59,12 +61,12 @@ internal fun NewEpisodePicsScreen(
 
 @Composable
 fun PickEpisodePhotoButton(
-	onPickPhotos: (List<Uri>) -> Unit,
+	onPickPhotos: (PersistentList<Uri>) -> Unit,
 ) {
 	val photoPickLauncher = rememberLauncherForActivityResult(
 		contract = ActivityResultContracts.PickMultipleVisualMedia(4),
 		onResult = { uris ->
-			onPickPhotos(uris)
+			onPickPhotos(uris.toPersistentList())
 		},
 	)
 

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodePicsScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodePicsScreen.kt
@@ -1,5 +1,9 @@
 package com.boostcamp.mapisode.episode
 
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -11,12 +15,15 @@ import androidx.navigation.NavController
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIconButton
 import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
-import com.boostcamp.mapisode.designsystem.compose.MapisodeText
+import com.boostcamp.mapisode.designsystem.compose.button.MapisodeFilledButton
 import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
-import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
+import timber.log.Timber
 
 @Composable
-internal fun NewEpisodePicsScreen(navController: NavController) {
+internal fun NewEpisodePicsScreen(
+	navController: NavController,
+	updatePics: (List<Uri>) -> Unit,
+) {
 	MapisodeScaffold(
 		topBar = {
 			TopAppBar(
@@ -40,10 +47,32 @@ internal fun NewEpisodePicsScreen(navController: NavController) {
 				.padding(innerPadding),
 			contentAlignment = Alignment.Center,
 		) {
-			MapisodeText(
-				text = "사진 선택 화면",
-				style = MapisodeTheme.typography.displayLarge,
-			)
+			PickEpisodePhotoButton { uris ->
+				updatePics(uris)
+				navController.navigate("new_episode_info")
+			}
 		}
 	}
+}
+
+@Composable
+fun PickEpisodePhotoButton(
+	onPickPhotos: (List<Uri>) -> Unit,
+) {
+	val photoPickLauncher = rememberLauncherForActivityResult(
+		contract = ActivityResultContracts.PickMultipleVisualMedia(4),
+		onResult = { uris ->
+			Timber.d(uris.toString())
+			onPickPhotos(uris)
+		},
+	)
+
+	MapisodeFilledButton(
+		onClick = {
+			photoPickLauncher.launch(
+				PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly),
+			)
+		},
+		text = "사진 추가",
+	)
 }

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/PickLocationScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/PickLocationScreen.kt
@@ -7,10 +7,14 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIconButton
@@ -29,8 +33,12 @@ import com.naver.maps.map.compose.Marker
 import com.naver.maps.map.compose.NaverMap
 import com.naver.maps.map.compose.rememberFusedLocationSource
 import com.naver.maps.map.compose.rememberMarkerState
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.debounce
 
-@OptIn(ExperimentalNaverMapApi::class)
+@OptIn(ExperimentalNaverMapApi::class, FlowPreview::class)
 @Composable
 internal fun PickLocationScreen(
 	cameraPositionState: CameraPositionState,
@@ -39,6 +47,18 @@ internal fun PickLocationScreen(
 ) {
 	val episodeMarkerState = rememberMarkerState()
 	episodeMarkerState.position = cameraPositionState.position.target
+	val locationStateFlow = remember {
+		MutableStateFlow(cameraPositionState.position.target)
+	}
+	val location by locationStateFlow.collectAsStateWithLifecycle()
+
+	LaunchedEffect(cameraPositionState.position.target) {
+		locationStateFlow
+			.debounce(500L)
+			.collectLatest {
+				locationStateFlow.value = cameraPositionState.position.target
+			}
+	}
 
 	MapisodeScaffold(
 		isStatusBarPaddingExist = true,
@@ -82,7 +102,7 @@ internal fun PickLocationScreen(
 						style = MapisodeTheme.typography.headlineSmall,
 					)
 					MapisodeText(
-						text = stringResource(R.string.new_episode_info_placeholder_location),
+						text = latLngString(location),
 						style = MapisodeTheme.typography.bodyLarge,
 					)
 					MapisodeFilledButton(

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/intent/NewEpisodeIntent.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/intent/NewEpisodeIntent.kt
@@ -1,8 +1,8 @@
 package com.boostcamp.mapisode.episode.intent
 
+import android.net.Uri
 import com.boostcamp.mapisode.ui.base.UiIntent
 import com.naver.maps.geometry.LatLng
-import android.net.Uri
 import kotlinx.collections.immutable.PersistentList
 import java.util.Date
 

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/intent/NewEpisodeIntent.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/intent/NewEpisodeIntent.kt
@@ -2,9 +2,12 @@ package com.boostcamp.mapisode.episode.intent
 
 import com.boostcamp.mapisode.ui.base.UiIntent
 import com.naver.maps.geometry.LatLng
+import android.net.Uri
+import kotlinx.collections.immutable.PersistentList
 import java.util.Date
 
 sealed class NewEpisodeIntent : UiIntent {
+	data class SetEpisodePics(val pics: PersistentList<Uri>) : NewEpisodeIntent()
 	data class SetEpisodeLocation(val latLng: LatLng) : NewEpisodeIntent()
 	data class SetEpisodeGroup(val group: String) : NewEpisodeIntent()
 	data class SetEpisodeCategory(val category: String) : NewEpisodeIntent()

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/intent/NewEpisodeState.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/intent/NewEpisodeState.kt
@@ -7,6 +7,8 @@ import com.boostcamp.mapisode.model.EpisodeModel
 import com.boostcamp.mapisode.ui.base.UiState
 import com.naver.maps.geometry.LatLng
 import com.naver.maps.map.CameraPosition
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
 import java.util.Date
 
 data class NewEpisodeState(
@@ -44,5 +46,5 @@ data class NewEpisodeInfo(
 data class NewEpisodeContent(
 	val title: String = "",
 	val description: String = "",
-	val images: List<Uri> = emptyList(),
+	val images: PersistentList<Uri> = emptyList<Uri>().toPersistentList(),
 )

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/intent/NewEpisodeViewModel.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/intent/NewEpisodeViewModel.kt
@@ -16,6 +16,14 @@ class NewEpisodeViewModel @Inject constructor(private val episodeRepository: Epi
 
 	override fun onIntent(intent: NewEpisodeIntent) {
 		when (intent) {
+			is NewEpisodeIntent.SetEpisodePics -> {
+				intent {
+					copy(
+						episodeContent = episodeContent.copy(images = intent.pics),
+					)
+				}
+			}
+
 			is NewEpisodeIntent.SetEpisodeLocation -> {
 				intent {
 					copy(

--- a/feature/episode/src/main/res/values/strings.xml
+++ b/feature/episode/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
 <resources>
 	<string name="new_episode_menu_title">새 에피소드</string>
 	<string name="new_episode_menu_create_episode">에피소드 생성</string>
+	<string name="new_episode_menu_add_pictures">사진 추가</string>
 
 	<string name="new_episode_info_location">장소</string>
 	<string name="new_episode_info_group">그룹</string>

--- a/feature/episode/src/main/res/values/strings.xml
+++ b/feature/episode/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
 	<string name="new_episode_info_placeholder_category">카테고리를 선택해주세요</string>
 	<string name="new_episode_info_placeholder_tags">태그를 입력해주세요</string>
 	<string name="new_episode_info_placeholder_date">날짜를 입력해주세요</string>
+	<string name="new_episode_info_next">다음</string>
 
 	<string name="new_episode_pick_location">이 장소로 할래요</string>
 	<string name="new_episode_pick_location_button">장소 선택하기</string>


### PR DESCRIPTION
- closed #100
## *📍 Work Description*

- 에피소드 생성 시, 이미지를 첨부하는 기능을 추가했습니다. (현재는 Android PhotoPicker 로 구현되어 있으며, 추후 커스텀 PhotoPicker 가 구현되면 교체 예정)
- 장소 선택 화면에서, 이동 시 위치 변경의 디바운스 처리를 추가하였습니다. (이후 위치를 기반으로 주소를 가져오는 API 대응을 위해)
## *📸 Screenshot*
[100-1.webm](https://github.com/user-attachments/assets/f91a20c4-27c7-4629-85c6-524cc6c00837)

## *📢 To Reviewers*
> 이 다음 구현할 것은, core:network 모듈이 될 것 같습니다. (장소에 따른 주소를 가져오는 API 를 구현할 필요가 있기 때문입니다.)

> 역시나 책임없는 리뷰공격 부탁드립니다! 이번에는 급하게 머지할 필요는 없으니 이전 PR의 리뷰 사항을 포함한 추가 리뷰 사항을 최대한 반영하겠습니다.
## ⏲️Time
    - 6 시간
