### PR TITLE
[REFACTOR/#103] MVI 구조 리펙토링

### DIFF
--- a/core/ui/src/main/kotlin/com/boostcamp/mapisode/ui/base/BaseViewModel.kt
+++ b/core/ui/src/main/kotlin/com/boostcamp/mapisode/ui/base/BaseViewModel.kt
@@ -1,36 +1,37 @@
 package com.boostcamp.mapisode.ui.base
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
-import timber.log.Timber
+import kotlinx.coroutines.launch
 
-abstract class BaseViewModel<UI_STATE : UiState, SIDE_EFFECT : SideEffect>(
+abstract class BaseViewModel<UI_INTENT : UiIntent, UI_STATE : UiState, SIDE_EFFECT : SideEffect>(
 	initialState: UI_STATE,
 ) : ViewModel() {
 
 	private val _uiState = MutableStateFlow(initialState)
 	val uiState = _uiState.asStateFlow()
 
-	private val _sideEffect: Channel<SIDE_EFFECT> = Channel(Channel.UNLIMITED)
+	private val _sideEffect: Channel<SIDE_EFFECT> = Channel(Channel.BUFFERED)
 	val sideEffect = _sideEffect.receiveAsFlow()
 
 	protected val currentState: UI_STATE
 		get() = _uiState.value
+
+	abstract fun onIntent(intent: UI_INTENT)
 
 	protected fun intent(reduce: UI_STATE.() -> UI_STATE) {
 		_uiState.update { currentState.reduce() }
 	}
 
 	protected fun postSideEffect(vararg effects: SIDE_EFFECT) {
-		effects.forEach { effect ->
-			val result = _sideEffect.trySend(effect)
-			if (result.isFailure) {
-				// TODO : 에러 로직처리 방법 결정 후 수정
-				Timber.e(result.exceptionOrNull())
+		viewModelScope.launch {
+			effects.forEach { effect ->
+				_sideEffect.send(effect)
 			}
 		}
 	}

--- a/core/ui/src/main/kotlin/com/boostcamp/mapisode/ui/base/UiIntent.kt
+++ b/core/ui/src/main/kotlin/com/boostcamp/mapisode/ui/base/UiIntent.kt
@@ -1,0 +1,3 @@
+package com.boostcamp.mapisode.ui.base
+
+interface UiIntent

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/intent/NewEpisodeIntent.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/intent/NewEpisodeIntent.kt
@@ -1,9 +1,10 @@
 package com.boostcamp.mapisode.episode.intent
 
+import com.boostcamp.mapisode.ui.base.UiIntent
 import com.naver.maps.geometry.LatLng
 import java.util.Date
 
-sealed class NewEpisodeIntent {
+sealed class NewEpisodeIntent : UiIntent {
 	data class SetEpisodeLocation(val latLng: LatLng) : NewEpisodeIntent()
 	data class SetEpisodeGroup(val group: String) : NewEpisodeIntent()
 	data class SetEpisodeCategory(val category: String) : NewEpisodeIntent()

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/intent/NewEpisodeViewModel.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/intent/NewEpisodeViewModel.kt
@@ -12,9 +12,9 @@ import javax.inject.Inject
 
 @HiltViewModel
 class NewEpisodeViewModel @Inject constructor(private val episodeRepository: EpisodeRepository) :
-	BaseViewModel<NewEpisodeState, NewEpisodeSideEffect>(NewEpisodeState()) {
+	BaseViewModel<NewEpisodeIntent, NewEpisodeState, NewEpisodeSideEffect>(NewEpisodeState()) {
 
-	fun onIntent(intent: NewEpisodeIntent) {
+	override fun onIntent(intent: NewEpisodeIntent) {
 		when (intent) {
 			is NewEpisodeIntent.SetEpisodeLocation -> {
 				intent {

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeIntent.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeIntent.kt
@@ -2,9 +2,10 @@ package com.boostcamp.mapisode.home
 
 import com.boostcamp.mapisode.home.common.ChipType
 import com.boostcamp.mapisode.model.EpisodeLatLng
+import com.boostcamp.mapisode.ui.base.UiIntent
 import com.naver.maps.geometry.LatLng
 
-sealed class HomeIntent {
+sealed class HomeIntent : UiIntent {
 	data object RequestLocationPermission : HomeIntent()
 	data class SetInitialLocation(val latLng: LatLng) : HomeIntent()
 	data class UpdateLocationPermission(val isGranted: Boolean) : HomeIntent() // 위치 권한 설정 여부 업데이트

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeViewModel.kt
@@ -15,9 +15,9 @@ import javax.inject.Inject
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(private val episodeRepository: EpisodeRepository) :
-	BaseViewModel<HomeState, HomeSideEffect>(HomeState()) {
+	BaseViewModel<HomeIntent, HomeState, HomeSideEffect>(HomeState()) {
 
-	fun onIntent(intent: HomeIntent) {
+	override fun onIntent(intent: HomeIntent) {
 		when (intent) {
 			is HomeIntent.RequestLocationPermission -> {
 				// 위치 권한 요청이 아직 이루어지지 않은 경우에만 요청

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupIntent.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupIntent.kt
@@ -1,9 +1,10 @@
 package com.boostcamp.mapisode.mygroup.intent
 
 import androidx.compose.runtime.Immutable
+import com.boostcamp.mapisode.ui.base.UiIntent
 
 @Immutable
-sealed class GroupIntent {
+sealed class GroupIntent : UiIntent {
 	data object LoadGroups : GroupIntent()
 	data object EndLoadingGroups : GroupIntent()
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupViewModel.kt
@@ -13,9 +13,9 @@ import javax.inject.Inject
 
 @HiltViewModel
 class GroupViewModel @Inject constructor(private val groupRepository: GroupRepository) :
-	BaseViewModel<GroupState, GroupSideEffect>(GroupState()) {
+	BaseViewModel<GroupIntent, GroupState, GroupSideEffect>(GroupState()) {
 
-	fun onIntent(intent: GroupIntent) {
+	override fun onIntent(intent: GroupIntent) {
 		when (intent) {
 			is GroupIntent.LoadGroups -> {
 				loadGroups()


### PR DESCRIPTION
- closed #103 

## *📍 Work Description*

- onIntent로 상태를 변경하는 것을 강제하고 있지 않아서, 개발자의 실수로 외부에서 상태를 조작할 가능성이 있음.
- 위와 같은 상황이 발생하면 MVI 구조를 라이브러리 없이 사용하는 것에 대한 이점이 없고(UDF를 보장하지 못함), 일관성이 부족해짐. 
- 따라서 접근 제한자와 onIntent 함수를 통해 최대한 아키텍처 스타일을 강제함. 자세한 내용은 블로그로 작성함. (링크 : [[Android] MVI 패턴에 대한 고찰](https://haeti.palms.blog/mvi))

## *📢 To Reviewers*
- 기존에 잘 분리해주셔서 충돌은 나지 않았습니다.
- 앞으로 해당 PR의 작업처럼 core:ui의 State, SideEffect, Intent 타입으로 각 화면에 대한 Contract를 정의해주시고, onIntent 내부에서 모든 상태 관리를 해주세요. 

## ⏲️Time

    - 0.5 h
