### PR TITLE
[FIX/#116] Designsystem / FilledButton 크기 modifier 외부에 자유도 부여

### DIFF
--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeFilledButton.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/button/MapisodeFilledButton.kt
@@ -38,8 +38,8 @@ fun MapisodeFilledButton(
 		onClick = onClick,
 		modifier = Modifier
 			.then(modifier)
-			.widthIn(320.dp)
-			.heightIn(52.dp),
+			.widthIn(30.dp)
+			.heightIn(30.dp),
 		backgroundColors = if (enabled) {
 			MapisodeTheme.colorScheme.filledButtonEnableBackground
 		} else {


### PR DESCRIPTION
- closed #116

## *📍 Work Description*

- FilledButton 최소 높이, 너비 30.dp 로 변경

## *📸 Screenshot*

<img src="https://github.com/user-attachments/assets/933225d1-7a2d-4e77-989a-66b67cbeceed" width=500>


## *📢 To Reviewers*
- 아이콘 하나의 크기보다 약간 크게 설정해서 거의 모든 사이즈의 크기 대응 가능합니다.

## ⏲️Time

    - 0.5 시간
