### PR TITLE
[FEAT/#101] Group / Group 화면 최소기능 완성

### DIFF
--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -12,5 +12,6 @@ android {
 dependencies {
 	implementation(projects.core.ui)
 	implementation(projects.core.model)
+	implementation(libs.bundles.coil)
 	androidTestImplementation(libs.bundles.test)
 }

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/card/GroupCard.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/card/GroupCard.kt
@@ -1,4 +1,4 @@
-package com.boostcamp.mapisode.mygroup.component
+package com.boostcamp.mapisode.designsystem.compose.card
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/card/GroupInfoCard.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/card/GroupInfoCard.kt
@@ -34,11 +34,6 @@ fun GroupInfoCard(
 	Row(
 		modifier = modifier
 			.fillMaxWidth()
-			.border(
-				width = 1.dp,
-				color = MapisodeTheme.colorScheme.textColoredContainer,
-				shape = RoundedCornerShape(12.dp),
-			)
 			.padding(10.dp)
 			.height(140.dp),
 	) {

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/card/GroupInfoCard.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/card/GroupInfoCard.kt
@@ -1,6 +1,5 @@
 package com.boostcamp.mapisode.designsystem.compose.card
 
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -57,12 +56,17 @@ fun GroupInfoCard(
 					.copy(fontWeight = FontWeight.SemiBold),
 				maxLines = 1,
 			)
+
 			Spacer(modifier = Modifier.padding(4.dp))
 
 			MapisodeText(
 				text = stringResource(R.string.group_created_date) + group.createdAt,
 				style = MapisodeTheme.typography.labelMedium,
+				maxLines = 1,
 			)
+
+			Spacer(modifier = Modifier.height(4.dp))
+
 			MapisodeText(
 				text = stringResource(
 					R.string.group_user_count,
@@ -72,6 +76,9 @@ fun GroupInfoCard(
 				),
 				style = MapisodeTheme.typography.labelMedium,
 			)
+
+			Spacer(modifier = Modifier.height(4.dp))
+
 			MapisodeText(
 				text = stringResource(R.string.group_recent_upload),
 				style = MapisodeTheme.typography.labelMedium,

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/card/GroupInfoCard.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/card/GroupInfoCard.kt
@@ -1,0 +1,86 @@
+package com.boostcamp.mapisode.designsystem.compose.card
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import com.boostcamp.mapisode.designsystem.R
+import com.boostcamp.mapisode.designsystem.compose.MapisodeDivider
+import com.boostcamp.mapisode.designsystem.compose.MapisodeText
+import com.boostcamp.mapisode.designsystem.compose.Thickness
+import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
+import com.boostcamp.mapisode.model.GroupModel
+
+@Composable
+fun GroupInfoCard(
+	group: GroupModel,
+	modifier: Modifier = Modifier,
+) {
+	Row(
+		modifier = modifier
+			.fillMaxWidth()
+			.border(
+				width = 1.dp,
+				color = MapisodeTheme.colorScheme.textColoredContainer,
+				shape = RoundedCornerShape(12.dp),
+			)
+			.padding(10.dp)
+			.height(140.dp),
+	) {
+		AsyncImage(
+			model = group.imageUrl,
+			contentDescription = null,
+			modifier = Modifier
+				.size(140.dp)
+				.clip(shape = RoundedCornerShape(16.dp)),
+		)
+		MapisodeDivider(thickness = Thickness.Thick)
+		Column(
+			modifier = Modifier
+				.fillMaxHeight()
+				.wrapContentWidth(),
+			verticalArrangement = Arrangement.Center,
+		) {
+			MapisodeText(
+				text = group.name,
+				style = MapisodeTheme.typography.titleMedium
+					.copy(fontWeight = FontWeight.SemiBold),
+				maxLines = 1,
+			)
+			Spacer(modifier = Modifier.padding(4.dp))
+
+			MapisodeText(
+				text = stringResource(R.string.group_created_date) + group.createdAt,
+				style = MapisodeTheme.typography.labelMedium,
+			)
+			MapisodeText(
+				text = stringResource(
+					R.string.group_user_count,
+					stringResource(R.string.group_members_number),
+					group.members.size,
+					stringResource(R.string.group_member_count),
+				),
+				style = MapisodeTheme.typography.labelMedium,
+			)
+			MapisodeText(
+				text = stringResource(R.string.group_recent_upload),
+				style = MapisodeTheme.typography.labelMedium,
+			)
+		}
+	}
+}

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/theme/ColorScheme.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/theme/ColorScheme.kt
@@ -112,7 +112,7 @@ val lightColorScheme = CustomColorScheme(
 	scaffoldBackground = Neutral10,
 
 	// TextColoredContainer
-	textColoredContainer = Neutral60,
+	textColoredContainer = Neutral40.copy(alpha = 0.4f),
 
 	// Scrim
 	scrim = Neutral110.copy(alpha = 0.32f),
@@ -207,7 +207,7 @@ val darkColorScheme = CustomColorScheme(
 	scaffoldBackground = Neutral110,
 
 	// TextColoredContainer
-	textColoredContainer = Neutral10,
+	textColoredContainer = Neutral80.copy(alpha = 0.6f),
 
 	// Scrim
 	scrim = Neutral10.copy(alpha = 0.32f),

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/theme/ColorScheme.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/theme/ColorScheme.kt
@@ -112,7 +112,7 @@ val lightColorScheme = CustomColorScheme(
 	scaffoldBackground = Neutral10,
 
 	// TextColoredContainer
-	textColoredContainer = Neutral90,
+	textColoredContainer = Neutral60,
 
 	// Scrim
 	scrim = Neutral110.copy(alpha = 0.32f),

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="group_created_date">"생성 날짜 : "</string>
+	<string name="group_user_count">%1$s %2$d %3$s</string>
+	<string name="group_members_number">"멤버수 : "</string>
+	<string name="group_member_count">명</string>
+	<string name="group_recent_upload">"최근 업로드 : "</string>
+</resources>

--- a/core/firebase/src/main/java/com/boostcamp/mapisode/firebase/firestore/FirestoreConstants.kt
+++ b/core/firebase/src/main/java/com/boostcamp/mapisode/firebase/firestore/FirestoreConstants.kt
@@ -4,6 +4,7 @@ object FirestoreConstants {
 	const val COLLECTION_EPISODE = "episode"
 	const val COLLECTION_GROUP = "group"
 	const val COLLECTION_USER = "user"
+	const val COLLECTION_INVITE_CODES = "inviteCodes"
 
 	const val FIELD_CATEGORY = "category"
 	const val FIELD_GROUP = "group"

--- a/core/firebase/src/main/java/com/boostcamp/mapisode/firebase/firestore/FirestoreConstants.kt
+++ b/core/firebase/src/main/java/com/boostcamp/mapisode/firebase/firestore/FirestoreConstants.kt
@@ -13,4 +13,5 @@ object FirestoreConstants {
 
 	const val FIELD_ADMIN_USER = "adminUser"
 	const val FIELD_MEMBERS = "members"
+	const val FIELD_CREATED_AT = "createdAt"
 }

--- a/core/model/src/main/kotlin/com/boostcamp/mapisode/model/GroupMemberModel.kt
+++ b/core/model/src/main/kotlin/com/boostcamp/mapisode/model/GroupMemberModel.kt
@@ -1,0 +1,11 @@
+package com.boostcamp.mapisode.model
+
+import java.util.Date
+
+class GroupMemberModel(
+	val name: String,
+	val email: String,
+	val profileUrl: String,
+	val joinedAt: Date,
+	val groups: List<String>,
+)

--- a/core/navigation/src/main/java/com/boostcamp/mapisode/navigation/GroupRoute.kt
+++ b/core/navigation/src/main/java/com/boostcamp/mapisode/navigation/GroupRoute.kt
@@ -7,11 +7,11 @@ sealed interface GroupRoute : Route {
 	data object Join : GroupRoute
 
 	@Serializable
-	data object Detail : GroupRoute
+	data class Detail(val groupId: String) : GroupRoute
 
 	@Serializable
 	data object Creation : GroupRoute
 
 	@Serializable
-	data object Edit : GroupRoute
+	data class Edit(val groupId: String) : GroupRoute
 }

--- a/data/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepositoryImpl.kt
+++ b/data/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepositoryImpl.kt
@@ -66,19 +66,28 @@ class GroupRepositoryImpl @Inject constructor(private val database: FirebaseFire
 		try {
 			database.runTransaction { transaction ->
 				// 그룹 문서의 멤버 리스트에 사용자 추가
-				val groupDocRef = database.collection(FirestoreConstants.COLLECTION_GROUP).document(groupId)
+				val groupDocRef = database
+					.collection(FirestoreConstants.COLLECTION_GROUP)
+					.document(groupId)
 				transaction.update(
 					groupDocRef,
 					FirestoreConstants.FIELD_MEMBERS,
-					FieldValue.arrayUnion(database.collection(FirestoreConstants.COLLECTION_USER).document(userId)),
+					FieldValue.arrayUnion(
+						database.collection(FirestoreConstants.COLLECTION_USER)
+							.document(userId),
+					),
 				)
 
 				// 사용자 문서의 그룹 리스트에 그룹 추가
-				val userDocRef = database.collection(FirestoreConstants.COLLECTION_USER).document(userId)
+				val userDocRef = database.collection(FirestoreConstants.COLLECTION_USER)
+					.document(userId)
 				transaction.update(
 					userDocRef,
 					FirestoreConstants.FIELD_GROUPS,
-					FieldValue.arrayUnion(database.collection(FirestoreConstants.COLLECTION_GROUP).document(groupId)),
+					FieldValue.arrayUnion(
+						database.collection(FirestoreConstants.COLLECTION_GROUP)
+							.document(groupId),
+					),
 				)
 			}.await()
 		} catch (e: Exception) {
@@ -121,17 +130,26 @@ class GroupRepositoryImpl @Inject constructor(private val database: FirebaseFire
 		try {
 			database.runTransaction { transaction ->
 				// group의 members 필드에서 사용자 제거
-				val groupDocRef = database.collection(FirestoreConstants.COLLECTION_GROUP).document(groupId)
+				val groupDocRef = database.collection(FirestoreConstants.COLLECTION_GROUP)
+					.document(groupId)
 				val groupSnapshot = transaction.get(groupDocRef)
-				val members = groupSnapshot.get(FirestoreConstants.FIELD_MEMBERS) as MutableList<DocumentReference>
+				val members = groupSnapshot.get(
+					FirestoreConstants.FIELD_MEMBERS,
+				) as MutableList<DocumentReference>
 				members.remove(database.collection(FirestoreConstants.COLLECTION_USER).document(userId))
 				transaction.update(groupDocRef, FirestoreConstants.FIELD_MEMBERS, members)
 
 				// user의 그룹 필드에서 그룹 제거
-				val userDocRef = database.collection(FirestoreConstants.COLLECTION_USER).document(userId)
+				val userDocRef = database.collection(FirestoreConstants.COLLECTION_USER)
+					.document(userId)
 				val userSnapshot = transaction.get(userDocRef)
-				val groups = userSnapshot.get(FirestoreConstants.FIELD_GROUPS) as MutableList<DocumentReference>
-				groups.remove(database.collection(FirestoreConstants.COLLECTION_GROUP).document(groupId))
+				val groups = userSnapshot.get(
+					FirestoreConstants.FIELD_GROUPS,
+				) as MutableList<DocumentReference>
+				groups.remove(
+					database.collection(FirestoreConstants.COLLECTION_GROUP)
+						.document(groupId),
+				)
 				transaction.update(userDocRef, FirestoreConstants.FIELD_GROUPS, groups)
 			}.await()
 		} catch (e: Exception) {

--- a/data/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepositoryImpl.kt
+++ b/data/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepositoryImpl.kt
@@ -114,12 +114,14 @@ class GroupRepositoryImpl @Inject constructor(private val database: FirebaseFire
 		).await()
 	}
 
-	override suspend fun createGroup(groupModel: GroupModel): String {
-		val newGroupId = UUID.randomUUID().toString().replace("-", "")
-		return try {
-			groupCollection.document(newGroupId).set(groupModel.toFirestoreModel(database))
+	override suspend fun createGroup(groupModel: GroupModel) {
+		try {
+			groupCollection.document(groupModel.id).set(groupModel.toFirestoreModel(database))
 				.await()
-			newGroupId
+			userCollection.document(groupModel.adminUser).update(
+				FirestoreConstants.FIELD_GROUPS,
+				FieldValue.arrayUnion(groupCollection.document(groupModel.id)),
+			).await()
 		} catch (e: Exception) {
 			throw e
 		}

--- a/data/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepositoryImpl.kt
+++ b/data/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepositoryImpl.kt
@@ -18,6 +18,16 @@ class GroupRepositoryImpl @Inject constructor(private val database: FirebaseFire
 	private val userCollection = database.collection(FirestoreConstants.COLLECTION_USER)
 	private val inviteCodesCollection = database.collection(FirestoreConstants.COLLECTION_INVITE_CODES)
 
+	override suspend fun getGroupByGroupId(groupId: String): GroupModel = try {
+		groupCollection.document(groupId)
+			.get()
+			.await()
+			.toObject(GroupFirestoreModel::class.java)?.toDomainModel(groupId)
+			?: throw Exception("그룹을 찾을 수 없습니다.")
+	} catch (e: Exception) {
+		throw e
+	}
+
 	override suspend fun getGroupsByUserId(userId: String): List<GroupModel> = try {
 		val userSnapshot = userCollection.document(userId).get().await()
 
@@ -34,7 +44,7 @@ class GroupRepositoryImpl @Inject constructor(private val database: FirebaseFire
 		throw e
 	}
 
-	override suspend fun getGroupById(inviteCodes: String): GroupModel = try {
+	override suspend fun getGroupByInviteCodes(inviteCodes: String): GroupModel = try {
 		val groupSnapshot = inviteCodesCollection.document(inviteCodes)
 			.get().await()
 		val group = groupSnapshot[FirestoreConstants.FIELD_GROUP] as DocumentReference

--- a/data/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepositoryImpl.kt
+++ b/data/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.boostcamp.mapisode.mygroup.model.GroupFirestoreModel
 import com.boostcamp.mapisode.mygroup.model.toDomainModel
 import com.boostcamp.mapisode.mygroup.model.toFirestoreModel
 import com.google.firebase.firestore.DocumentReference
+import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.tasks.await
 import java.util.UUID
@@ -30,6 +31,19 @@ class GroupRepositoryImpl @Inject constructor(private val database: FirebaseFire
 		}
 	} catch (e: Exception) {
 		throw e
+	}
+
+	override suspend fun joinGroup(userId: String, groupId: String) {
+		groupCollection.document(groupId).update(
+			FirestoreConstants.FIELD_MEMBERS,
+			// 기존 유저 리스트에 덮어씌우지 않고 추가
+			FieldValue.arrayUnion(userCollection.document(userId))
+		).await()
+
+		userCollection.document(userId).update(
+			FirestoreConstants.FIELD_GROUPS,
+			FieldValue.arrayUnion(groupCollection.document(groupId))
+		).await()
 	}
 
 	override suspend fun createGroup(groupModel: GroupModel): String {

--- a/data/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepositoryImpl.kt
+++ b/data/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepositoryImpl.kt
@@ -42,7 +42,7 @@ class GroupRepositoryImpl @Inject constructor(private val database: FirebaseFire
 		groupCollection.document(group.id)
 			.get()
 			.await()
-			.toObject(GroupFirestoreModel::class.java)?.toDomainModel(inviteCodes)
+			.toObject(GroupFirestoreModel::class.java)?.toDomainModel(group.id)
 			?: throw Exception("Group not found")
 	} catch (e: Exception) {
 		throw e
@@ -52,12 +52,12 @@ class GroupRepositoryImpl @Inject constructor(private val database: FirebaseFire
 		groupCollection.document(groupId).update(
 			FirestoreConstants.FIELD_MEMBERS,
 			// 기존 유저 리스트에 덮어씌우지 않고 추가
-			FieldValue.arrayUnion(userCollection.document(userId))
+			FieldValue.arrayUnion(userCollection.document(userId)),
 		).await()
 
 		userCollection.document(userId).update(
 			FirestoreConstants.FIELD_GROUPS,
-			FieldValue.arrayUnion(groupCollection.document(groupId))
+			FieldValue.arrayUnion(groupCollection.document(groupId)),
 		).await()
 	}
 

--- a/data/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepositoryImpl.kt
+++ b/data/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepositoryImpl.kt
@@ -33,6 +33,16 @@ class GroupRepositoryImpl @Inject constructor(private val database: FirebaseFire
 		throw e
 	}
 
+	override suspend fun getGroupById(groupId: String): GroupModel = try {
+		groupCollection.document(groupId)
+			.get()
+			.await()
+			.toObject(GroupFirestoreModel::class.java)?.toDomainModel(groupId)
+			?: throw Exception("Group not found")
+	} catch (e: Exception) {
+		throw e
+	}
+
 	override suspend fun joinGroup(userId: String, groupId: String) {
 		groupCollection.document(groupId).update(
 			FirestoreConstants.FIELD_MEMBERS,

--- a/data/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepositoryImpl.kt
+++ b/data/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepositoryImpl.kt
@@ -102,6 +102,18 @@ class GroupRepositoryImpl @Inject constructor(private val database: FirebaseFire
 		throw e
 	}
 
+	override suspend fun leaveGroup(userId: String, groupId: String) {
+		groupCollection.document(groupId).update(
+			FirestoreConstants.FIELD_MEMBERS,
+			FieldValue.arrayRemove(userCollection.document(userId)),
+		).await()
+
+		userCollection.document(userId).update(
+			FirestoreConstants.FIELD_GROUPS,
+			FieldValue.arrayRemove(groupCollection.document(groupId)),
+		).await()
+	}
+
 	override suspend fun createGroup(groupModel: GroupModel): String {
 		val newGroupId = UUID.randomUUID().toString().replace("-", "")
 		return try {

--- a/data/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepositoryImpl.kt
+++ b/data/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepositoryImpl.kt
@@ -7,11 +7,13 @@ import com.boostcamp.mapisode.mygroup.model.GroupFirestoreModel
 import com.boostcamp.mapisode.mygroup.model.UserFirestoreModel
 import com.boostcamp.mapisode.mygroup.model.toDomainModel
 import com.boostcamp.mapisode.mygroup.model.toFirestoreModel
+import com.google.firebase.Timestamp
 import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.tasks.await
 import timber.log.Timber
+import java.util.Calendar
 import java.util.UUID
 import javax.inject.Inject
 
@@ -89,7 +91,9 @@ class GroupRepositoryImpl @Inject constructor(private val database: FirebaseFire
 			existingInviteCodeDocument.id
 		} else {
 			val inviteCode = UUID.randomUUID().toString().replace("-", "")
-			val timestamp = com.google.firebase.Timestamp.now()
+			val timestamp = Timestamp(
+				Calendar.getInstance().apply { add(Calendar.DAY_OF_YEAR, 7) }.time,
+			)
 			inviteCodesCollection.document(inviteCode).set(
 				mapOf(
 					FirestoreConstants.FIELD_GROUP to groupReference,

--- a/data/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepositoryImpl.kt
+++ b/data/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepositoryImpl.kt
@@ -16,6 +16,7 @@ class GroupRepositoryImpl @Inject constructor(private val database: FirebaseFire
 	GroupRepository {
 	private val groupCollection = database.collection(FirestoreConstants.COLLECTION_GROUP)
 	private val userCollection = database.collection(FirestoreConstants.COLLECTION_USER)
+	private val inviteCodesCollection = database.collection(FirestoreConstants.COLLECTION_INVITE_CODES)
 
 	override suspend fun getGroupsByUserId(userId: String): List<GroupModel> = try {
 		val userSnapshot = userCollection.document(userId).get().await()
@@ -33,11 +34,15 @@ class GroupRepositoryImpl @Inject constructor(private val database: FirebaseFire
 		throw e
 	}
 
-	override suspend fun getGroupById(groupId: String): GroupModel = try {
-		groupCollection.document(groupId)
+	override suspend fun getGroupById(inviteCodes: String): GroupModel = try {
+		val groupSnapshot = inviteCodesCollection.document(inviteCodes)
+			.get().await()
+		val group = groupSnapshot[FirestoreConstants.FIELD_GROUP] as DocumentReference
+
+		groupCollection.document(group.id)
 			.get()
 			.await()
-			.toObject(GroupFirestoreModel::class.java)?.toDomainModel(groupId)
+			.toObject(GroupFirestoreModel::class.java)?.toDomainModel(inviteCodes)
 			?: throw Exception("Group not found")
 	} catch (e: Exception) {
 		throw e

--- a/data/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/model/UserFirestoreModel.kt
+++ b/data/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/model/UserFirestoreModel.kt
@@ -1,0 +1,13 @@
+package com.boostcamp.mapisode.mygroup.model
+
+import com.google.firebase.Timestamp
+import com.google.firebase.firestore.DocumentReference
+
+data class UserFirestoreModel(
+	val id: String = "",
+	val email: String = "",
+	val groups: List<DocumentReference> = listOf(),
+	val joinedAt: Timestamp = Timestamp.now(),
+	val name: String = "",
+	val profileUrl: String = "",
+)

--- a/domain/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepository.kt
+++ b/domain/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepository.kt
@@ -4,6 +4,7 @@ import com.boostcamp.mapisode.model.GroupModel
 
 interface GroupRepository {
 	suspend fun getGroupsByUserId(userId: String): List<GroupModel>
+	suspend fun getGroupById(groupId: String): GroupModel
 	suspend fun joinGroup(userId: String, groupId: String)
 	suspend fun createGroup(groupModel: GroupModel): String
 	suspend fun updateGroup(groupId: String, groupModel: GroupModel)

--- a/domain/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepository.kt
+++ b/domain/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepository.kt
@@ -9,6 +9,7 @@ interface GroupRepository {
 	suspend fun getGroupByInviteCodes(inviteCodes: String): GroupModel
 	suspend fun joinGroup(userId: String, groupId: String)
 	suspend fun issueInvitationCode(groupId: String): String
+	suspend fun leaveGroup(userId: String, groupId: String)
 	suspend fun createGroup(groupModel: GroupModel): String
 	suspend fun updateGroup(groupId: String, groupModel: GroupModel)
 	suspend fun deleteGroup(groupId: String)

--- a/domain/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepository.kt
+++ b/domain/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepository.kt
@@ -7,6 +7,7 @@ interface GroupRepository {
 	suspend fun getGroupsByUserId(userId: String): List<GroupModel>
 	suspend fun getGroupByInviteCodes(inviteCodes: String): GroupModel
 	suspend fun joinGroup(userId: String, groupId: String)
+	suspend fun issueInvitationCode(groupId: String): String
 	suspend fun createGroup(groupModel: GroupModel): String
 	suspend fun updateGroup(groupId: String, groupModel: GroupModel)
 	suspend fun deleteGroup(groupId: String)

--- a/domain/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepository.kt
+++ b/domain/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepository.kt
@@ -1,5 +1,6 @@
 package com.boostcamp.mapisode.mygroup
 
+import com.boostcamp.mapisode.model.GroupMemberModel
 import com.boostcamp.mapisode.model.GroupModel
 
 interface GroupRepository {
@@ -11,4 +12,6 @@ interface GroupRepository {
 	suspend fun createGroup(groupModel: GroupModel): String
 	suspend fun updateGroup(groupId: String, groupModel: GroupModel)
 	suspend fun deleteGroup(groupId: String)
+
+	suspend fun getUserInfoByUserId(userId: String): GroupMemberModel
 }

--- a/domain/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepository.kt
+++ b/domain/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepository.kt
@@ -10,7 +10,7 @@ interface GroupRepository {
 	suspend fun joinGroup(userId: String, groupId: String)
 	suspend fun issueInvitationCode(groupId: String): String
 	suspend fun leaveGroup(userId: String, groupId: String)
-	suspend fun createGroup(groupModel: GroupModel): String
+	suspend fun createGroup(groupModel: GroupModel)
 	suspend fun updateGroup(groupId: String, groupModel: GroupModel)
 	suspend fun deleteGroup(groupId: String)
 

--- a/domain/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepository.kt
+++ b/domain/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepository.kt
@@ -4,7 +4,7 @@ import com.boostcamp.mapisode.model.GroupModel
 
 interface GroupRepository {
 	suspend fun getGroupsByUserId(userId: String): List<GroupModel>
-	suspend fun getGroupById(groupId: String): GroupModel
+	suspend fun getGroupById(inviteCodes: String): GroupModel
 	suspend fun joinGroup(userId: String, groupId: String)
 	suspend fun createGroup(groupModel: GroupModel): String
 	suspend fun updateGroup(groupId: String, groupModel: GroupModel)

--- a/domain/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepository.kt
+++ b/domain/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepository.kt
@@ -4,6 +4,7 @@ import com.boostcamp.mapisode.model.GroupModel
 
 interface GroupRepository {
 	suspend fun getGroupsByUserId(userId: String): List<GroupModel>
+	suspend fun joinGroup(userId: String, groupId: String)
 	suspend fun createGroup(groupModel: GroupModel): String
 	suspend fun updateGroup(groupId: String, groupModel: GroupModel)
 	suspend fun deleteGroup(groupId: String)

--- a/domain/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepository.kt
+++ b/domain/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepository.kt
@@ -3,8 +3,9 @@ package com.boostcamp.mapisode.mygroup
 import com.boostcamp.mapisode.model.GroupModel
 
 interface GroupRepository {
+	suspend fun getGroupByGroupId(groupId: String): GroupModel
 	suspend fun getGroupsByUserId(userId: String): List<GroupModel>
-	suspend fun getGroupById(inviteCodes: String): GroupModel
+	suspend fun getGroupByInviteCodes(inviteCodes: String): GroupModel
 	suspend fun joinGroup(userId: String, groupId: String)
 	suspend fun createGroup(groupModel: GroupModel): String
 	suspend fun updateGroup(groupId: String, groupModel: GroupModel)

--- a/feature/login/src/main/java/com/boostcamp/mapisode/login/AuthViewModel.kt
+++ b/feature/login/src/main/java/com/boostcamp/mapisode/login/AuthViewModel.kt
@@ -85,7 +85,7 @@ class AuthViewModel @Inject constructor(
 		viewModelScope.launch {
 			try {
 				if (uiState.value.nickname.isBlank()) throw IllegalArgumentException("닉네임을 입력해주세요.")
-				if (uiState.value.profileUrl.isBlank()) throw IllegalArgumentException("프로필 사진을 선택해주세요.")
+				//if (uiState.value.profileUrl.isBlank()) throw IllegalArgumentException("프로필 사진을 선택해주세요.")
 				if (uiState.value.authData == null) throw IllegalArgumentException("로그인 정보가 없습니다.")
 
 				userRepository.createUser(

--- a/feature/login/src/main/java/com/boostcamp/mapisode/login/AuthViewModel.kt
+++ b/feature/login/src/main/java/com/boostcamp/mapisode/login/AuthViewModel.kt
@@ -85,7 +85,7 @@ class AuthViewModel @Inject constructor(
 		viewModelScope.launch {
 			try {
 				if (uiState.value.nickname.isBlank()) throw IllegalArgumentException("닉네임을 입력해주세요.")
-				//if (uiState.value.profileUrl.isBlank()) throw IllegalArgumentException("프로필 사진을 선택해주세요.")
+				// if (uiState.value.profileUrl.isBlank()) throw IllegalArgumentException("프로필 사진을 선택해주세요.")
 				if (uiState.value.authData == null) throw IllegalArgumentException("로그인 정보가 없습니다.")
 
 				userRepository.createUser(

--- a/feature/main/src/main/java/com/boostcamp/mapisode/main/MainNavigator.kt
+++ b/feature/main/src/main/java/com/boostcamp/mapisode/main/MainNavigator.kt
@@ -55,16 +55,16 @@ internal class MainNavigator(
 		navController.navigateGroupJoin()
 	}
 
-	fun navigateGroupDetail() {
-		navController.navigateGroupDetail()
+	fun navigateGroupDetail(groupId: String) {
+		navController.navigateGroupDetail(groupId)
 	}
 
 	fun navigateGroupCreation() {
 		navController.navigateGroupCreation()
 	}
 
-	fun navigateGroupEdit() {
-		navController.navigateGroupEdit()
+	fun navigateGroupEdit(groupId: String) {
+		navController.navigateGroupEdit(groupId)
 	}
 
 	private fun popBackStack() {

--- a/feature/main/src/main/java/com/boostcamp/mapisode/main/component/MainNavHost.kt
+++ b/feature/main/src/main/java/com/boostcamp/mapisode/main/component/MainNavHost.kt
@@ -35,9 +35,13 @@ internal fun MainNavHost(
 			addGroupNavGraph(
 				onBackClick = navigator::popBackStackIfNotHome,
 				onGroupJoinClick = navigator::navigateGroupJoin,
-				onGroupDetailClick = navigator::navigateGroupDetail,
+				onGroupDetailClick = { groupId: String ->
+					navigator.navigateGroupDetail(groupId)
+				},
 				onGroupCreationClick = navigator::navigateGroupCreation,
-				onGroupEditClick = navigator::navigateGroupEdit,
+				onGroupEditClick = { groupId: String ->
+					navigator.navigateGroupEdit(groupId)
+				},
 			)
 			addMyPageNavGraph()
 		}

--- a/feature/mygroup/build.gradle.kts
+++ b/feature/mygroup/build.gradle.kts
@@ -11,4 +11,5 @@ android {
 dependencies {
 	implementation(libs.bundles.coil)
 	implementation(projects.domain.mygroup)
+	implementation(projects.core.datastore)
 }

--- a/feature/mygroup/build.gradle.kts
+++ b/feature/mygroup/build.gradle.kts
@@ -12,5 +12,4 @@ dependencies {
 	implementation(libs.bundles.coil)
 	implementation(projects.domain.mygroup)
 	implementation(projects.domain.episode)
-	implementation(projects.core.datastore)
 }

--- a/feature/mygroup/build.gradle.kts
+++ b/feature/mygroup/build.gradle.kts
@@ -11,5 +11,6 @@ android {
 dependencies {
 	implementation(libs.bundles.coil)
 	implementation(projects.domain.mygroup)
+	implementation(projects.domain.episode)
 	implementation(projects.core.datastore)
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/component/GroupCard.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/component/GroupCard.kt
@@ -27,7 +27,8 @@ import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 
 @Composable
 fun GroupCard(
-	onGroupDetailClick: () -> Unit,
+	onGroupDetailClick: (String) -> Unit,
+	groupId: String,
 	imageUrl: String,
 	title: String,
 	content: String,
@@ -40,7 +41,9 @@ fun GroupCard(
 			.clickable(
 				interactionSource = null,
 				indication = MapisodeRippleAIndication,
-				onClick = onGroupDetailClick,
+				onClick = {
+					onGroupDetailClick(groupId)
+				},
 			),
 	) {
 		AsyncImage(
@@ -80,6 +83,7 @@ fun GroupCardPreview() {
 	CompositionLocalProvider(LocalAsyncImagePreviewHandler provides previewHandler) {
 		GroupCard(
 			onGroupDetailClick = {},
+			groupId = "",
 			imageUrl = "https://avatars.githubusercontent.com/u/127717111?v=4",
 			title = "그룹 이름",
 			content = "멤버 수",

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupCreationIntent.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupCreationIntent.kt
@@ -6,9 +6,6 @@ import com.boostcamp.mapisode.ui.base.UiIntent
 @Immutable
 sealed class GroupCreationIntent : UiIntent {
 	data object OnBackClick : GroupCreationIntent()
-	data class OnGroupCreationClick(
-		val title: String,
-		val content: String,
-		val imageUrl: String,
-	) : GroupCreationIntent()
+	data class OnGroupCreationClick(val title: String, val content: String, val imageUrl: String) :
+		GroupCreationIntent()
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupCreationIntent.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupCreationIntent.kt
@@ -8,4 +8,5 @@ sealed class GroupCreationIntent : UiIntent {
 	data object OnBackClick : GroupCreationIntent()
 	data class OnGroupCreationClick(val title: String, val content: String, val imageUrl: String) :
 		GroupCreationIntent()
+	data object OnGroupCreationError : GroupCreationIntent()
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupCreationIntent.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupCreationIntent.kt
@@ -1,0 +1,14 @@
+package com.boostcamp.mapisode.mygroup.intent
+
+import androidx.compose.runtime.Immutable
+import com.boostcamp.mapisode.ui.base.UiIntent
+
+@Immutable
+sealed class GroupCreationIntent : UiIntent {
+	data object OnBackClick : GroupCreationIntent()
+	data class OnGroupCreationClick(
+		val title: String,
+		val content: String,
+		val imageUrl: String,
+	) : GroupCreationIntent()
+}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupDetailIntent.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupDetailIntent.kt
@@ -5,6 +5,8 @@ import com.boostcamp.mapisode.ui.base.UiIntent
 
 @Immutable
 sealed class GroupDetailIntent: UiIntent {
+	data class GetGroupId(val groupId: String) : GroupDetailIntent()
 	data class TryGetGroup(val inviteCode: String) : GroupDetailIntent()
+	data class GoToGroupEditScreen(val groupId: String) : GroupDetailIntent()
 	data object BackToGroupScreen : GroupDetailIntent()
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupDetailIntent.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupDetailIntent.kt
@@ -10,4 +10,5 @@ sealed class GroupDetailIntent : UiIntent {
 	data class OnEditClick(val groupId: String) : GroupDetailIntent()
 	data object OnBackClick : GroupDetailIntent()
 	data class OnEpisodeClick(val episodeId: String) : GroupDetailIntent()
+	data object OnIssueCodeClick : GroupDetailIntent()
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupDetailIntent.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupDetailIntent.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Immutable
 import com.boostcamp.mapisode.ui.base.UiIntent
 
 @Immutable
-sealed class GroupDetailIntent: UiIntent {
+sealed class GroupDetailIntent : UiIntent {
 	data class GetGroupId(val groupId: String) : GroupDetailIntent()
 	data class TryGetGroup(val inviteCode: String) : GroupDetailIntent()
 	data class GoToGroupEditScreen(val groupId: String) : GroupDetailIntent()

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupDetailIntent.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupDetailIntent.kt
@@ -12,4 +12,7 @@ sealed class GroupDetailIntent : UiIntent {
 	data object OnBackClick : GroupDetailIntent()
 	data class OnEpisodeClick(val episodeId: String) : GroupDetailIntent()
 	data object OnIssueCodeClick : GroupDetailIntent()
+	data object OnGroupOutClick : GroupDetailIntent()
+	data object OnGroupOutConfirm : GroupDetailIntent()
+	data object OnGroupOutCancel : GroupDetailIntent()
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupDetailIntent.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupDetailIntent.kt
@@ -5,8 +5,9 @@ import com.boostcamp.mapisode.ui.base.UiIntent
 
 @Immutable
 sealed class GroupDetailIntent : UiIntent {
-	data class GetGroupId(val groupId: String) : GroupDetailIntent()
+	data class InitializeGroupDetail(val groupId: String) : GroupDetailIntent()
 	data class TryGetGroup(val inviteCode: String) : GroupDetailIntent()
-	data class GoToGroupEditScreen(val groupId: String) : GroupDetailIntent()
-	data object BackToGroupScreen : GroupDetailIntent()
+	data class OnEditClick(val groupId: String) : GroupDetailIntent()
+	data object OnBackClick : GroupDetailIntent()
+	data class OnEpisodeClick(val episodeId: String) : GroupDetailIntent()
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupDetailIntent.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupDetailIntent.kt
@@ -6,8 +6,9 @@ import com.boostcamp.mapisode.ui.base.UiIntent
 @Immutable
 sealed class GroupDetailIntent : UiIntent {
 	data class InitializeGroupDetail(val groupId: String) : GroupDetailIntent()
-	data class TryGetGroup(val inviteCode: String) : GroupDetailIntent()
+	data class TryGetGroup(val groupId: String) : GroupDetailIntent()
 	data object TryGetUserInfo : GroupDetailIntent()
+	data object TryGetGroupEpisodes : GroupDetailIntent()
 	data class OnEditClick(val groupId: String) : GroupDetailIntent()
 	data object OnBackClick : GroupDetailIntent()
 	data class OnEpisodeClick(val episodeId: String) : GroupDetailIntent()

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupDetailIntent.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupDetailIntent.kt
@@ -9,7 +9,7 @@ sealed class GroupDetailIntent : UiIntent {
 	data class TryGetGroup(val groupId: String) : GroupDetailIntent()
 	data object TryGetUserInfo : GroupDetailIntent()
 	data object TryGetGroupEpisodes : GroupDetailIntent()
-	data class OnEditClick(val groupId: String) : GroupDetailIntent()
+	data object OnEditClick : GroupDetailIntent()
 	data object OnBackClick : GroupDetailIntent()
 	data class OnEpisodeClick(val episodeId: String) : GroupDetailIntent()
 	data object OnIssueCodeClick : GroupDetailIntent()

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupDetailIntent.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupDetailIntent.kt
@@ -1,0 +1,9 @@
+package com.boostcamp.mapisode.mygroup.intent
+
+import androidx.compose.runtime.Immutable
+
+@Immutable
+sealed class GroupDetailIntent {
+	data class TryGetGroup(val inviteCode: String) : GroupDetailIntent()
+	data object BackToGroupScreen : GroupDetailIntent()
+}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupDetailIntent.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupDetailIntent.kt
@@ -7,6 +7,7 @@ import com.boostcamp.mapisode.ui.base.UiIntent
 sealed class GroupDetailIntent : UiIntent {
 	data class InitializeGroupDetail(val groupId: String) : GroupDetailIntent()
 	data class TryGetGroup(val inviteCode: String) : GroupDetailIntent()
+	data object TryGetUserInfo : GroupDetailIntent()
 	data class OnEditClick(val groupId: String) : GroupDetailIntent()
 	data object OnBackClick : GroupDetailIntent()
 	data class OnEpisodeClick(val episodeId: String) : GroupDetailIntent()

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupDetailIntent.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupDetailIntent.kt
@@ -1,9 +1,10 @@
 package com.boostcamp.mapisode.mygroup.intent
 
 import androidx.compose.runtime.Immutable
+import com.boostcamp.mapisode.ui.base.UiIntent
 
 @Immutable
-sealed class GroupDetailIntent {
+sealed class GroupDetailIntent: UiIntent {
 	data class TryGetGroup(val inviteCode: String) : GroupDetailIntent()
 	data object BackToGroupScreen : GroupDetailIntent()
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupEditIntent.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupEditIntent.kt
@@ -1,0 +1,15 @@
+package com.boostcamp.mapisode.mygroup.intent
+
+import androidx.compose.runtime.Immutable
+import com.boostcamp.mapisode.ui.base.UiIntent
+
+@Immutable
+sealed class GroupEditIntent : UiIntent {
+	data class LoadGroups(val groupId: String) : GroupEditIntent()
+	data object OnBackClick : GroupEditIntent()
+	data class OnGroupEditClick(
+		val title: String,
+		val content: String,
+		val imageUrl: String,
+	) : GroupEditIntent()
+}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupEditIntent.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupEditIntent.kt
@@ -7,9 +7,6 @@ import com.boostcamp.mapisode.ui.base.UiIntent
 sealed class GroupEditIntent : UiIntent {
 	data class LoadGroups(val groupId: String) : GroupEditIntent()
 	data object OnBackClick : GroupEditIntent()
-	data class OnGroupEditClick(
-		val title: String,
-		val content: String,
-		val imageUrl: String,
-	) : GroupEditIntent()
+	data class OnGroupEditClick(val title: String, val content: String, val imageUrl: String) :
+		GroupEditIntent()
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupIntent.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupIntent.kt
@@ -6,7 +6,6 @@ import com.boostcamp.mapisode.ui.base.UiIntent
 @Immutable
 sealed class GroupIntent : UiIntent {
 	data object LoadGroups : GroupIntent()
-	data object EndLoadingGroups : GroupIntent()
 	data object OnJoinClick : GroupIntent()
 	data object OnGroupCreateClick : GroupIntent()
 	data class OnGroupDetailClick(val groupId: String) : GroupIntent()

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupIntent.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupIntent.kt
@@ -7,4 +7,7 @@ import com.boostcamp.mapisode.ui.base.UiIntent
 sealed class GroupIntent : UiIntent {
 	data object LoadGroups : GroupIntent()
 	data object EndLoadingGroups : GroupIntent()
+	data object OnJoinClick : GroupIntent()
+	data object OnGroupCreateClick : GroupIntent()
+	data class OnGroupDetailClick(val groupId: String) : GroupIntent()
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupJoinIntent.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupJoinIntent.kt
@@ -5,6 +5,6 @@ import androidx.compose.runtime.Immutable
 @Immutable
 sealed class GroupJoinIntent {
 	data class TryGetGroup(val inviteCode: String) : GroupJoinIntent()
-	data class JoinTheGroup(val userId: String, val groupId: String) : GroupJoinIntent()
+	data object JoinTheGroup : GroupJoinIntent()
 	data object BackToGroupScreen : GroupJoinIntent()
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupJoinIntent.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupJoinIntent.kt
@@ -1,9 +1,10 @@
 package com.boostcamp.mapisode.mygroup.intent
 
 import androidx.compose.runtime.Immutable
+import com.boostcamp.mapisode.ui.base.UiIntent
 
 @Immutable
-sealed class GroupJoinIntent {
+sealed class GroupJoinIntent: UiIntent {
 	data class TryGetGroup(val inviteCode: String) : GroupJoinIntent()
 	data object JoinTheGroup : GroupJoinIntent()
 	data object BackToGroupScreen : GroupJoinIntent()

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupJoinIntent.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupJoinIntent.kt
@@ -4,8 +4,8 @@ import androidx.compose.runtime.Immutable
 import com.boostcamp.mapisode.ui.base.UiIntent
 
 @Immutable
-sealed class GroupJoinIntent: UiIntent {
+sealed class GroupJoinIntent : UiIntent {
 	data class TryGetGroup(val inviteCode: String) : GroupJoinIntent()
-	data object JoinTheGroup : GroupJoinIntent()
-	data object BackToGroupScreen : GroupJoinIntent()
+	data object OnJoinClick : GroupJoinIntent()
+	data object OnBackClick : GroupJoinIntent()
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupJoinIntent.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupJoinIntent.kt
@@ -1,0 +1,10 @@
+package com.boostcamp.mapisode.mygroup.intent
+
+import androidx.compose.runtime.Immutable
+
+@Immutable
+sealed class GroupJoinIntent {
+	data class TryGetGroup(val inviteCode: String) : GroupJoinIntent()
+	data class JoinTheGroup(val userId: String, val groupId: String) : GroupJoinIntent()
+	data object BackToGroupScreen : GroupJoinIntent()
+}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/navigation/GroupNavigation.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/navigation/GroupNavigation.kt
@@ -60,8 +60,8 @@ fun NavGraphBuilder.addGroupNavGraph(
 		)
 	}
 
-	composable<GroupRoute.Detail> {backStackEntry ->
-		val detail : GroupRoute.Detail = backStackEntry.toRoute()
+	composable<GroupRoute.Detail> { backStackEntry ->
+		val detail: GroupRoute.Detail = backStackEntry.toRoute()
 
 		GroupDetailScreen(
 			detail = detail,
@@ -76,8 +76,8 @@ fun NavGraphBuilder.addGroupNavGraph(
 		)
 	}
 
-	composable<GroupRoute.Edit> {backStackEntry ->
-		val edit : GroupRoute.Edit = backStackEntry.toRoute()
+	composable<GroupRoute.Edit> { backStackEntry ->
+		val edit: GroupRoute.Edit = backStackEntry.toRoute()
 
 		GroupEditScreen(
 			edit = edit,

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/navigation/GroupNavigation.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/navigation/GroupNavigation.kt
@@ -4,6 +4,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import androidx.navigation.toRoute
 import com.boostcamp.mapisode.mygroup.screen.GroupCreationScreen
 import com.boostcamp.mapisode.mygroup.screen.GroupDetailScreen
 import com.boostcamp.mapisode.mygroup.screen.GroupEditScreen
@@ -19,9 +20,10 @@ fun NavController.navigateGroupJoin(
 }
 
 fun NavController.navigateGroupDetail(
+	groupId: String,
 	navOptions: NavOptions? = null,
 ) {
-	navigate(GroupRoute.Detail, navOptions)
+	navigate(GroupRoute.Detail(groupId), navOptions)
 }
 
 fun NavController.navigateGroupCreation(
@@ -31,17 +33,18 @@ fun NavController.navigateGroupCreation(
 }
 
 fun NavController.navigateGroupEdit(
+	groupId: String,
 	navOptions: NavOptions? = null,
 ) {
-	navigate(GroupRoute.Edit, navOptions)
+	navigate(GroupRoute.Edit(groupId), navOptions)
 }
 
 fun NavGraphBuilder.addGroupNavGraph(
 	onBackClick: () -> Unit,
 	onGroupJoinClick: () -> Unit,
-	onGroupDetailClick: () -> Unit,
+	onGroupDetailClick: (String) -> Unit,
 	onGroupCreationClick: () -> Unit,
-	onGroupEditClick: () -> Unit,
+	onGroupEditClick: (String) -> Unit,
 ) {
 	composable<MainRoute.Group> {
 		MainGroupRoute(
@@ -57,8 +60,11 @@ fun NavGraphBuilder.addGroupNavGraph(
 		)
 	}
 
-	composable<GroupRoute.Detail> {
+	composable<GroupRoute.Detail> {backStackEntry ->
+		val detail : GroupRoute.Detail = backStackEntry.toRoute()
+
 		GroupDetailScreen(
+			detail = detail,
 			onBackClick = onBackClick,
 			onEditClick = onGroupEditClick,
 		)
@@ -70,8 +76,11 @@ fun NavGraphBuilder.addGroupNavGraph(
 		)
 	}
 
-	composable<GroupRoute.Edit> {
+	composable<GroupRoute.Edit> {backStackEntry ->
+		val edit : GroupRoute.Edit = backStackEntry.toRoute()
+
 		GroupEditScreen(
+			edit = edit,
 			onBackClick = onBackClick,
 		)
 	}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupCreationScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupCreationScreen.kt
@@ -18,7 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -131,9 +131,9 @@ fun GroupCreationField(
 	paddingValues: PaddingValues,
 	onGroupEditClick: (title: String, content: String, imageUrl: String) -> Unit,
 ) {
-	var name by remember { mutableStateOf("") }
-	var description by remember { mutableStateOf("") }
-	var profileUrl by remember { mutableStateOf("") }
+	var name by rememberSaveable { mutableStateOf("") }
+	var description by rememberSaveable { mutableStateOf("") }
+	var profileUrl by rememberSaveable { mutableStateOf("") }
 
 	Box(
 		modifier = Modifier

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupCreationScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupCreationScreen.kt
@@ -1,38 +1,115 @@
 package com.boostcamp.mapisode.mygroup.screen
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil3.compose.AsyncImage
 import com.boostcamp.mapisode.designsystem.R
-import com.boostcamp.mapisode.designsystem.compose.MapisodeDialog
+import com.boostcamp.mapisode.designsystem.compose.Direction
+import com.boostcamp.mapisode.designsystem.compose.MapisodeDivider
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIconButton
 import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
+import com.boostcamp.mapisode.designsystem.compose.MapisodeText
+import com.boostcamp.mapisode.designsystem.compose.MapisodeTextField
+import com.boostcamp.mapisode.designsystem.compose.Thickness
 import com.boostcamp.mapisode.designsystem.compose.button.MapisodeFilledButton
+import com.boostcamp.mapisode.designsystem.compose.button.MapisodeImageButton
 import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
+import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
+import com.boostcamp.mapisode.mygroup.intent.GroupCreationIntent
+import com.boostcamp.mapisode.mygroup.sideeffect.GroupCreationSideEffect
+import com.boostcamp.mapisode.mygroup.sideeffect.rememberFlowWithLifecycle
+import com.boostcamp.mapisode.mygroup.state.GroupCreationState
+import com.boostcamp.mapisode.mygroup.viewmodel.GroupCreationViewModel
 
 @Composable
-fun GroupCreationScreen(onBackClick: () -> Unit) {
-	var isNavigationIconEnabled by remember { mutableStateOf(true) }
+fun GroupCreationScreen(
+	onBackClick: () -> Unit,
+	viewModel: GroupCreationViewModel = hiltViewModel(),
+) {
+	val uiState = viewModel.uiState.collectAsStateWithLifecycle()
+	val effect = rememberFlowWithLifecycle(
+		flow = viewModel.sideEffect,
+		initialValue = GroupCreationSideEffect.Idle,
+	).value
+
+	LaunchedEffect(effect) {
+		when (effect) {
+			is GroupCreationSideEffect.NavigateToGroupScreen -> {
+				onBackClick()
+			}
+		}
+	}
+
+	GroupCreationContent(
+		uiState = uiState.value,
+		onBackClick = onBackClick,
+		onGroupEditClick = { title, content, imageUrl ->
+			viewModel.onIntent(
+				GroupCreationIntent.OnGroupCreationClick(
+					title = title,
+					content = content,
+					imageUrl = imageUrl,
+				),
+			)
+		},
+	)
+}
+
+@Composable
+fun GroupCreationContent(
+	uiState: GroupCreationState,
+	onBackClick: () -> Unit,
+	onGroupEditClick: (title: String, content: String, imageUrl: String) -> Unit,
+) {
+	val focusManager = LocalFocusManager.current
 
 	MapisodeScaffold(
+		modifier = Modifier
+			.fillMaxSize()
+			.pointerInput(Unit) {
+				detectTapGestures(
+					onPress = {
+						focusManager.clearFocus()
+					},
+				)
+			},
 		isStatusBarPaddingExist = true,
+		isNavigationBarPaddingExist = true,
 		topBar = {
 			TopAppBar(
-				title = "그룹 생성",
+				title = "그룹 편집",
 				navigationIcon = {
 					MapisodeIconButton(
-						onClick = { onBackClick() },
-						enabled = isNavigationIconEnabled,
+						onClick = {
+							onBackClick()
+						},
 					) {
 						MapisodeIcon(
 							id = R.drawable.ic_arrow_back_ios,
@@ -41,44 +118,135 @@ fun GroupCreationScreen(onBackClick: () -> Unit) {
 				},
 			)
 		},
-	) {
-		Column(
-			modifier = Modifier
-				.fillMaxSize()
-				.padding(it),
-			verticalArrangement = Arrangement.spacedBy(16.dp),
-			horizontalAlignment = Alignment.CenterHorizontally,
-		) {
-			MapisodeFilledButton(
-				onClick = { isNavigationIconEnabled = !isNavigationIconEnabled },
-				text = "네비게이션 아이콘 활성/비활성화",
-				showRipple = true,
-			)
-			DialogExample()
-		}
+	) { paddingValues ->
+		GroupCreationField(
+			paddingValues = paddingValues,
+			onGroupEditClick = onGroupEditClick,
+		)
 	}
 }
 
 @Composable
-fun DialogExample() {
-	var showDialog by remember { mutableStateOf(false) }
+fun GroupCreationField(
+	paddingValues: PaddingValues,
+	onGroupEditClick: (title: String, content: String, imageUrl: String) -> Unit,
+) {
+	var name by remember { mutableStateOf("") }
+	var description by remember { mutableStateOf("") }
+	var profileUrl by remember { mutableStateOf("") }
 
-	MapisodeFilledButton(onClick = { showDialog = true }, text = "다이얼로그 열기")
+	Box(
+		modifier = Modifier
+			.fillMaxSize()
+			.padding(paddingValues)
+			.padding(horizontal = 20.dp),
+	) {
+		LazyColumn(
+			modifier = Modifier
+				.fillMaxSize(),
+			horizontalAlignment = Alignment.CenterHorizontally,
+			verticalArrangement = Arrangement.spacedBy(20.dp),
+			contentPadding = PaddingValues(vertical = 10.dp),
+		) {
+			item {
+				Column {
+					MapisodeText(
+						text = "그룹 대표 이미지",
+						style = MapisodeTheme.typography.titleMedium
+							.copy(fontWeight = FontWeight.SemiBold),
+					)
 
-	if (showDialog) {
-		MapisodeDialog(
-			onDismissRequest = { showDialog = false },
-			onResultRequest = { result ->
-				if (result) {
-					// TODO: 삭제 버튼 클릭 시 처리
-				} else {
-					// TODO: 취소 버튼 클릭 시 처리
+					Spacer(modifier = Modifier.padding(4.dp))
+
+					MapisodeImageButton(
+						modifier = Modifier
+							.sizeIn(maxWidth = 380.dp, maxHeight = 380.dp)
+							.fillMaxWidth()
+							.aspectRatio(1f),
+						onClick = { },
+						showImage = false,
+						text = "이미지를 선택하세요",
+					) {
+						AsyncImage(
+							model = profileUrl,
+							contentDescription = "그룹 이미지",
+							modifier = Modifier.fillMaxSize(),
+						)
+					}
 				}
-			},
-			titleText = "정말 삭제하시겠습니까?",
-			contentText = "영구적으로 삭제됩니다.",
-			cancelText = "취소",
-			confirmText = "확인",
-		)
+			}
+			item {
+				Column(
+					modifier = Modifier
+						.sizeIn(maxWidth = 380.dp, maxHeight = 380.dp)
+						.fillMaxWidth(),
+				) {
+					MapisodeText(
+						text = "이름",
+						style = MapisodeTheme.typography.titleMedium
+							.copy(fontWeight = FontWeight.SemiBold),
+					)
+
+					Spacer(modifier = Modifier.padding(4.dp))
+
+					MapisodeTextField(
+						value = name,
+						onValueChange = {
+							name = it
+						},
+						modifier = Modifier.fillMaxWidth(),
+					)
+				}
+			}
+			item {
+				Column(
+					modifier = Modifier
+						.sizeIn(maxWidth = 380.dp, maxHeight = 380.dp)
+						.fillMaxWidth(),
+				) {
+					MapisodeText(
+						text = "설명",
+						style = MapisodeTheme.typography.titleMedium
+							.copy(fontWeight = FontWeight.SemiBold),
+					)
+
+					Spacer(modifier = Modifier.padding(4.dp))
+
+					MapisodeTextField(
+						value = description,
+						onValueChange = {
+							description = it
+						},
+						modifier = Modifier
+							.heightIn(min = 100.dp, max = 300.dp)
+							.fillMaxWidth(),
+					)
+
+					Spacer(modifier = Modifier.padding(40.dp))
+				}
+			}
+		}
+		Column(
+			modifier = Modifier
+				.fillMaxWidth()
+				.align(Alignment.BottomCenter)
+				.background(MapisodeTheme.colorScheme.surfaceBackground),
+			horizontalAlignment = Alignment.CenterHorizontally,
+		) {
+			Spacer(modifier = Modifier.padding(top = 4.dp))
+			MapisodeDivider(direction = Direction.Horizontal, thickness = Thickness.Thin)
+			Spacer(modifier = Modifier.padding(5.dp))
+			MapisodeFilledButton(
+				modifier = Modifier
+					.sizeIn(maxWidth = 380.dp, maxHeight = 380.dp)
+					.fillMaxWidth()
+					.heightIn(52.dp),
+				onClick = {
+					onGroupEditClick(name, description, profileUrl)
+				},
+				text = "편집하기",
+				showRipple = true,
+			)
+		}
 	}
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupCreationScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupCreationScreen.kt
@@ -45,7 +45,6 @@ import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 import com.boostcamp.mapisode.mygroup.intent.GroupCreationIntent
 import com.boostcamp.mapisode.mygroup.sideeffect.GroupCreationSideEffect
 import com.boostcamp.mapisode.mygroup.sideeffect.rememberFlowWithLifecycle
-import com.boostcamp.mapisode.mygroup.state.GroupCreationState
 import com.boostcamp.mapisode.mygroup.viewmodel.GroupCreationViewModel
 
 @Composable
@@ -67,8 +66,13 @@ fun GroupCreationScreen(
 		}
 	}
 
+	LaunchedEffect(uiState.value.isGroupEditError) {
+		if (uiState.value.isGroupEditError) {
+			viewModel.onIntent(GroupCreationIntent.OnGroupCreationError)
+		}
+	}
+
 	GroupCreationContent(
-		uiState = uiState.value,
 		onBackClick = onBackClick,
 		onGroupEditClick = { title, content, imageUrl ->
 			viewModel.onIntent(
@@ -84,7 +88,6 @@ fun GroupCreationScreen(
 
 @Composable
 fun GroupCreationContent(
-	uiState: GroupCreationState,
 	onBackClick: () -> Unit,
 	onGroupEditClick: (title: String, content: String, imageUrl: String) -> Unit,
 ) {

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupDetailScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupDetailScreen.kt
@@ -12,6 +12,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.boostcamp.mapisode.designsystem.R
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIconButton
@@ -20,6 +22,7 @@ import com.boostcamp.mapisode.designsystem.compose.MapisodeText
 import com.boostcamp.mapisode.designsystem.compose.tab.MapisodeTab
 import com.boostcamp.mapisode.designsystem.compose.tab.MapisodeTabRow
 import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
+import com.boostcamp.mapisode.mygroup.viewmodel.GroupDetailViewModel
 import com.boostcamp.mapisode.navigation.GroupRoute
 import kotlinx.coroutines.launch
 
@@ -28,10 +31,13 @@ fun GroupDetailScreen(
 	detail: GroupRoute.Detail,
 	onBackClick: () -> Unit,
 	onEditClick: (String) -> Unit,
+	viewModel: GroupDetailViewModel = hiltViewModel(),
 ) {
 	val pagerState = rememberPagerState(pageCount = { 2 })
 	val list = listOf("그룹 상세", "에피소드")
+	viewModel.getGroupDetail(detail.groupId)
 	val scope = rememberCoroutineScope()
+	val uiState = viewModel.uiState.collectAsStateWithLifecycle()
 	val groupId = detail.groupId
 
 	MapisodeScaffold(
@@ -50,7 +56,9 @@ fun GroupDetailScreen(
 				},
 				actions = {
 					MapisodeIconButton(
-						onClick = { },
+						onClick = {
+							onEditClick(groupId)
+						},
 					) {
 						MapisodeIcon(
 							id = R.drawable.ic_edit,
@@ -94,14 +102,25 @@ fun GroupDetailScreen(
 fun TabsContent(pagerState: PagerState) {
 	HorizontalPager(state = pagerState) { page ->
 		when (page) {
-			0 -> TabContentScreen(data = "그룹 상세")
-			1 -> TabContentScreen(data = "에피소드")
+			0 -> GroupDetailContent(data = "그룹 상세")
+			1 -> GroupEpisodesContent(data = "에피소드")
 		}
 	}
 }
 
 @Composable
-fun TabContentScreen(data: String) {
+fun GroupDetailContent(data: String) {
+	Column(
+		modifier = Modifier.fillMaxSize(),
+		horizontalAlignment = Alignment.CenterHorizontally,
+		verticalArrangement = Arrangement.Center,
+	) {
+		MapisodeText(text = data)
+	}
+}
+
+@Composable
+fun GroupEpisodesContent(data: String) {
 	Column(
 		modifier = Modifier.fillMaxSize(),
 		horizontalAlignment = Alignment.CenterHorizontally,

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupDetailScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupDetailScreen.kt
@@ -69,7 +69,6 @@ import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 import com.boostcamp.mapisode.model.EpisodeModel
 import com.boostcamp.mapisode.model.GroupMemberModel
 import com.boostcamp.mapisode.model.GroupModel
-import com.boostcamp.mapisode.mygroup.R as S
 import com.boostcamp.mapisode.mygroup.intent.GroupDetailIntent
 import com.boostcamp.mapisode.mygroup.sideeffect.GroupDetailSideEffect
 import com.boostcamp.mapisode.mygroup.sideeffect.rememberFlowWithLifecycle
@@ -77,6 +76,7 @@ import com.boostcamp.mapisode.mygroup.state.GroupDetailState
 import com.boostcamp.mapisode.mygroup.viewmodel.GroupDetailViewModel
 import com.boostcamp.mapisode.navigation.GroupRoute
 import kotlinx.coroutines.launch
+import com.boostcamp.mapisode.mygroup.R as S
 
 @Composable
 fun GroupDetailScreen(
@@ -500,7 +500,6 @@ fun GroupMemberContent(
 		}
 	}
 }
-
 
 @Composable
 fun EpisodeCard(

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupDetailScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupDetailScreen.kt
@@ -171,7 +171,7 @@ fun GroupDetailScreen(
 			viewModel.onIntent(GroupDetailIntent.OnBackClick)
 		},
 		onEditClick = {
-			viewModel.onIntent(GroupDetailIntent.OnEditClick(detail.groupId))
+			viewModel.onIntent(GroupDetailIntent.OnEditClick)
 		},
 		onIssueCodeClick = {
 			viewModel.onIntent(GroupDetailIntent.OnIssueCodeClick)
@@ -209,15 +209,18 @@ fun GroupDetailContent(
 						)
 					}
 				},
+
 				actions = {
-					MapisodeIconButton(
-						onClick = {
-							onEditClick()
-						},
-					) {
-						MapisodeIcon(
-							id = R.drawable.ic_edit,
-						)
+					if (uiState.isGroupOwner) {
+						MapisodeIconButton(
+							onClick = {
+								onEditClick()
+							},
+						) {
+							MapisodeIcon(
+								id = R.drawable.ic_edit,
+							)
+						}
 					}
 				},
 			)

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupDetailScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupDetailScreen.kt
@@ -20,22 +20,25 @@ import com.boostcamp.mapisode.designsystem.compose.MapisodeText
 import com.boostcamp.mapisode.designsystem.compose.tab.MapisodeTab
 import com.boostcamp.mapisode.designsystem.compose.tab.MapisodeTabRow
 import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
+import com.boostcamp.mapisode.navigation.GroupRoute
 import kotlinx.coroutines.launch
 
 @Composable
 fun GroupDetailScreen(
+	detail: GroupRoute.Detail,
 	onBackClick: () -> Unit,
-	onEditClick: () -> Unit,
+	onEditClick: (String) -> Unit,
 ) {
 	val pagerState = rememberPagerState(pageCount = { 2 })
 	val list = listOf("그룹 상세", "에피소드")
 	val scope = rememberCoroutineScope()
+	val groupId = detail.groupId
 
 	MapisodeScaffold(
 		isStatusBarPaddingExist = true,
 		topBar = {
 			TopAppBar(
-				title = "그룹 상세",
+				title = groupId,
 				navigationIcon = {
 					MapisodeIconButton(
 						onClick = { onBackClick() },

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupDetailScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupDetailScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -22,6 +23,7 @@ import com.boostcamp.mapisode.designsystem.compose.MapisodeText
 import com.boostcamp.mapisode.designsystem.compose.tab.MapisodeTab
 import com.boostcamp.mapisode.designsystem.compose.tab.MapisodeTabRow
 import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
+import com.boostcamp.mapisode.mygroup.intent.GroupDetailIntent
 import com.boostcamp.mapisode.mygroup.viewmodel.GroupDetailViewModel
 import com.boostcamp.mapisode.navigation.GroupRoute
 import kotlinx.coroutines.launch
@@ -35,16 +37,18 @@ fun GroupDetailScreen(
 ) {
 	val pagerState = rememberPagerState(pageCount = { 2 })
 	val list = listOf("그룹 상세", "에피소드")
-	viewModel.getGroupDetail(detail.groupId)
 	val scope = rememberCoroutineScope()
 	val uiState = viewModel.uiState.collectAsStateWithLifecycle()
-	val groupId = detail.groupId
+
+	LaunchedEffect(uiState) {
+		viewModel.onIntent(GroupDetailIntent.GetGroupId(detail.groupId))
+	}
 
 	MapisodeScaffold(
 		isStatusBarPaddingExist = true,
 		topBar = {
 			TopAppBar(
-				title = groupId,
+				title = "그룹 상세",
 				navigationIcon = {
 					MapisodeIconButton(
 						onClick = { onBackClick() },
@@ -57,7 +61,7 @@ fun GroupDetailScreen(
 				actions = {
 					MapisodeIconButton(
 						onClick = {
-							onEditClick(groupId)
+							onEditClick(detail.groupId)
 						},
 					) {
 						MapisodeIcon(

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupEditScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupEditScreen.kt
@@ -18,7 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -144,9 +144,9 @@ fun GroupEditField(
 	group: GroupModel,
 	onGroupEditClick: (title: String, content: String, imageUrl: String) -> Unit,
 ) {
-	var name by remember { mutableStateOf(group.name) }
-	var description by remember { mutableStateOf(group.description) }
-	var profileUrl by remember { mutableStateOf(group.imageUrl) }
+	var name by rememberSaveable { mutableStateOf(group.name) }
+	var description by rememberSaveable { mutableStateOf(group.description) }
+	var profileUrl by rememberSaveable { mutableStateOf(group.imageUrl) }
 
 	Box(
 		modifier = Modifier

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupEditScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupEditScreen.kt
@@ -23,13 +23,16 @@ import com.boostcamp.mapisode.designsystem.compose.MapisodeIconButton
 import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
 import com.boostcamp.mapisode.designsystem.compose.button.MapisodeImageButton
 import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
+import com.boostcamp.mapisode.navigation.GroupRoute
 
 @Composable
 fun GroupEditScreen(
+	edit: GroupRoute.Edit,
 	onBackClick: () -> Unit,
 	// onEpisodeClick: () -> Unit,
 ) {
 	val focusManager = LocalFocusManager.current
+	val groupId = edit.groupId
 
 	MapisodeScaffold(
 		modifier = Modifier

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupEditScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupEditScreen.kt
@@ -1,12 +1,19 @@
 package com.boostcamp.mapisode.mygroup.screen
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -17,18 +24,29 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
 import com.boostcamp.mapisode.designsystem.R
+import com.boostcamp.mapisode.designsystem.compose.Direction
+import com.boostcamp.mapisode.designsystem.compose.MapisodeDivider
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIconButton
 import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
+import com.boostcamp.mapisode.designsystem.compose.MapisodeText
+import com.boostcamp.mapisode.designsystem.compose.MapisodeTextField
+import com.boostcamp.mapisode.designsystem.compose.Thickness
+import com.boostcamp.mapisode.designsystem.compose.button.MapisodeFilledButton
 import com.boostcamp.mapisode.designsystem.compose.button.MapisodeImageButton
 import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
+import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
+import com.boostcamp.mapisode.model.GroupModel
 import com.boostcamp.mapisode.mygroup.intent.GroupEditIntent
 import com.boostcamp.mapisode.mygroup.sideeffect.GroupEditSideEffect
 import com.boostcamp.mapisode.mygroup.sideeffect.rememberFlowWithLifecycle
+import com.boostcamp.mapisode.mygroup.state.GroupEditState
 import com.boostcamp.mapisode.mygroup.viewmodel.GroupEditViewModel
 import com.boostcamp.mapisode.navigation.GroupRoute
 
@@ -45,7 +63,7 @@ fun GroupEditScreen(
 	).value
 
 	LaunchedEffect(uiState.value) {
-		if(uiState.value.isInitializing) {
+		if (uiState.value.isInitializing) {
 			viewModel.onIntent(GroupEditIntent.LoadGroups(edit.groupId))
 		}
 	}
@@ -59,13 +77,25 @@ fun GroupEditScreen(
 	}
 
 	GroupEditContent(
+		uiState = uiState.value,
 		onBackClick = onBackClick,
+		onGroupEditClick = { title, content, imageUrl ->
+			viewModel.onIntent(
+				GroupEditIntent.OnGroupEditClick(
+					title = title,
+					content = content,
+					imageUrl = imageUrl,
+				),
+			)
+		},
 	)
 }
 
 @Composable
 fun GroupEditContent(
+	uiState: GroupEditState,
 	onBackClick: () -> Unit,
+	onGroupEditClick: (title: String, content: String, imageUrl: String) -> Unit,
 ) {
 	val focusManager = LocalFocusManager.current
 
@@ -80,6 +110,7 @@ fun GroupEditContent(
 				)
 			},
 		isStatusBarPaddingExist = true,
+		isNavigationBarPaddingExist = true,
 		topBar = {
 			TopAppBar(
 				title = "그룹 편집",
@@ -96,29 +127,139 @@ fun GroupEditContent(
 				},
 			)
 		},
+	) { paddingValues ->
+		if (uiState.group != null) {
+			GroupEditField(
+				paddingValues = paddingValues,
+				group = uiState.group,
+				onGroupEditClick = onGroupEditClick,
+			)
+		}
+	}
+}
+
+@Composable
+fun GroupEditField(
+	paddingValues: PaddingValues,
+	group: GroupModel,
+	onGroupEditClick: (title: String, content: String, imageUrl: String) -> Unit,
+) {
+	var name by remember { mutableStateOf(group.name) }
+	var description by remember { mutableStateOf(group.description) }
+	var profileUrl by remember { mutableStateOf(group.imageUrl) }
+
+	Box(
+		modifier = Modifier
+			.fillMaxSize()
+			.padding(paddingValues)
+			.padding(horizontal = 20.dp),
 	) {
-		var isClicked by remember { mutableStateOf(true) }
+		LazyColumn(
+			modifier = Modifier
+				.fillMaxSize(),
+			horizontalAlignment = Alignment.CenterHorizontally,
+			verticalArrangement = Arrangement.spacedBy(20.dp),
+			contentPadding = PaddingValues(vertical = 10.dp),
+		) {
+			item {
+				Column {
+					MapisodeText(
+						text = "그룹 대표 이미지",
+						style = MapisodeTheme.typography.titleMedium
+							.copy(fontWeight = FontWeight.SemiBold),
+					)
+
+					Spacer(modifier = Modifier.padding(4.dp))
+
+					MapisodeImageButton(
+						modifier = Modifier
+							.sizeIn(maxWidth = 380.dp, maxHeight = 380.dp)
+							.fillMaxWidth()
+							.aspectRatio(1f),
+						onClick = { },
+						showImage = false,
+						text = "이미지를 선택하세요",
+					) {
+						AsyncImage(
+							model = profileUrl,
+							contentDescription = "그룹 이미지",
+							modifier = Modifier.fillMaxSize(),
+						)
+					}
+				}
+			}
+			item {
+				Column(
+					modifier = Modifier
+						.sizeIn(maxWidth = 380.dp, maxHeight = 380.dp)
+						.fillMaxWidth(),
+				) {
+					MapisodeText(
+						text = "이름",
+						style = MapisodeTheme.typography.titleMedium
+							.copy(fontWeight = FontWeight.SemiBold),
+					)
+
+					Spacer(modifier = Modifier.padding(4.dp))
+
+					MapisodeTextField(
+						value = name,
+						onValueChange = {
+							name = it
+						},
+						modifier = Modifier.fillMaxWidth(),
+					)
+				}
+			}
+			item {
+				Column(
+					modifier = Modifier
+						.sizeIn(maxWidth = 380.dp, maxHeight = 380.dp)
+						.fillMaxWidth(),
+				) {
+					MapisodeText(
+						text = "설명",
+						style = MapisodeTheme.typography.titleMedium
+							.copy(fontWeight = FontWeight.SemiBold),
+					)
+
+					Spacer(modifier = Modifier.padding(4.dp))
+
+					MapisodeTextField(
+						value = description,
+						onValueChange = {
+							description = it
+						},
+						modifier = Modifier
+							.heightIn(min = 100.dp, max = 300.dp)
+							.fillMaxWidth(),
+					)
+
+					Spacer(modifier = Modifier.padding(40.dp))
+				}
+			}
+		}
 		Column(
 			modifier = Modifier
-				.fillMaxSize()
-				.padding(it),
-			verticalArrangement = Arrangement.Center,
+				.fillMaxWidth()
+				.align(Alignment.BottomCenter)
+				.background(MapisodeTheme.colorScheme.surfaceBackground),
 			horizontalAlignment = Alignment.CenterHorizontally,
 		) {
-			MapisodeImageButton(
+			Spacer(modifier = Modifier.padding(top = 4.dp))
+			MapisodeDivider(direction = Direction.Horizontal, thickness = Thickness.Thin)
+			Spacer(modifier = Modifier.padding(5.dp))
+			MapisodeFilledButton(
 				modifier = Modifier
-					.fillMaxWidth(0.8f)
-					.aspectRatio(1f),
-				onClick = { isClicked = !isClicked },
-				showImage = isClicked,
-				text = "이미지를 선택하세요",
-			) {
-				AsyncImage(
-					model = "https://m.media-amazon.com/images/I/61jyqnlyIaS.jpg",
-					contentDescription = "그룹 이미지",
-					modifier = Modifier.fillMaxSize(),
-				)
-			}
+					.sizeIn(maxWidth = 380.dp, maxHeight = 380.dp)
+					.fillMaxWidth()
+					.heightIn(52.dp),
+				onClick = {
+					onGroupEditClick(name, description, profileUrl)
+				},
+				text = "편집하기",
+				showRipple = true,
+			)
 		}
 	}
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupEditScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupEditScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -16,6 +17,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
 import com.boostcamp.mapisode.designsystem.R
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
@@ -23,16 +26,48 @@ import com.boostcamp.mapisode.designsystem.compose.MapisodeIconButton
 import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
 import com.boostcamp.mapisode.designsystem.compose.button.MapisodeImageButton
 import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
+import com.boostcamp.mapisode.mygroup.intent.GroupEditIntent
+import com.boostcamp.mapisode.mygroup.sideeffect.GroupEditSideEffect
+import com.boostcamp.mapisode.mygroup.sideeffect.rememberFlowWithLifecycle
+import com.boostcamp.mapisode.mygroup.viewmodel.GroupEditViewModel
 import com.boostcamp.mapisode.navigation.GroupRoute
 
 @Composable
 fun GroupEditScreen(
 	edit: GroupRoute.Edit,
 	onBackClick: () -> Unit,
-	// onEpisodeClick: () -> Unit,
+	viewModel: GroupEditViewModel = hiltViewModel(),
+) {
+	val uiState = viewModel.uiState.collectAsStateWithLifecycle()
+	val effect = rememberFlowWithLifecycle(
+		flow = viewModel.sideEffect,
+		initialValue = GroupEditSideEffect.Idle,
+	).value
+
+	LaunchedEffect(uiState.value) {
+		if(uiState.value.isInitializing) {
+			viewModel.onIntent(GroupEditIntent.LoadGroups(edit.groupId))
+		}
+	}
+
+	LaunchedEffect(effect) {
+		when (effect) {
+			is GroupEditSideEffect.NavigateToGroupDetailScreen -> {
+				onBackClick()
+			}
+		}
+	}
+
+	GroupEditContent(
+		onBackClick = onBackClick,
+	)
+}
+
+@Composable
+fun GroupEditContent(
+	onBackClick: () -> Unit,
 ) {
 	val focusManager = LocalFocusManager.current
-	val groupId = edit.groupId
 
 	MapisodeScaffold(
 		modifier = Modifier
@@ -47,7 +82,7 @@ fun GroupEditScreen(
 		isStatusBarPaddingExist = true,
 		topBar = {
 			TopAppBar(
-				title = "나의 그룹",
+				title = "그룹 편집",
 				navigationIcon = {
 					MapisodeIconButton(
 						onClick = {

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupJoinScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupJoinScreen.kt
@@ -63,10 +63,23 @@ fun GroupJoinScreen(
 	val focusManager = LocalFocusManager.current
 	var joinCodeText by rememberSaveable { mutableStateOf("") }
 	var onGetGroup by remember { mutableStateOf(false) }
+	var onJoinGroup by remember { mutableStateOf(false) }
+
 	val uiState = viewModel.uiState.collectAsStateWithLifecycle()
 
 	LaunchedEffect(onGetGroup) {
 		viewModel.onIntent(GroupJoinIntent.TryGetGroup(joinCodeText))
+	}
+
+	LaunchedEffect(onJoinGroup) {
+		viewModel.onIntent(GroupJoinIntent.JoinTheGroup)
+	}
+
+	LaunchedEffect(uiState.value.isJoinedSuccess) {
+		if (uiState.value.isJoinedSuccess) {
+			viewModel.onIntent(GroupJoinIntent.BackToGroupScreen)
+			onBackClick()
+		}
 	}
 
 	MapisodeScaffold(
@@ -187,7 +200,7 @@ fun GroupJoinScreen(
 					Spacer(modifier = Modifier.padding(5.dp))
 					MapisodeFilledButton(
 						modifier = Modifier.fillMaxWidth(),
-						onClick = {},
+						onClick = { onJoinGroup = !onJoinGroup },
 						text = "참여하기",
 						showRipple = true,
 					)

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupJoinScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupJoinScreen.kt
@@ -3,10 +3,8 @@ package com.boostcamp.mapisode.mygroup.screen
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
@@ -14,9 +12,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
@@ -28,15 +24,12 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import coil3.compose.AsyncImage
 import com.boostcamp.mapisode.designsystem.R
 import com.boostcamp.mapisode.designsystem.compose.Direction
 import com.boostcamp.mapisode.designsystem.compose.MapisodeDivider
@@ -48,6 +41,7 @@ import com.boostcamp.mapisode.designsystem.compose.MapisodeTextField
 import com.boostcamp.mapisode.designsystem.compose.TextAlignment
 import com.boostcamp.mapisode.designsystem.compose.Thickness
 import com.boostcamp.mapisode.designsystem.compose.button.MapisodeFilledButton
+import com.boostcamp.mapisode.designsystem.compose.card.GroupInfoCard
 import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
 import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 import com.boostcamp.mapisode.model.GroupModel
@@ -224,58 +218,9 @@ fun ConfirmJoinGroup(group: GroupModel) {
 			style = MapisodeTheme.typography.labelLarge,
 		)
 		Spacer(modifier = Modifier.padding(4.dp))
-		Row(
-			modifier = Modifier
-				.fillMaxWidth()
-				.border(
-					width = 1.dp,
-					color = MapisodeTheme.colorScheme.textColoredContainer,
-					shape = RoundedCornerShape(12.dp),
-				)
-				.padding(10.dp)
-				.height(140.dp),
-		) {
-			AsyncImage(
-				model = group.imageUrl,
-				contentDescription = "",
-				modifier = Modifier
-					.size(140.dp)
-					.clip(shape = RoundedCornerShape(16.dp)),
-			)
-			MapisodeDivider(thickness = Thickness.Thick)
-			Column(
-				modifier = Modifier
-					.fillMaxHeight()
-					.wrapContentWidth(),
-				verticalArrangement = Arrangement.Center,
-			) {
-				MapisodeText(
-					text = group.name,
-					style = MapisodeTheme.typography.titleMedium
-						.copy(fontWeight = FontWeight.SemiBold),
-					maxLines = 1,
-				)
-				Spacer(modifier = Modifier.padding(4.dp))
 
-				MapisodeText(
-					text = stringResource(S.string.group_created_date) + group.createdAt,
-					style = MapisodeTheme.typography.labelMedium,
-				)
-				MapisodeText(
-					text = stringResource(
-						S.string.group_user_count,
-						stringResource(S.string.group_members_number),
-						group.members.size,
-						stringResource(S.string.group_member_count),
-					),
-					style = MapisodeTheme.typography.labelMedium,
-				)
-				MapisodeText(
-					text = stringResource(S.string.group_recent_upload),
-					style = MapisodeTheme.typography.labelMedium,
-				)
-			}
-		}
+		GroupInfoCard(group = group)
+
 		Spacer(modifier = Modifier.padding(10.dp))
 		MapisodeText(
 			modifier = Modifier

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupJoinScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupJoinScreen.kt
@@ -247,7 +247,15 @@ fun ConfirmJoinGroup(group: GroupModel) {
 		)
 		Spacer(modifier = Modifier.padding(4.dp))
 
-		GroupInfoCard(group = group)
+		GroupInfoCard(
+			group = group,
+			modifier = Modifier
+				.border(
+					width = 1.dp,
+					color = MapisodeTheme.colorScheme.textColoredContainer,
+					shape = RoundedCornerShape(12.dp),
+				),
+		)
 
 		Spacer(modifier = Modifier.padding(10.dp))
 		MapisodeText(

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupJoinScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupJoinScreen.kt
@@ -68,7 +68,7 @@ fun GroupJoinScreen(
 
 	LaunchedEffect(effect) {
 		when (effect) {
-			is GroupJoinSideEffect.NavigateToGroupJoinScreen -> {
+			is GroupJoinSideEffect.NavigateToGroupScreen -> {
 				onBackClick()
 			}
 

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupScreen.kt
@@ -29,7 +29,7 @@ import com.boostcamp.mapisode.designsystem.compose.MapisodeText
 import com.boostcamp.mapisode.designsystem.compose.menu.MapisodeDropdownMenu
 import com.boostcamp.mapisode.designsystem.compose.menu.MapisodeDropdownMenuItem
 import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
-import com.boostcamp.mapisode.mygroup.component.GroupCard
+import com.boostcamp.mapisode.designsystem.compose.card.GroupCard
 import com.boostcamp.mapisode.mygroup.intent.GroupIntent
 import com.boostcamp.mapisode.mygroup.intent.GroupState
 import com.boostcamp.mapisode.mygroup.viewmodel.GroupViewModel

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupScreen.kt
@@ -38,7 +38,7 @@ import com.boostcamp.mapisode.mygroup.R as S
 @Composable
 internal fun MainGroupRoute(
 	onGroupJoinClick: () -> Unit,
-	onGroupDetailClick: () -> Unit,
+	onGroupDetailClick: (String) -> Unit,
 	onGroupCreationClick: () -> Unit,
 	viewModel: GroupViewModel = hiltViewModel(),
 ) {
@@ -55,7 +55,7 @@ internal fun MainGroupRoute(
 @Composable
 private fun <T> GroupScreen(
 	onGroupJoinClick: () -> Unit,
-	onGroupDetailClick: () -> Unit,
+	onGroupDetailClick: (String) -> Unit,
 	onGroupCreationClick: () -> Unit,
 	uiState: State<T>,
 	onIntent: (GroupIntent) -> Unit,
@@ -135,6 +135,7 @@ private fun <T> GroupScreen(
 					item {
 						GroupCard(
 							onGroupDetailClick = onGroupDetailClick,
+							groupId = group.id,
 							imageUrl = group.imageUrl,
 							title = group.name,
 							content = stringResource(S.string.group_members_number) + group.members.size.toString(),

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupScreen.kt
@@ -31,7 +31,7 @@ import com.boostcamp.mapisode.designsystem.compose.menu.MapisodeDropdownMenuItem
 import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
 import com.boostcamp.mapisode.designsystem.compose.card.GroupCard
 import com.boostcamp.mapisode.mygroup.intent.GroupIntent
-import com.boostcamp.mapisode.mygroup.intent.GroupState
+import com.boostcamp.mapisode.mygroup.state.GroupState
 import com.boostcamp.mapisode.mygroup.viewmodel.GroupViewModel
 import com.boostcamp.mapisode.mygroup.R as S
 

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/sideeffect/GroupCreationSideEffect.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/sideeffect/GroupCreationSideEffect.kt
@@ -1,0 +1,11 @@
+package com.boostcamp.mapisode.mygroup.sideeffect
+
+import androidx.compose.runtime.Immutable
+import com.boostcamp.mapisode.ui.base.SideEffect
+
+@Immutable
+sealed class GroupCreationSideEffect : SideEffect {
+	data object Idle : GroupSideEffect()
+	data class ShowToast(val messageResId: Int) : GroupCreationSideEffect()
+	data object NavigateToGroupScreen : GroupCreationSideEffect()
+}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/sideeffect/GroupDetailSideEffect.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/sideeffect/GroupDetailSideEffect.kt
@@ -6,8 +6,9 @@ import com.boostcamp.mapisode.ui.base.SideEffect
 @Immutable
 sealed class GroupDetailSideEffect : SideEffect {
 	data object Idle : GroupJoinSideEffect()
-	data class ShowToast(val message: String) : GroupDetailSideEffect()
+	data class ShowToast(val messageResId: Int) : GroupDetailSideEffect()
 	data class NavigateToGroupEditScreen(val groupId: String) : GroupDetailSideEffect()
 	data object NavigateToGroupScreen : GroupDetailSideEffect()
 	data class NavigateToEpisode(val episodeId: String) : GroupDetailSideEffect()
+	data class IssueInvitationCode(val invitationCode: String) : GroupDetailSideEffect()
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/sideeffect/GroupDetailSideEffect.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/sideeffect/GroupDetailSideEffect.kt
@@ -5,5 +5,9 @@ import com.boostcamp.mapisode.ui.base.SideEffect
 
 @Immutable
 sealed class GroupDetailSideEffect : SideEffect {
+	data object Idle : GroupJoinSideEffect()
 	data class ShowToast(val message: String) : GroupDetailSideEffect()
+	data object NavigateToGroupEditScreen : GroupDetailSideEffect()
+	data object NavigateToGroupScreen : GroupDetailSideEffect()
+	data class NavigateToEpisode(val episodeId: String) : GroupDetailSideEffect()
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/sideeffect/GroupDetailSideEffect.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/sideeffect/GroupDetailSideEffect.kt
@@ -7,7 +7,7 @@ import com.boostcamp.mapisode.ui.base.SideEffect
 sealed class GroupDetailSideEffect : SideEffect {
 	data object Idle : GroupJoinSideEffect()
 	data class ShowToast(val message: String) : GroupDetailSideEffect()
-	data object NavigateToGroupEditScreen : GroupDetailSideEffect()
+	data class NavigateToGroupEditScreen(val groupId: String) : GroupDetailSideEffect()
 	data object NavigateToGroupScreen : GroupDetailSideEffect()
 	data class NavigateToEpisode(val episodeId: String) : GroupDetailSideEffect()
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/sideeffect/GroupDetailSideEffect.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/sideeffect/GroupDetailSideEffect.kt
@@ -11,4 +11,6 @@ sealed class GroupDetailSideEffect : SideEffect {
 	data object NavigateToGroupScreen : GroupDetailSideEffect()
 	data class NavigateToEpisode(val episodeId: String) : GroupDetailSideEffect()
 	data class IssueInvitationCode(val invitationCode: String) : GroupDetailSideEffect()
+	data object WarnGroupOut : GroupDetailSideEffect()
+	data object RemoveDialog : GroupDetailSideEffect()
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/sideeffect/GroupDetailSideEffect.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/sideeffect/GroupDetailSideEffect.kt
@@ -1,9 +1,9 @@
-package com.boostcamp.mapisode.mygroup.intent
+package com.boostcamp.mapisode.mygroup.sideeffect
 
 import androidx.compose.runtime.Immutable
 import com.boostcamp.mapisode.ui.base.SideEffect
 
 @Immutable
-sealed class GroupSideEffect : SideEffect {
+sealed class GroupDetailSideEffect : SideEffect {
 	data class ShowToast(val messageResId: Int) : GroupSideEffect()
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/sideeffect/GroupDetailSideEffect.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/sideeffect/GroupDetailSideEffect.kt
@@ -5,5 +5,5 @@ import com.boostcamp.mapisode.ui.base.SideEffect
 
 @Immutable
 sealed class GroupDetailSideEffect : SideEffect {
-	data class ShowToast(val messageResId: Int) : GroupSideEffect()
+	data class ShowToast(val message: String) : GroupDetailSideEffect()
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/sideeffect/GroupEditSideEffect.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/sideeffect/GroupEditSideEffect.kt
@@ -1,0 +1,11 @@
+package com.boostcamp.mapisode.mygroup.sideeffect
+
+import androidx.compose.runtime.Immutable
+import com.boostcamp.mapisode.ui.base.SideEffect
+
+@Immutable
+sealed class GroupEditSideEffect : SideEffect {
+	data object Idle : GroupSideEffect()
+	data class ShowToast(val messageResId: Int) : GroupEditSideEffect()
+	data object NavigateToGroupDetailScreen : GroupEditSideEffect()
+}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/sideeffect/GroupJoinSideEffect.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/sideeffect/GroupJoinSideEffect.kt
@@ -1,0 +1,9 @@
+package com.boostcamp.mapisode.mygroup.sideeffect
+
+import androidx.compose.runtime.Immutable
+import com.boostcamp.mapisode.ui.base.SideEffect
+
+@Immutable
+sealed class GroupJoinSideEffect : SideEffect {
+	data class ShowToast(val messageResId: Int) : GroupJoinSideEffect()
+}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/sideeffect/GroupJoinSideEffect.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/sideeffect/GroupJoinSideEffect.kt
@@ -7,5 +7,5 @@ import com.boostcamp.mapisode.ui.base.SideEffect
 sealed class GroupJoinSideEffect : SideEffect {
 	data object Idle : GroupJoinSideEffect()
 	data class ShowToast(val messageResId: Int) : GroupJoinSideEffect()
-	data object NavigateToGroupJoinScreen : GroupJoinSideEffect()
+	data object NavigateToGroupScreen : GroupJoinSideEffect()
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/sideeffect/GroupJoinSideEffect.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/sideeffect/GroupJoinSideEffect.kt
@@ -5,5 +5,7 @@ import com.boostcamp.mapisode.ui.base.SideEffect
 
 @Immutable
 sealed class GroupJoinSideEffect : SideEffect {
+	data object Idle : GroupJoinSideEffect()
 	data class ShowToast(val messageResId: Int) : GroupJoinSideEffect()
+	data object NavigateToGroupJoinScreen : GroupJoinSideEffect()
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/sideeffect/GroupSideEffect.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/sideeffect/GroupSideEffect.kt
@@ -5,5 +5,9 @@ import com.boostcamp.mapisode.ui.base.SideEffect
 
 @Immutable
 sealed class GroupSideEffect : SideEffect {
+	data object Idle : GroupSideEffect()
 	data class ShowToast(val messageResId: Int) : GroupSideEffect()
+	data object NavigateToGroupJoinScreen : GroupSideEffect()
+	data object NavigateToGroupCreateScreen : GroupSideEffect()
+	data class NavigateToGroupDetailScreen(val groupId: String) : GroupSideEffect()
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/sideeffect/GroupSideEffect.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/sideeffect/GroupSideEffect.kt
@@ -1,0 +1,9 @@
+package com.boostcamp.mapisode.mygroup.sideeffect
+
+import androidx.compose.runtime.Immutable
+import com.boostcamp.mapisode.ui.base.SideEffect
+
+@Immutable
+sealed class GroupSideEffect : SideEffect {
+	data class ShowToast(val messageResId: Int) : GroupSideEffect()
+}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/sideeffect/RememberFlowWithLifecycle.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/sideeffect/RememberFlowWithLifecycle.kt
@@ -15,8 +15,6 @@ fun <T> rememberFlowWithLifecycle(
 	flow: Flow<T>,
 	lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current,
 	initialValue: T,
-): State<T> {
-	return remember(flow, lifecycleOwner) {
-		flow.flowWithLifecycle(lifecycleOwner.lifecycle, Lifecycle.State.STARTED)
-	}.collectAsState(initial = initialValue)
-}
+): State<T> = remember(flow, lifecycleOwner) {
+	flow.flowWithLifecycle(lifecycleOwner.lifecycle, Lifecycle.State.STARTED)
+}.collectAsState(initial = initialValue)

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/sideeffect/RememberFlowWithLifecycle.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/sideeffect/RememberFlowWithLifecycle.kt
@@ -1,0 +1,22 @@
+package com.boostcamp.mapisode.mygroup.sideeffect
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.remember
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.flowWithLifecycle
+import kotlinx.coroutines.flow.Flow
+
+@Composable
+fun <T> rememberFlowWithLifecycle(
+	flow: Flow<T>,
+	lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current,
+	initialValue: T,
+): State<T> {
+	return remember(flow, lifecycleOwner) {
+		flow.flowWithLifecycle(lifecycleOwner.lifecycle, Lifecycle.State.STARTED)
+	}.collectAsState(initial = initialValue)
+}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupCreationState.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupCreationState.kt
@@ -4,6 +4,4 @@ import androidx.compose.runtime.Immutable
 import com.boostcamp.mapisode.ui.base.UiState
 
 @Immutable
-data class GroupCreationState(
-	val isGroupEditError: Boolean = false,
-) : UiState
+data class GroupCreationState(val isGroupEditError: Boolean = false) : UiState

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupCreationState.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupCreationState.kt
@@ -1,0 +1,9 @@
+package com.boostcamp.mapisode.mygroup.state
+
+import androidx.compose.runtime.Immutable
+import com.boostcamp.mapisode.ui.base.UiState
+
+@Immutable
+data class GroupCreationState(
+	val isGroupEditError: Boolean = false,
+) : UiState

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupDetailState.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupDetailState.kt
@@ -1,0 +1,11 @@
+package com.boostcamp.mapisode.mygroup.state
+
+import androidx.compose.runtime.Immutable
+import com.boostcamp.mapisode.model.GroupModel
+import com.boostcamp.mapisode.ui.base.UiState
+
+@Immutable
+data class GroupDetailState(
+	val isGroupLoading: Boolean = false,
+	val group: GroupModel? = null,
+) : UiState

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupDetailState.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupDetailState.kt
@@ -1,6 +1,7 @@
 package com.boostcamp.mapisode.mygroup.state
 
 import androidx.compose.runtime.Immutable
+import com.boostcamp.mapisode.model.GroupMemberModel
 import com.boostcamp.mapisode.model.GroupModel
 import com.boostcamp.mapisode.ui.base.UiState
 
@@ -9,4 +10,5 @@ data class GroupDetailState(
 	val isGroupIdCaching: Boolean = true,
 	val isGroupLoading: Boolean = false,
 	val group: GroupModel? = null,
+	val membersInfo: List<GroupMemberModel> = emptyList(),
 ) : UiState

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupDetailState.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupDetailState.kt
@@ -6,6 +6,7 @@ import com.boostcamp.mapisode.ui.base.UiState
 
 @Immutable
 data class GroupDetailState(
+	val isGroupIdCaching: Boolean = true,
 	val isGroupLoading: Boolean = false,
 	val group: GroupModel? = null,
 ) : UiState

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupDetailState.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupDetailState.kt
@@ -1,6 +1,7 @@
 package com.boostcamp.mapisode.mygroup.state
 
 import androidx.compose.runtime.Immutable
+import com.boostcamp.mapisode.model.EpisodeModel
 import com.boostcamp.mapisode.model.GroupMemberModel
 import com.boostcamp.mapisode.model.GroupModel
 import com.boostcamp.mapisode.ui.base.UiState
@@ -11,4 +12,5 @@ data class GroupDetailState(
 	val isGroupLoading: Boolean = false,
 	val group: GroupModel? = null,
 	val membersInfo: List<GroupMemberModel> = emptyList(),
+	val episodes: List<EpisodeModel> = emptyList(),
 ) : UiState

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupDetailState.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupDetailState.kt
@@ -10,6 +10,7 @@ import com.boostcamp.mapisode.ui.base.UiState
 data class GroupDetailState(
 	val isGroupIdCaching: Boolean = true,
 	val isGroupLoading: Boolean = false,
+	val isGroupOwner: Boolean = false,
 	val group: GroupModel? = null,
 	val membersInfo: List<GroupMemberModel> = emptyList(),
 	val episodes: List<EpisodeModel> = emptyList(),

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupEditState.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupEditState.kt
@@ -1,0 +1,12 @@
+package com.boostcamp.mapisode.mygroup.state
+
+import androidx.compose.runtime.Immutable
+import com.boostcamp.mapisode.model.GroupModel
+import com.boostcamp.mapisode.ui.base.UiState
+
+@Immutable
+data class GroupEditState(
+	val isInitializing: Boolean = true,
+	val isGroupEditError: Boolean = false,
+	val group: GroupModel? = null,
+) : UiState

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupJoinState.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupJoinState.kt
@@ -1,0 +1,13 @@
+package com.boostcamp.mapisode.mygroup.state
+
+import androidx.compose.runtime.Immutable
+import com.boostcamp.mapisode.model.GroupModel
+import com.boostcamp.mapisode.ui.base.UiState
+
+@Immutable
+data class GroupJoinState(
+	val isGroupExist: Boolean = false,
+	val isGroupLoading: Boolean = false,
+	val isJoinedSuccess: Boolean = false,
+	val group: GroupModel? = null,
+) : UiState

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupState.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupState.kt
@@ -1,4 +1,4 @@
-package com.boostcamp.mapisode.mygroup.intent
+package com.boostcamp.mapisode.mygroup.state
 
 import androidx.compose.runtime.Immutable
 import com.boostcamp.mapisode.model.GroupModel

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupState.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupState.kt
@@ -8,6 +8,7 @@ import kotlinx.collections.immutable.persistentListOf
 
 @Immutable
 data class GroupState(
+	val isInitializing: Boolean = true,
 	val areGroupsLoading: Boolean = false,
 	val groups: PersistentList<GroupModel> = persistentListOf(),
 ) : UiState

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupState.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupState.kt
@@ -9,6 +9,5 @@ import kotlinx.collections.immutable.persistentListOf
 @Immutable
 data class GroupState(
 	val isInitializing: Boolean = true,
-	val areGroupsLoading: Boolean = false,
 	val groups: PersistentList<GroupModel> = persistentListOf(),
 ) : UiState

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupCreationViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupCreationViewModel.kt
@@ -33,6 +33,10 @@ class GroupCreationViewModel @Inject constructor(
 			is GroupCreationIntent.OnGroupCreationClick -> {
 				checkGroupEdit(intent.title, intent.content, intent.imageUrl)
 			}
+
+			is GroupCreationIntent.OnGroupCreationError -> {
+				postSideEffect(GroupCreationSideEffect.ShowToast(R.string.message_error_edit_input))
+			}
 		}
 	}
 
@@ -41,9 +45,6 @@ class GroupCreationViewModel @Inject constructor(
 			try {
 				if (title.length !in 2..24 || content.length < 10 || imageUrl.isBlank()) {
 					intent { copy(isGroupEditError = true) }
-					postSideEffect(
-						GroupCreationSideEffect.ShowToast(R.string.message_error_edit_input),
-					)
 				} else {
 					intent { copy(isGroupEditError = false) }
 					val newGroupId = UUID.randomUUID().toString().replace("-", "")
@@ -68,11 +69,7 @@ class GroupCreationViewModel @Inject constructor(
 					postSideEffect(GroupCreationSideEffect.NavigateToGroupScreen)
 				}
 			} catch (e: Exception) {
-				postSideEffect(
-					GroupCreationSideEffect.ShowToast(
-						R.string.message_error_creation_group_fail,
-					),
-				)
+				intent { copy(isGroupEditError = true) }
 			}
 		}
 	}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupCreationViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupCreationViewModel.kt
@@ -1,0 +1,67 @@
+package com.boostcamp.mapisode.mygroup.viewmodel
+
+import androidx.lifecycle.viewModelScope
+import com.boostcamp.mapisode.datastore.UserPreferenceDataStore
+import com.boostcamp.mapisode.model.GroupModel
+import com.boostcamp.mapisode.mygroup.GroupRepository
+import com.boostcamp.mapisode.mygroup.R
+import com.boostcamp.mapisode.mygroup.intent.GroupCreationIntent
+import com.boostcamp.mapisode.mygroup.sideeffect.GroupCreationSideEffect
+import com.boostcamp.mapisode.mygroup.state.GroupCreationState
+import com.boostcamp.mapisode.ui.base.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import java.util.Date
+import java.util.UUID
+import javax.inject.Inject
+
+@HiltViewModel
+class GroupCreationViewModel @Inject constructor(
+	private val groupRepository: GroupRepository,
+	private val userPreferenceDataStore: UserPreferenceDataStore,
+) : BaseViewModel<GroupCreationIntent, GroupCreationState, GroupCreationSideEffect>(GroupCreationState()) {
+
+	override fun onIntent(intent: GroupCreationIntent) {
+		when (intent) {
+			is GroupCreationIntent.OnBackClick -> {
+				postSideEffect(GroupCreationSideEffect.NavigateToGroupScreen)
+			}
+
+			is GroupCreationIntent.OnGroupCreationClick -> {
+				checkGroupEdit(intent.title, intent.content, intent.imageUrl)
+			}
+		}
+	}
+
+	private fun checkGroupEdit(title: String, content: String, imageUrl: String) {
+		viewModelScope.launch {
+			try {
+				if (title.length !in 2..8 || content.length < 10) {
+					intent { copy(isGroupEditError = true) }
+					postSideEffect(GroupCreationSideEffect.ShowToast(R.string.message_error_edit_input))
+				} else {
+					intent { copy(isGroupEditError = false) }
+					val newGroupId = UUID.randomUUID().toString().replace("-", "")
+					val editedGroup = GroupModel(
+						id = newGroupId,
+						name = title,
+						createdAt = Date(),
+						description = content,
+						imageUrl = imageUrl,
+						adminUser = userPreferenceDataStore.getUserId().first()
+							?: throw Exception(),
+						members = emptyList(),
+					)
+					groupRepository.createGroup(editedGroup)
+					postSideEffect(GroupCreationSideEffect.ShowToast(R.string.message_error_creation_group_success))
+					delay(100)
+					postSideEffect(GroupCreationSideEffect.NavigateToGroupScreen)
+				}
+			} catch (e: Exception) {
+				postSideEffect(GroupCreationSideEffect.ShowToast(R.string.message_error_creation_group_fail))
+			}
+		}
+	}
+}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupCreationViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupCreationViewModel.kt
@@ -44,15 +44,16 @@ class GroupCreationViewModel @Inject constructor(
 				} else {
 					intent { copy(isGroupEditError = false) }
 					val newGroupId = UUID.randomUUID().toString().replace("-", "")
+					val userId = userPreferenceDataStore.getUserId().first()
 					val editedGroup = GroupModel(
 						id = newGroupId,
 						name = title,
 						createdAt = Date(),
 						description = content,
 						imageUrl = imageUrl,
-						adminUser = userPreferenceDataStore.getUserId().first()
+						adminUser = userId
 							?: throw Exception(),
-						members = emptyList(),
+						members = listOf(userId),
 					)
 					groupRepository.createGroup(editedGroup)
 					postSideEffect(GroupCreationSideEffect.ShowToast(R.string.message_error_creation_group_success))

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupCreationViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupCreationViewModel.kt
@@ -22,7 +22,7 @@ class GroupCreationViewModel @Inject constructor(
 	private val groupRepository: GroupRepository,
 	private val userPreferenceDataStore: UserPreferenceDataStore,
 ) : BaseViewModel<GroupCreationIntent, GroupCreationState, GroupCreationSideEffect>(
-	GroupCreationState()
+	GroupCreationState(),
 ) {
 	override fun onIntent(intent: GroupCreationIntent) {
 		when (intent) {
@@ -42,7 +42,7 @@ class GroupCreationViewModel @Inject constructor(
 				if (title.length !in 2..24 || content.length < 10 || imageUrl.isBlank()) {
 					intent { copy(isGroupEditError = true) }
 					postSideEffect(
-						GroupCreationSideEffect.ShowToast(R.string.message_error_edit_input)
+						GroupCreationSideEffect.ShowToast(R.string.message_error_edit_input),
 					)
 				} else {
 					intent { copy(isGroupEditError = false) }
@@ -59,12 +59,20 @@ class GroupCreationViewModel @Inject constructor(
 						members = listOf(userId),
 					)
 					groupRepository.createGroup(editedGroup)
-					postSideEffect(GroupCreationSideEffect.ShowToast(R.string.message_error_creation_group_success))
+					postSideEffect(
+						GroupCreationSideEffect.ShowToast(
+							R.string.message_error_creation_group_success,
+						),
+					)
 					delay(100)
 					postSideEffect(GroupCreationSideEffect.NavigateToGroupScreen)
 				}
 			} catch (e: Exception) {
-				postSideEffect(GroupCreationSideEffect.ShowToast(R.string.message_error_creation_group_fail))
+				postSideEffect(
+					GroupCreationSideEffect.ShowToast(
+						R.string.message_error_creation_group_fail,
+					),
+				)
 			}
 		}
 	}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupCreationViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupCreationViewModel.kt
@@ -39,7 +39,7 @@ class GroupCreationViewModel @Inject constructor(
 	private fun checkGroupEdit(title: String, content: String, imageUrl: String) {
 		viewModelScope.launch {
 			try {
-				if (title.length !in 2..8 || content.length < 10) {
+				if (title.length !in 2..24 || content.length < 10 || imageUrl.isBlank()) {
 					intent { copy(isGroupEditError = true) }
 					postSideEffect(
 						GroupCreationSideEffect.ShowToast(R.string.message_error_edit_input)

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupCreationViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupCreationViewModel.kt
@@ -21,8 +21,9 @@ import javax.inject.Inject
 class GroupCreationViewModel @Inject constructor(
 	private val groupRepository: GroupRepository,
 	private val userPreferenceDataStore: UserPreferenceDataStore,
-) : BaseViewModel<GroupCreationIntent, GroupCreationState, GroupCreationSideEffect>(GroupCreationState()) {
-
+) : BaseViewModel<GroupCreationIntent, GroupCreationState, GroupCreationSideEffect>(
+	GroupCreationState()
+) {
 	override fun onIntent(intent: GroupCreationIntent) {
 		when (intent) {
 			is GroupCreationIntent.OnBackClick -> {
@@ -40,7 +41,9 @@ class GroupCreationViewModel @Inject constructor(
 			try {
 				if (title.length !in 2..8 || content.length < 10) {
 					intent { copy(isGroupEditError = true) }
-					postSideEffect(GroupCreationSideEffect.ShowToast(R.string.message_error_edit_input))
+					postSideEffect(
+						GroupCreationSideEffect.ShowToast(R.string.message_error_edit_input)
+					)
 				} else {
 					intent { copy(isGroupEditError = false) }
 					val newGroupId = UUID.randomUUID().toString().replace("-", "")

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupDetailViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupDetailViewModel.kt
@@ -12,6 +12,7 @@ import com.boostcamp.mapisode.mygroup.state.GroupDetailState
 import com.boostcamp.mapisode.ui.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -53,6 +54,20 @@ class GroupDetailViewModel @Inject constructor(
 
 				is GroupDetailIntent.OnIssueCodeClick -> {
 					issueInvitationCode()
+				}
+
+				is GroupDetailIntent.OnGroupOutClick -> {
+					postSideEffect(GroupDetailSideEffect.WarnGroupOut)
+				}
+
+				is GroupDetailIntent.OnGroupOutConfirm -> {
+					postSideEffect(GroupDetailSideEffect.RemoveDialog)
+					delay(100)
+					leaveGroup()
+				}
+
+				is GroupDetailIntent.OnGroupOutCancel -> {
+					postSideEffect(GroupDetailSideEffect.RemoveDialog)
 				}
 			}
 		}
@@ -110,6 +125,21 @@ class GroupDetailViewModel @Inject constructor(
 				copy(
 					membersInfo = memberInfo
 				)
+			}
+		}
+	}
+
+	private fun leaveGroup() {
+		viewModelScope.launch {
+			val userId = userPreferenceDataStore.getUserId().first() ?: "xtRVRTS7XnBDOYlOezFE"
+			val groupId = groupId.value
+			try {
+				groupRepository.leaveGroup(userId, groupId)
+				postSideEffect(GroupDetailSideEffect.ShowToast(R.string.message_group_out_success))
+				delay(100)
+				postSideEffect(GroupDetailSideEffect.NavigateToGroupScreen)
+			} catch (e: Exception) {
+				postSideEffect(GroupDetailSideEffect.ShowToast(R.string.message_group_out_fail))
 			}
 		}
 	}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupDetailViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupDetailViewModel.kt
@@ -3,6 +3,7 @@ package com.boostcamp.mapisode.mygroup.viewmodel
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.viewModelScope
 import com.boostcamp.mapisode.datastore.UserPreferenceDataStore
+import com.boostcamp.mapisode.model.GroupMemberModel
 import com.boostcamp.mapisode.mygroup.GroupRepository
 import com.boostcamp.mapisode.mygroup.R
 import com.boostcamp.mapisode.mygroup.intent.GroupDetailIntent
@@ -30,6 +31,10 @@ class GroupDetailViewModel @Inject constructor(
 
 				is GroupDetailIntent.TryGetGroup -> {
 					tryGetGroup()
+				}
+
+				is GroupDetailIntent.TryGetUserInfo -> {
+					setGroupMembersInfo()
 				}
 
 				is GroupDetailIntent.OnEditClick -> {
@@ -88,6 +93,23 @@ class GroupDetailViewModel @Inject constructor(
 				postSideEffect(GroupDetailSideEffect.ShowToast(R.string.message_issue_code_success))
 			} catch (e: Exception) {
 				postSideEffect(GroupDetailSideEffect.ShowToast(R.string.message_issue_code_fail))
+			}
+		}
+	}
+
+	private fun setGroupMembersInfo(){
+		viewModelScope.launch {
+			val group = currentState.group ?: throw Exception()
+			val members = group.members
+			val memberInfo = mutableListOf<GroupMemberModel>()
+			members.forEach { member ->
+				val user = groupRepository.getUserInfoByUserId(member)
+				memberInfo.add(user)
+			}
+			intent {
+				copy(
+					membersInfo = memberInfo
+				)
 			}
 		}
 	}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupDetailViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupDetailViewModel.kt
@@ -3,6 +3,7 @@ package com.boostcamp.mapisode.mygroup.viewmodel
 import androidx.lifecycle.SavedStateHandle
 import com.boostcamp.mapisode.datastore.UserPreferenceDataStore
 import com.boostcamp.mapisode.mygroup.GroupRepository
+import com.boostcamp.mapisode.mygroup.intent.GroupDetailIntent
 import com.boostcamp.mapisode.mygroup.intent.GroupSideEffect
 import com.boostcamp.mapisode.mygroup.state.GroupDetailState
 import com.boostcamp.mapisode.ui.base.BaseViewModel
@@ -14,9 +15,13 @@ class GroupDetailViewModel @Inject constructor(
 	private val groupRepository: GroupRepository,
 	private val userPreferenceDataStore: UserPreferenceDataStore,
 	private val savedStateHandle: SavedStateHandle,
-) : BaseViewModel<GroupDetailState, GroupSideEffect>(GroupDetailState()) {
+) : BaseViewModel<GroupDetailIntent, GroupDetailState, GroupSideEffect>(GroupDetailState()) {
 
 	fun getGroupDetail(groupId: String) {
 
+	}
+
+	override fun onIntent(intent: GroupDetailIntent) {
+		TODO("Not yet implemented")
 	}
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupDetailViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupDetailViewModel.kt
@@ -1,6 +1,5 @@
 package com.boostcamp.mapisode.mygroup.viewmodel
 
-import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.viewModelScope
 import com.boostcamp.mapisode.datastore.UserPreferenceDataStore
@@ -59,13 +58,7 @@ class GroupDetailViewModel @Inject constructor(
 		}
 	}
 
-	private fun goToGroupEditScreen() {
+	private fun goToGroupEditScreen() { }
 
-	}
-
-	private fun backToGroupScreen() {
-
-	}
-
-
+	private fun backToGroupScreen() { }
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupDetailViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupDetailViewModel.kt
@@ -15,7 +15,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -167,7 +166,6 @@ class GroupDetailViewModel @Inject constructor(
 						episodes = episodes,
 					)
 				}
-				Timber.e("episodes: $episodes")
 			} catch (e: Exception) {
 				postSideEffect(GroupDetailSideEffect.ShowToast(R.string.message_group_not_found))
 			}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupDetailViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupDetailViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.boostcamp.mapisode.datastore.UserPreferenceDataStore
 import com.boostcamp.mapisode.mygroup.GroupRepository
 import com.boostcamp.mapisode.mygroup.intent.GroupDetailIntent
-import com.boostcamp.mapisode.mygroup.intent.GroupSideEffect
+import com.boostcamp.mapisode.mygroup.sideeffect.GroupDetailSideEffect
 import com.boostcamp.mapisode.mygroup.state.GroupDetailState
 import com.boostcamp.mapisode.ui.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -15,7 +15,7 @@ class GroupDetailViewModel @Inject constructor(
 	private val groupRepository: GroupRepository,
 	private val userPreferenceDataStore: UserPreferenceDataStore,
 	private val savedStateHandle: SavedStateHandle,
-) : BaseViewModel<GroupDetailIntent, GroupDetailState, GroupSideEffect>(GroupDetailState()) {
+) : BaseViewModel<GroupDetailIntent, GroupDetailState, GroupDetailSideEffect>(GroupDetailState()) {
 
 	fun getGroupDetail(groupId: String) {
 

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupDetailViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupDetailViewModel.kt
@@ -1,6 +1,8 @@
 package com.boostcamp.mapisode.mygroup.viewmodel
 
-import androidx.lifecycle.SavedStateHandle
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.viewModelScope
 import com.boostcamp.mapisode.datastore.UserPreferenceDataStore
 import com.boostcamp.mapisode.mygroup.GroupRepository
 import com.boostcamp.mapisode.mygroup.intent.GroupDetailIntent
@@ -8,20 +10,62 @@ import com.boostcamp.mapisode.mygroup.sideeffect.GroupDetailSideEffect
 import com.boostcamp.mapisode.mygroup.state.GroupDetailState
 import com.boostcamp.mapisode.ui.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class GroupDetailViewModel @Inject constructor(
 	private val groupRepository: GroupRepository,
 	private val userPreferenceDataStore: UserPreferenceDataStore,
-	private val savedStateHandle: SavedStateHandle,
 ) : BaseViewModel<GroupDetailIntent, GroupDetailState, GroupDetailSideEffect>(GroupDetailState()) {
-
-	fun getGroupDetail(groupId: String) {
-
-	}
+	private val userId = mutableStateOf("")
 
 	override fun onIntent(intent: GroupDetailIntent) {
-		TODO("Not yet implemented")
+		when (intent) {
+			is GroupDetailIntent.GetGroupId -> {
+				getGroupDetail(intent.groupId)
+			}
+
+			is GroupDetailIntent.TryGetGroup -> {
+				tryGetGroup()
+			}
+
+			is GroupDetailIntent.GoToGroupEditScreen -> {
+				goToGroupEditScreen()
+			}
+
+			is GroupDetailIntent.BackToGroupScreen -> {
+				backToGroupScreen()
+			}
+		}
 	}
+
+	private fun getGroupDetail(groupId: String) {
+		userId.value = groupId
+	}
+
+	private fun tryGetGroup() {
+		viewModelScope.launch {
+			try {
+				val group = groupRepository.getGroupByGroupId(userId.value)
+				intent {
+					copy(
+						group = group,
+					)
+				}
+			} catch (e: Exception) {
+				postSideEffect(GroupDetailSideEffect.ShowToast(e.message ?: "그룹을 찾을 수 없습니다."))
+			}
+		}
+	}
+
+	private fun goToGroupEditScreen() {
+
+	}
+
+	private fun backToGroupScreen() {
+
+	}
+
+
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupDetailViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupDetailViewModel.kt
@@ -42,7 +42,7 @@ class GroupDetailViewModel @Inject constructor(
 				}
 
 				is GroupDetailIntent.OnEditClick -> {
-					postSideEffect(GroupDetailSideEffect.NavigateToGroupEditScreen(intent.groupId))
+					postSideEffect(GroupDetailSideEffect.NavigateToGroupEditScreen(groupId.value))
 					delay(100)
 					intent { copy(isGroupLoading = true) }
 				}
@@ -99,6 +99,13 @@ class GroupDetailViewModel @Inject constructor(
 						isGroupLoading = false,
 						group = group,
 					)
+				}
+				if (group.adminUser == userPreferenceDataStore.getUserId().first()) {
+					intent {
+						copy(
+							isGroupOwner = true
+						)
+					}
 				}
 			} catch (e: Exception) {
 				postSideEffect(GroupDetailSideEffect.ShowToast(R.string.message_group_not_found))

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupDetailViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupDetailViewModel.kt
@@ -1,0 +1,22 @@
+package com.boostcamp.mapisode.mygroup.viewmodel
+
+import androidx.lifecycle.SavedStateHandle
+import com.boostcamp.mapisode.datastore.UserPreferenceDataStore
+import com.boostcamp.mapisode.mygroup.GroupRepository
+import com.boostcamp.mapisode.mygroup.intent.GroupSideEffect
+import com.boostcamp.mapisode.mygroup.state.GroupDetailState
+import com.boostcamp.mapisode.ui.base.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class GroupDetailViewModel @Inject constructor(
+	private val groupRepository: GroupRepository,
+	private val userPreferenceDataStore: UserPreferenceDataStore,
+	private val savedStateHandle: SavedStateHandle,
+) : BaseViewModel<GroupDetailState, GroupSideEffect>(GroupDetailState()) {
+
+	fun getGroupDetail(groupId: String) {
+
+	}
+}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupDetailViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupDetailViewModel.kt
@@ -103,7 +103,7 @@ class GroupDetailViewModel @Inject constructor(
 				if (group.adminUser == userPreferenceDataStore.getUserId().first()) {
 					intent {
 						copy(
-							isGroupOwner = true
+							isGroupOwner = true,
 						)
 					}
 				}
@@ -126,7 +126,7 @@ class GroupDetailViewModel @Inject constructor(
 		}
 	}
 
-	private fun setGroupMembersInfo(){
+	private fun setGroupMembersInfo() {
 		viewModelScope.launch {
 			val group = currentState.group ?: throw Exception()
 			val members = group.members
@@ -137,7 +137,7 @@ class GroupDetailViewModel @Inject constructor(
 			}
 			intent {
 				copy(
-					membersInfo = memberInfo
+					membersInfo = memberInfo,
 				)
 			}
 		}
@@ -164,7 +164,7 @@ class GroupDetailViewModel @Inject constructor(
 				val episodes = episodeRepository.getEpisodesByGroup(groupId.value)
 				intent {
 					copy(
-						episodes = episodes
+						episodes = episodes,
 					)
 				}
 				Timber.e("episodes: $episodes")

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupEditViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupEditViewModel.kt
@@ -12,9 +12,8 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class GroupEditViewModel @Inject constructor(
-	private val groupRepository: GroupRepository,
-) : BaseViewModel<GroupEditIntent, GroupEditState, GroupEditSideEffect>(GroupEditState()) {
+class GroupEditViewModel @Inject constructor(private val groupRepository: GroupRepository) :
+	BaseViewModel<GroupEditIntent, GroupEditState, GroupEditSideEffect>(GroupEditState()) {
 	private lateinit var cachedGroupId: String
 
 	override fun onIntent(intent: GroupEditIntent) {

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupEditViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupEditViewModel.kt
@@ -48,7 +48,7 @@ class GroupEditViewModel @Inject constructor(private val groupRepository: GroupR
 	private fun checkGroupEdit(title: String, content: String, imageUrl: String) {
 		viewModelScope.launch {
 			try {
-				if (title.length !in 2..8 || content.length < 10 || imageUrl.isEmpty()) {
+				if (title.length !in 2..24 || content.length < 10 || imageUrl.isBlank()) {
 					intent { copy(isGroupEditError = true) }
 					postSideEffect(GroupEditSideEffect.ShowToast(R.string.message_error_edit_input))
 				} else {

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupEditViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupEditViewModel.kt
@@ -1,0 +1,70 @@
+package com.boostcamp.mapisode.mygroup.viewmodel
+
+import androidx.lifecycle.viewModelScope
+import com.boostcamp.mapisode.mygroup.GroupRepository
+import com.boostcamp.mapisode.mygroup.R
+import com.boostcamp.mapisode.mygroup.intent.GroupEditIntent
+import com.boostcamp.mapisode.mygroup.sideeffect.GroupEditSideEffect
+import com.boostcamp.mapisode.mygroup.state.GroupEditState
+import com.boostcamp.mapisode.ui.base.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class GroupEditViewModel @Inject constructor(
+	private val groupRepository: GroupRepository,
+) : BaseViewModel<GroupEditIntent, GroupEditState, GroupEditSideEffect>(GroupEditState()) {
+	private lateinit var cachedGroupId: String
+
+	override fun onIntent(intent: GroupEditIntent) {
+		when (intent) {
+			is GroupEditIntent.LoadGroups -> {
+				loadGroups(intent.groupId)
+			}
+
+			is GroupEditIntent.OnBackClick -> {
+				postSideEffect(GroupEditSideEffect.NavigateToGroupDetailScreen)
+			}
+
+			is GroupEditIntent.OnGroupEditClick -> {
+				checkGroupEdit(intent.title, intent.content, intent.imageUrl)
+			}
+		}
+	}
+
+	private fun loadGroups(groupId: String) {
+		viewModelScope.launch {
+			cachedGroupId = groupId
+			val group = groupRepository.getGroupByGroupId(groupId)
+			intent {
+				copy(
+					isInitializing = false,
+					group = group,
+				)
+			}
+		}
+	}
+
+	private fun checkGroupEdit(title: String, content: String, imageUrl: String) {
+		viewModelScope.launch {
+			try {
+				if (title.length !in 2..8 || content.length < 10 || imageUrl.isEmpty()) {
+					intent { copy(isGroupEditError = true) }
+					postSideEffect(GroupEditSideEffect.ShowToast(R.string.message_error_edit_input))
+				} else {
+					intent { copy(isGroupEditError = false) }
+					val editedGroup = currentState.group?.copy(
+						name = title,
+						description = content,
+						imageUrl = imageUrl,
+					) ?: return@launch
+					groupRepository.updateGroup(cachedGroupId, editedGroup)
+					postSideEffect(GroupEditSideEffect.NavigateToGroupDetailScreen)
+				}
+			} catch (e: Exception) {
+				postSideEffect(GroupEditSideEffect.ShowToast(R.string.message_error_edit_group))
+			}
+		}
+	}
+}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupJoinViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupJoinViewModel.kt
@@ -12,7 +12,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
-import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -64,7 +63,6 @@ class GroupJoinViewModel @Inject constructor(
 			try {
 				val group = groupRepository.getGroupByInviteCodes(inviteCodes)
 				intent { copy(isGroupExist = true, group = group) }
-				Timber.d("group: $currentState")
 			} catch (e: Exception) {
 				intent { copy(isGroupExist = false) }
 				postSideEffect(GroupJoinSideEffect.ShowToast(R.string.group_join_not_exist))
@@ -76,13 +74,11 @@ class GroupJoinViewModel @Inject constructor(
 		viewModelScope.launch {
 			val userId = myId.value
 			val group = currentState.group ?: return@launch
-			Timber.d("userId: $userId, group: $group")
 			intent { copy(isGroupLoading = true) }
 			try {
 				groupRepository.joinGroup(userId, group.id)
 				intent { copy(isJoinedSuccess = true) }
 			} catch (e: Exception) {
-				Timber.e(e)
 				intent { copy(isGroupLoading = false, isJoinedSuccess = false, group = null) }
 				postSideEffect(GroupJoinSideEffect.ShowToast(R.string.group_join_failure))
 			}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupJoinViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupJoinViewModel.kt
@@ -86,7 +86,7 @@ class GroupJoinViewModel @Inject constructor(
 				postSideEffect(GroupJoinSideEffect.ShowToast(R.string.group_join_failure))
 			}
 			postSideEffect(GroupJoinSideEffect.ShowToast(R.string.group_join_success))
-			delay(10)
+			delay(100)
 			postSideEffect(GroupJoinSideEffect.NavigateToGroupJoinScreen)
 		}
 	}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupJoinViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupJoinViewModel.kt
@@ -60,7 +60,7 @@ class GroupJoinViewModel @Inject constructor(
 		viewModelScope.launch {
 			intent { copy(isGroupLoading = true) }
 			try {
-				val group = groupRepository.getGroupById(inviteCodes)
+				val group = groupRepository.getGroupByInviteCodes(inviteCodes)
 				intent { copy(isGroupExist = true, group = group) }
 				Timber.d("group: $currentState")
 			} catch (e: Exception) {

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupJoinViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupJoinViewModel.kt
@@ -9,6 +9,7 @@ import com.boostcamp.mapisode.mygroup.sideeffect.GroupJoinSideEffect
 import com.boostcamp.mapisode.mygroup.state.GroupJoinState
 import com.boostcamp.mapisode.ui.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -46,12 +47,12 @@ class GroupJoinViewModel @Inject constructor(
 				tryGetGroupByGroupId(intent.inviteCode)
 			}
 
-			is GroupJoinIntent.JoinTheGroup -> {
+			is GroupJoinIntent.OnJoinClick -> {
 				joinGroup()
 			}
 
-			is GroupJoinIntent.BackToGroupScreen -> {
-
+			is GroupJoinIntent.OnBackClick -> {
+				postSideEffect(GroupJoinSideEffect.NavigateToGroupJoinScreen)
 			}
 		}
 	}
@@ -79,13 +80,14 @@ class GroupJoinViewModel @Inject constructor(
 			try {
 				groupRepository.joinGroup(userId, group.id)
 				intent { copy(isJoinedSuccess = true) }
-				postSideEffect(GroupJoinSideEffect.ShowToast(R.string.group_join_success))
-				Timber.d(currentState.toString())
 			} catch (e: Exception) {
 				Timber.e(e)
 				intent { copy(isGroupLoading = false, isJoinedSuccess = false, group = null) }
 				postSideEffect(GroupJoinSideEffect.ShowToast(R.string.group_join_failure))
 			}
+			postSideEffect(GroupJoinSideEffect.ShowToast(R.string.group_join_success))
+			delay(10)
+			postSideEffect(GroupJoinSideEffect.NavigateToGroupJoinScreen)
 		}
 	}
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupJoinViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupJoinViewModel.kt
@@ -52,7 +52,7 @@ class GroupJoinViewModel @Inject constructor(
 			}
 
 			is GroupJoinIntent.OnBackClick -> {
-				postSideEffect(GroupJoinSideEffect.NavigateToGroupJoinScreen)
+				postSideEffect(GroupJoinSideEffect.NavigateToGroupScreen)
 			}
 		}
 	}
@@ -87,7 +87,7 @@ class GroupJoinViewModel @Inject constructor(
 			}
 			postSideEffect(GroupJoinSideEffect.ShowToast(R.string.group_join_success))
 			delay(100)
-			postSideEffect(GroupJoinSideEffect.NavigateToGroupJoinScreen)
+			postSideEffect(GroupJoinSideEffect.NavigateToGroupScreen)
 		}
 	}
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupJoinViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupJoinViewModel.kt
@@ -1,0 +1,33 @@
+package com.boostcamp.mapisode.mygroup.viewmodel
+
+import androidx.lifecycle.viewModelScope
+import com.boostcamp.mapisode.datastore.UserPreferenceDataStore
+import com.boostcamp.mapisode.mygroup.GroupRepository
+import com.boostcamp.mapisode.mygroup.R
+import com.boostcamp.mapisode.mygroup.sideeffect.GroupJoinSideEffect
+import com.boostcamp.mapisode.mygroup.state.GroupJoinState
+import com.boostcamp.mapisode.ui.base.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class GroupJoinViewModel @Inject constructor(
+	private val groupRepository: GroupRepository,
+	private val userPreferenceDataStore: UserPreferenceDataStore,
+) : BaseViewModel<GroupJoinState, GroupJoinSideEffect>(GroupJoinState()) {
+	private val myId: MutableStateFlow<String> = MutableStateFlow("")
+
+	init {
+		observeUserId()
+	}
+
+	private fun observeUserId() {
+		viewModelScope.launch {
+			userPreferenceDataStore.getUserId().collect { userId ->
+				myId.value = userId ?: ""
+			}
+		}
+	}
+}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupJoinViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupJoinViewModel.kt
@@ -53,11 +53,11 @@ class GroupJoinViewModel @Inject constructor(
 		}
 	}
 
-	private fun tryGetGroupByGroupId(inviteCode: String) {
+	private fun tryGetGroupByGroupId(inviteCodes: String) {
 		viewModelScope.launch {
 			intent { copy(isGroupLoading = true) }
 			try {
-				val group = groupRepository.getGroupById(inviteCode)
+				val group = groupRepository.getGroupById(inviteCodes)
 				intent { copy(isGroupExist = true, group = group) }
 
 			} catch (e: Exception) {

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupJoinViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupJoinViewModel.kt
@@ -27,9 +27,10 @@ class GroupJoinViewModel @Inject constructor(
 		observeUserId()
 	}
 
+	// TODO : 삭제할 임시 함수
 	private fun setUserIde() {
 		viewModelScope.launch {
-			userPreferenceDataStore.updateUserId("o6UT6Ze1LFgsvekEvj9J")
+			userPreferenceDataStore.updateUserId("J6O9lIukqkSEKANK87XgQjiDpD82")
 		}
 	}
 

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupJoinViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupJoinViewModel.kt
@@ -18,7 +18,7 @@ import javax.inject.Inject
 class GroupJoinViewModel @Inject constructor(
 	private val groupRepository: GroupRepository,
 	private val userPreferenceDataStore: UserPreferenceDataStore,
-) : BaseViewModel<GroupJoinState, GroupJoinSideEffect>(GroupJoinState()) {
+) : BaseViewModel<GroupJoinIntent, GroupJoinState, GroupJoinSideEffect>(GroupJoinState()) {
 	private val myId: MutableStateFlow<String> = MutableStateFlow("")
 
 	init {
@@ -40,7 +40,7 @@ class GroupJoinViewModel @Inject constructor(
 		}
 	}
 
-	fun onIntent(intent: GroupJoinIntent) {
+	override fun onIntent(intent: GroupJoinIntent) {
 		when (intent) {
 			is GroupJoinIntent.TryGetGroup -> {
 				tryGetGroupByGroupId(intent.inviteCode)

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupJoinViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupJoinViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.viewModelScope
 import com.boostcamp.mapisode.datastore.UserPreferenceDataStore
 import com.boostcamp.mapisode.mygroup.GroupRepository
 import com.boostcamp.mapisode.mygroup.R
+import com.boostcamp.mapisode.mygroup.intent.GroupJoinIntent
 import com.boostcamp.mapisode.mygroup.sideeffect.GroupJoinSideEffect
 import com.boostcamp.mapisode.mygroup.state.GroupJoinState
 import com.boostcamp.mapisode.ui.base.BaseViewModel
@@ -20,13 +21,62 @@ class GroupJoinViewModel @Inject constructor(
 	private val myId: MutableStateFlow<String> = MutableStateFlow("")
 
 	init {
+		setUserIde()
 		observeUserId()
+	}
+
+	private fun setUserIde() {
+		viewModelScope.launch {
+			userPreferenceDataStore.updateUserId("o6UT6Ze1LFgsvekEvj9J")
+		}
 	}
 
 	private fun observeUserId() {
 		viewModelScope.launch {
 			userPreferenceDataStore.getUserId().collect { userId ->
 				myId.value = userId ?: ""
+			}
+		}
+	}
+
+	fun onIntent(intent: GroupJoinIntent) {
+		when (intent) {
+			is GroupJoinIntent.TryGetGroup -> {
+				tryGetGroupByGroupId(intent.inviteCode)
+			}
+			is GroupJoinIntent.JoinTheGroup -> {
+				joinGroup()
+			}
+			is GroupJoinIntent.BackToGroupScreen -> {
+				intent { copy(isGroupExist = false) }
+			}
+		}
+	}
+
+	private fun tryGetGroupByGroupId(inviteCode: String) {
+		viewModelScope.launch {
+			intent { copy(isGroupLoading = true) }
+			try {
+				val group = groupRepository.getGroupById(inviteCode)
+				intent { copy(isGroupExist = true, group = group) }
+
+			} catch (e: Exception) {
+				intent { copy(isGroupExist = false) }
+				postSideEffect(GroupJoinSideEffect.ShowToast(R.string.group_join_not_exist))
+			}
+		}
+	}
+
+	private fun joinGroup() {
+		viewModelScope.launch {
+			val userId = myId.value
+			val group = currentState.group ?: return@launch
+			try {
+				groupRepository.joinGroup(userId, group.id)
+				intent { copy(isJoinedSuccess = true) }
+				postSideEffect(GroupJoinSideEffect.ShowToast(R.string.group_join_success))
+			} catch (e: Exception) {
+				postSideEffect(GroupJoinSideEffect.ShowToast(R.string.group_join_failure))
 			}
 		}
 	}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupViewModel.kt
@@ -25,6 +25,18 @@ class GroupViewModel @Inject constructor(private val groupRepository: GroupRepos
 			is GroupIntent.EndLoadingGroups -> {
 				confirmGroupsLoaded()
 			}
+
+			is GroupIntent.OnJoinClick -> {
+				navigateToGroupJoinScreen()
+			}
+
+			is GroupIntent.OnGroupCreateClick -> {
+				navigateToGroupCreationScreen()
+			}
+
+			is GroupIntent.OnGroupDetailClick -> {
+				navigateToGroupDetailScreen(intent.groupId)
+			}
 		}
 	}
 
@@ -36,6 +48,7 @@ class GroupViewModel @Inject constructor(private val groupRepository: GroupRepos
 					.toPersistentList()
 				intent {
 					copy(
+						isInitializing = false,
 						areGroupsLoading = true,
 						groups = group,
 					)
@@ -52,5 +65,17 @@ class GroupViewModel @Inject constructor(private val groupRepository: GroupRepos
 				areGroupsLoading = false,
 			)
 		}
+	}
+
+	private fun navigateToGroupJoinScreen() {
+		postSideEffect(GroupSideEffect.NavigateToGroupJoinScreen)
+	}
+
+	private fun navigateToGroupCreationScreen() {
+		postSideEffect(GroupSideEffect.NavigateToGroupCreateScreen)
+	}
+
+	private fun navigateToGroupDetailScreen(groupId: String) {
+		postSideEffect(GroupSideEffect.NavigateToGroupDetailScreen(groupId))
 	}
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupViewModel.kt
@@ -1,6 +1,7 @@
 package com.boostcamp.mapisode.mygroup.viewmodel
 
 import androidx.lifecycle.viewModelScope
+import com.boostcamp.mapisode.datastore.UserPreferenceDataStore
 import com.boostcamp.mapisode.mygroup.GroupRepository
 import com.boostcamp.mapisode.mygroup.R
 import com.boostcamp.mapisode.mygroup.intent.GroupIntent
@@ -10,12 +11,15 @@ import com.boostcamp.mapisode.ui.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class GroupViewModel @Inject constructor(private val groupRepository: GroupRepository) :
-	BaseViewModel<GroupIntent, GroupState, GroupSideEffect>(GroupState()) {
+class GroupViewModel @Inject constructor(
+	private val groupRepository: GroupRepository,
+	private val userPreferenceDataStore: UserPreferenceDataStore,
+) : BaseViewModel<GroupIntent, GroupState, GroupSideEffect>(GroupState()) {
 
 	override fun onIntent(intent: GroupIntent) {
 		when (intent) {
@@ -40,8 +44,9 @@ class GroupViewModel @Inject constructor(private val groupRepository: GroupRepos
 	private fun loadGroups() {
 		viewModelScope.launch {
 			try {
+				val userId = userPreferenceDataStore.getUserId().first() ?: throw Exception()
 				val group = groupRepository
-					.getGroupsByUserId("o6UT6Ze1LFgsvekEvj9J")
+					.getGroupsByUserId(userId)
 					.toPersistentList()
 				intent {
 					copy(

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupViewModel.kt
@@ -9,6 +9,7 @@ import com.boostcamp.mapisode.mygroup.state.GroupState
 import com.boostcamp.mapisode.ui.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -20,10 +21,6 @@ class GroupViewModel @Inject constructor(private val groupRepository: GroupRepos
 		when (intent) {
 			is GroupIntent.LoadGroups -> {
 				loadGroups()
-			}
-
-			is GroupIntent.EndLoadingGroups -> {
-				confirmGroupsLoaded()
 			}
 
 			is GroupIntent.OnJoinClick -> {
@@ -49,7 +46,6 @@ class GroupViewModel @Inject constructor(private val groupRepository: GroupRepos
 				intent {
 					copy(
 						isInitializing = false,
-						areGroupsLoading = true,
 						groups = group,
 					)
 				}
@@ -59,23 +55,27 @@ class GroupViewModel @Inject constructor(private val groupRepository: GroupRepos
 		}
 	}
 
-	private fun confirmGroupsLoaded() {
-		intent {
-			copy(
-				areGroupsLoading = false,
-			)
+	private fun navigateToGroupJoinScreen() {
+		viewModelScope.launch {
+			postSideEffect(GroupSideEffect.NavigateToGroupJoinScreen)
+			delay(100)
+			intent { copy(isInitializing = true) }
 		}
 	}
 
-	private fun navigateToGroupJoinScreen() {
-		postSideEffect(GroupSideEffect.NavigateToGroupJoinScreen)
-	}
-
 	private fun navigateToGroupCreationScreen() {
-		postSideEffect(GroupSideEffect.NavigateToGroupCreateScreen)
+		viewModelScope.launch {
+			postSideEffect(GroupSideEffect.NavigateToGroupCreateScreen)
+			delay(100)
+			intent { copy(isInitializing = true) }
+		}
 	}
 
 	private fun navigateToGroupDetailScreen(groupId: String) {
-		postSideEffect(GroupSideEffect.NavigateToGroupDetailScreen(groupId))
+		viewModelScope.launch {
+			postSideEffect(GroupSideEffect.NavigateToGroupDetailScreen(groupId))
+			delay(100)
+			intent { copy(isInitializing = true) }
+		}
 	}
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupViewModel.kt
@@ -2,9 +2,10 @@ package com.boostcamp.mapisode.mygroup.viewmodel
 
 import androidx.lifecycle.viewModelScope
 import com.boostcamp.mapisode.mygroup.GroupRepository
+import com.boostcamp.mapisode.mygroup.R
 import com.boostcamp.mapisode.mygroup.intent.GroupIntent
-import com.boostcamp.mapisode.mygroup.intent.GroupSideEffect
-import com.boostcamp.mapisode.mygroup.intent.GroupState
+import com.boostcamp.mapisode.mygroup.sideeffect.GroupSideEffect
+import com.boostcamp.mapisode.mygroup.state.GroupState
 import com.boostcamp.mapisode.ui.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toPersistentList
@@ -40,7 +41,7 @@ class GroupViewModel @Inject constructor(private val groupRepository: GroupRepos
 					)
 				}
 			} catch (e: Exception) {
-				// TODO : SideEffect - 에러 메세지 출력
+				postSideEffect(GroupSideEffect.ShowToast(R.string.group_load_failure))
 			}
 		}
 	}

--- a/feature/mygroup/src/main/res/values/strings.xml
+++ b/feature/mygroup/src/main/res/values/strings.xml
@@ -12,4 +12,5 @@
     <string name="group_join_not_exist">그룹이 존재하지 않습니다.</string>
 	<string name="group_join_success">그룹 참여 성공</string>
 	<string name="group_join_failure">그룹 참여 실패</string>
+	<string name="group_load_failure">그룹을 불러오는데 실패했습니다.</string>
 </resources>

--- a/feature/mygroup/src/main/res/values/strings.xml
+++ b/feature/mygroup/src/main/res/values/strings.xml
@@ -13,4 +13,10 @@
 	<string name="group_join_success">그룹 참여 성공</string>
 	<string name="group_join_failure">그룹 참여 실패</string>
 	<string name="group_load_failure">그룹을 불러오는데 실패했습니다.</string>
+	<string name="group_description_label">그룹 설명</string>
+	<string name="group_btn_issue_code">초대그룹 발급</string>
+	<string name="message_issue_code">클립보드에 복사되었습니다.</string>
+	<string name="message_group_not_found">그룹을 찾을 수 없습니다.</string>
+	<string name="message_issue_code_success">클립보드에 복사했습니다.</string>
+	<string name="message_issue_code_fail">코드 발급을 실패했습니다. 인터넷 연결을 확인해주세요.</string>
 </resources>

--- a/feature/mygroup/src/main/res/values/strings.xml
+++ b/feature/mygroup/src/main/res/values/strings.xml
@@ -19,4 +19,5 @@
 	<string name="message_group_not_found">그룹을 찾을 수 없습니다.</string>
 	<string name="message_issue_code_success">클립보드에 복사했습니다.</string>
 	<string name="message_issue_code_fail">코드 발급을 실패했습니다. 인터넷 연결을 확인해주세요.</string>
+	<string name="label_detail_group_member">그룹원</string>
 </resources>

--- a/feature/mygroup/src/main/res/values/strings.xml
+++ b/feature/mygroup/src/main/res/values/strings.xml
@@ -14,17 +14,23 @@
 	<string name="group_join_failure">그룹 참여 실패</string>
 	<string name="group_load_failure">그룹을 불러오는데 실패했습니다.</string>
 	<string name="group_description_label">그룹 설명</string>
-	<string name="group_btn_issue_code">초대그룹 발급</string>
 	<string name="message_issue_code">클립보드에 복사되었습니다.</string>
 	<string name="message_group_not_found">그룹을 찾을 수 없습니다.</string>
+	<string name="message_episode_not_loaded">에피소드를 불러올 수 없습니다.</string>
 	<string name="message_issue_code_success">클립보드에 복사했습니다.</string>
 	<string name="message_issue_code_fail">코드 발급을 실패했습니다. 인터넷 연결을 확인해주세요.</string>
 	<string name="message_group_out_success">그룹 탈퇴 성공</string>
 	<string name="message_group_out_fail">그룹 탈퇴 실패</string>
 	<string name="label_detail_group_member">그룹원</string>
+	<string name="btn_issue_code">초대코드 발급</string>
 	<string name="btn_group_out">그룹 탈퇴</string>
 	<string name="dialog_group_out_title">그룹 탈퇴</string>
 	<string name="dialog_group_out_message">정말 그룹을 탈퇴하시겠습니까?</string>
 	<string name="dialog_group_out_positive">예</string>
 	<string name="dialog_group_out_negative">아니오</string>
+	<string name="label_episode">에피소드</string>
+	<string name="overview_created_by">글쓴이 : </string>
+	<string name="overview_location">위치 : </string>
+	<string name="overview_date">작성일 : </string>
+	<string name="overview_content">내용 : </string>
 </resources>

--- a/feature/mygroup/src/main/res/values/strings.xml
+++ b/feature/mygroup/src/main/res/values/strings.xml
@@ -19,5 +19,12 @@
 	<string name="message_group_not_found">그룹을 찾을 수 없습니다.</string>
 	<string name="message_issue_code_success">클립보드에 복사했습니다.</string>
 	<string name="message_issue_code_fail">코드 발급을 실패했습니다. 인터넷 연결을 확인해주세요.</string>
+	<string name="message_group_out_success">그룹 탈퇴 성공</string>
+	<string name="message_group_out_fail">그룹 탈퇴 실패</string>
 	<string name="label_detail_group_member">그룹원</string>
+	<string name="btn_group_out">그룹 탈퇴</string>
+	<string name="dialog_group_out_title">그룹 탈퇴</string>
+	<string name="dialog_group_out_message">정말 그룹을 탈퇴하시겠습니까?</string>
+	<string name="dialog_group_out_positive">예</string>
+	<string name="dialog_group_out_negative">아니오</string>
 </resources>

--- a/feature/mygroup/src/main/res/values/strings.xml
+++ b/feature/mygroup/src/main/res/values/strings.xml
@@ -11,4 +11,9 @@
 	<string name="group_overview">그룹 개요</string>
 	<string name="group_descript">그룹 설명</string>
     <string name="group_members_number">"멤버수 : "</string>
+    <string name="group_join_not_exist">그룹이 존재하지 않습니다.</string>
+	<string name="group_join_success">그룹 참여 성공</string>
+	<string name="group_join_failure">그룹 참여 실패</string>
+	<string name="group_member_count">명</string>
+	<string name="group_user_count">%1$s %2$d %3$s</string>
 </resources>

--- a/feature/mygroup/src/main/res/values/strings.xml
+++ b/feature/mygroup/src/main/res/values/strings.xml
@@ -5,15 +5,11 @@
 	<string name="group_join_textinput_label">초대 코드</string>
 	<string name="group_join_textfield_hint">초대 코드를 입력해주세요</string>
 	<string name="group_join_btn_direction">확인</string>
-	<string name="group_created_date">"생성 날짜 : "</string>
+	<string name="group_members_number">"멤버수 : "</string>
 	<string name="group_user_number">"동료 : "</string>
-	<string name="group_recent_upload">"최근 업로드 : "</string>
 	<string name="group_overview">그룹 개요</string>
 	<string name="group_descript">그룹 설명</string>
-    <string name="group_members_number">"멤버수 : "</string>
     <string name="group_join_not_exist">그룹이 존재하지 않습니다.</string>
 	<string name="group_join_success">그룹 참여 성공</string>
 	<string name="group_join_failure">그룹 참여 실패</string>
-	<string name="group_member_count">명</string>
-	<string name="group_user_count">%1$s %2$d %3$s</string>
 </resources>

--- a/feature/mygroup/src/main/res/values/strings.xml
+++ b/feature/mygroup/src/main/res/values/strings.xml
@@ -33,4 +33,6 @@
 	<string name="overview_location">위치 : </string>
 	<string name="overview_date">작성일 : </string>
 	<string name="overview_content">내용 : </string>
+	<string name="message_error_edit_input">입력 조건을 만족해주세요.</string>
+	<string name="message_error_edit_group">그룹 수정에 실패했습니다.</string>
 </resources>

--- a/feature/mygroup/src/main/res/values/strings.xml
+++ b/feature/mygroup/src/main/res/values/strings.xml
@@ -35,4 +35,6 @@
 	<string name="overview_content">내용 : </string>
 	<string name="message_error_edit_input">입력 조건을 만족해주세요.</string>
 	<string name="message_error_edit_group">그룹 수정에 실패했습니다.</string>
+	<string name="message_error_creation_group_success">그룹 생성에 성공했습니다.</string>
+	<string name="message_error_creation_group_fail">그룹 생성에 실패했습니다.</string>
 </resources>


### PR DESCRIPTION
- closed #101 

## *📍 Work Description*

- Group 화면 최소기능 완성

## *📸 Screenshot*

https://github.com/user-attachments/assets/395b6057-2af5-4b29-ac46-0780762b3d95

https://github.com/user-attachments/assets/e6cb5305-c66b-4d33-ba18-590ee1cb2b43

<img src="https://github.com/user-attachments/assets/90674ad9-7c82-49a7-be34-820b7d3f7022" width=300>

https://github.com/user-attachments/assets/2d8347bd-6662-4bcf-9412-1f26d843bab6

<img src="https://github.com/user-attachments/assets/24c5283e-2ec6-485a-a591-01f0812410ad" width=300>

<img src="https://github.com/user-attachments/assets/b6304e5b-b37d-4e09-af8f-777bac5c7726" width=300>


## *📢 To Reviewers*

### 1️⃣ 공통 사항

- **뷰모델과 구조**
  - 각 화면에 대응되는 ViewModel은 `state`, `intent`, `sideEffect`를 관리.
  - 화면 구성은 `Screen → Content → Field`로 나뉨.
    - **Screen**: `intent`와 `sideEffect`를 처리하며, `Content`에 `state`를 전달.
    - **Content, Field**: 전달받은 `state`로 UI를 구성.
  - `Scaffold`의 시작점은 `Content`로 설정.

- **SideEffect 수집**
  - **Screen**에서 `sideEffect`를 수집하며, 화면의 생명주기 동안 유지.
  - `collectAsStateWithLifecycle`과 유사한 커스텀 함수를 제작하여 사용.
    - `Channel`로 초기화된 `sideEffect`를 `Flow`로 변환.
    - 초기값 없는 상태를 보완하기 위해 `remember`와 `collectAsState`를 합성한 상태 저장 함수 제작.
    - 초기값은 아무 동작도 하지 않는 `Idle`로 설정.

- **공통 사용 리소스**
  - 모든 ViewModel은 도메인의 `GroupRepository`에서 정의된 함수 사용.
  - `usecase` 미적용.
  - **UserPreferenceDataStore 활용** (단, `GroupCreationScreen`은 제외).
    - **GroupScreen**: User ID로 속한 그룹 조회.
    - **GroupJoinScreen**: 그룹 참여 시, User ID를 Firestore의 `group/members`와 `user/group` 필드에 저장.
    - **GroupDetailScreen**: 그룹 편집 버튼 노출 조건으로 `adminUser` ID와 User ID 비교.
    - **GroupCreationScreen**: 그룹 생성 시 `adminUser` ID를 User ID로 설정.

---

### 2️⃣ GroupScreen

- **기능**
  - User ID 기반으로 사용자가 속한 그룹만 화면에 표시.
  - 내부 화면 이동 후 복귀 시 그룹 리스트를 다시 로드하여 최신 데이터 반영.
  - 특정 그룹을 터치하면 `groupId`를 `Navigation`으로 전달하여 **GroupDetailScreen**으로 이동.

---

### 3️⃣ GroupJoinScreen

- **초대 코드 입력**
  - Firestore의 `inviteCodes` 컬렉션에서 `document(id)`를 탐색.
  - 존재할 경우, 해당 문서의 `group` 필드에서 `groupId`를 가져옴.
  - 이후, `groupId`를 사용하여 그룹 객체를 탐색.

- **참여 버튼 동작**
  - Firestore에서 `group/members`에 User ID를 추가.
  - 동시에 `user/group` 필드에 `groupId` 추가.

- **오류 처리**
  - **그룹 찾기 실패**: 버튼 아래에 “그룹이 존재하지 않음” 문구 표시.
  - **인터넷 문제**: Toast 메시지로 오류 알림.

---

### 4️⃣ GroupCreationScreen

- **입력 필드**
  - 사진 선택, 제목, 내용 입력 필드가 존재하며 모두 필수 입력.
    - **제목**: 2~20자 제한.
    - **내용**: 최소 10자 이상 입력 요구.

- **생성 요청 조건**
  - 그룹 객체의 프로퍼티 설정:
    - `adminUser`: User ID.
    - `groupId`: 랜덤 UUID.
    - `members`: User ID 포함.
    - `createdAt`: `java.util.Date()` 값.

- **Firestore 연동**
  - 그룹 객체를 `group` 컬렉션에 추가 요청.
    - **성공 시**: Toast 메시지 표시 후 뒤로가기 전환.
    - **실패 시**: Toast 메시지로 오류 알림.

---

### 5️⃣ GroupDetailScreen

- **그룹 정보 가져오기**
  - **GroupScreen**에서 전달받은 `groupId`를 사용하여 Firestore에서 `group` 객체를 요청.
  - 요청한 `group` 객체의 `members`(String 리스트)를 통해 각 User 객체를 Firestore에서 추가로 요청.
  - 가져온 `group` 객체와 `user` 객체를 화면에 표시.

- **초대 코드 발급**
  - **초대 코드 복사**: 초대코드를 클립보드에 복사한 뒤 Toast 메시지로 알림.
  - 초대 코드 생성 과정:
    1. 해당 `groupId`에 이미 발급된 `inviteCodes` 컬렉션 탐색.
       - 존재한다면 해당 컬렉션의 `document(id)` 반환.
    2. 존재하지 않을 경우:
       - 새 `inviteCodes` 컬렉션 생성.
       - `document(id)`는 랜덤 UUID로 생성.
       - `field` 구성:
         - `expiredBy`: 오늘로부터 일주일 뒤의 날짜(Firebase의 `Timestamp` 타입 사용).
         - `group`: 해당 `groupId`.

- **에피소드 데이터 가져오기**
  - **User** 객체 요청 이후, `groupId`를 통해 관련된 에피소드 데이터를 추가로 요청.
  - **EpisodeRepository**를 통해 Firestore에서 에피소드 객체를 가져옴.
  - 가져온 에피소드 데이터를 화면의 탭 오른쪽에 표시.

- **에피소드 정렬**
  - 최초 정렬 방식은 **최신순**.
  - 드롭다운 메뉴를 통해 다음과 같은 방식으로 정렬 가능:
    - 최신순
    - 과거순
    - 날짜순

- **GroupEditScreen으로 이동**
  - **조건**: `adminUser` ID가 현재 유저의 ID와 일치하는 경우에만, 탑바의 액션 버튼에 이동 버튼 표시.
  - 이동 시 `GroupEditScreen`에 `groupId`를 전달.

---

### 6️⃣ GroupEditScreen

- **그룹 데이터 가져오기**
  - 전달받은 `groupId`를 사용하여 Firestore에서 해당 `group` 객체를 요청.
  - 가져온 데이터를 활용하여 다음 필드에 값 부여:
    - 사진 선택 필드
    - 타이틀 `TextField`
    - 내용 `TextField`

- **편집 제약사항**
  - **GroupCreationScreen**의 제약사항과 동일:
    - 제목: 2~20자.
    - 내용: 10자 이상.
    - 사진 선택 필수.

- **그룹 정보 편집**
  - 편집 버튼 클릭 시, 기존 `group` 객체를 복사하여 수정된 사항 반영.
  - Firestore에 업데이트 요청:
    - 객체에 저장된 `groupId`를 통해 `group` 컬렉션에서 해당 그룹 추적.
    - 덮어쓰기 방식으로 업데이트 수행.

- **결과 처리**
  - **성공 시**: Toast 메시지 표시 및 이전 화면으로 전환.
  - **실패 시**: Toast 메시지로 오류 알림.

## ⏲️Time

    - 24시간
