### PR TITLE
[FEAT/#113] Home / 에피소드 카드 구현 및 상세 로직 구현 

### DIFF
--- a/core/common/src/main/java/com/boostcamp/mapisode/common/util/DateUtil.kt
+++ b/core/common/src/main/java/com/boostcamp/mapisode/common/util/DateUtil.kt
@@ -1,0 +1,10 @@
+package com.boostcamp.mapisode.common.util
+
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+fun Date.toFormattedString(): String {
+	val dateFormat = SimpleDateFormat("yyyy.MM.dd", Locale.getDefault())
+	return dateFormat.format(this)
+}

--- a/core/common/src/main/java/com/boostcamp/mapisode/common/util/DistanceUtil.kt
+++ b/core/common/src/main/java/com/boostcamp/mapisode/common/util/DistanceUtil.kt
@@ -1,0 +1,22 @@
+package com.boostcamp.mapisode.common.util
+
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.pow
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+fun calculateDistance(lat1: Double, lon1: Double, lat2: Double, lon2: Double): Double {
+	val earthRadius = 6371e3 // 지구 반지름 (미터 단위)
+
+	val dLat = Math.toRadians(lat2 - lat1)
+	val dLon = Math.toRadians(lon2 - lon1)
+
+	val a = sin(dLat / 2).pow(2.0) +
+		cos(Math.toRadians(lat1)) * cos(Math.toRadians(lat2)) *
+		sin(dLon / 2).pow(2.0)
+
+	val c = 2 * atan2(sqrt(a), sqrt(1 - a))
+
+	return earthRadius * c // 미터 단위 거리 반환
+}

--- a/core/common/src/main/java/com/boostcamp/mapisode/common/util/EpisodeLatLngExt.kt
+++ b/core/common/src/main/java/com/boostcamp/mapisode/common/util/EpisodeLatLngExt.kt
@@ -3,8 +3,7 @@ package com.boostcamp.mapisode.common.util
 import com.boostcamp.mapisode.model.EpisodeLatLng
 import com.naver.maps.geometry.LatLng
 
-fun EpisodeLatLng.distanceTo(other: EpisodeLatLng): Double {
-	return calculateDistance(this.latitude, this.longitude, other.latitude, other.longitude)
-}
+fun EpisodeLatLng.distanceTo(other: EpisodeLatLng) =
+	calculateDistance(this.latitude, this.longitude, other.latitude, other.longitude)
 
 fun EpisodeLatLng.toLatLng() = LatLng(this.latitude, this.longitude)

--- a/core/common/src/main/java/com/boostcamp/mapisode/common/util/EpisodeLatLngExt.kt
+++ b/core/common/src/main/java/com/boostcamp/mapisode/common/util/EpisodeLatLngExt.kt
@@ -1,0 +1,10 @@
+package com.boostcamp.mapisode.common.util
+
+import com.boostcamp.mapisode.model.EpisodeLatLng
+import com.naver.maps.geometry.LatLng
+
+fun EpisodeLatLng.distanceTo(other: EpisodeLatLng): Double {
+	return calculateDistance(this.latitude, this.longitude, other.latitude, other.longitude)
+}
+
+fun EpisodeLatLng.toLatLng() = LatLng(this.latitude, this.longitude)

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeIntent.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeIntent.kt
@@ -2,6 +2,7 @@ package com.boostcamp.mapisode.home
 
 import com.boostcamp.mapisode.home.common.ChipType
 import com.boostcamp.mapisode.model.EpisodeLatLng
+import com.boostcamp.mapisode.model.EpisodeModel
 import com.boostcamp.mapisode.ui.base.UiIntent
 import com.naver.maps.geometry.LatLng
 
@@ -12,6 +13,13 @@ sealed class HomeIntent : UiIntent {
 	data object MarkPermissionRequested : HomeIntent() // 위치 권한 요청 기록
 	data class SelectChip(val chipType: ChipType) : HomeIntent()
 	data object ShowBottomSheet : HomeIntent()
-	data class LoadEpisode(val start: EpisodeLatLng, val end: EpisodeLatLng) : HomeIntent()
 	data class ClickTextMarker(val latLng: EpisodeLatLng) : HomeIntent()
+	data class ShowCard(val selectedEpisode: EpisodeModel) : HomeIntent()
+	data object CloseCard : HomeIntent()
+	data object MapMovedWhileCardVisible : HomeIntent()
+	data class LoadEpisode(
+		val start: EpisodeLatLng,
+		val end: EpisodeLatLng,
+		val shouldSort: Boolean = false,
+	) : HomeIntent()
 }

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeIntent.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeIntent.kt
@@ -17,6 +17,8 @@ sealed class HomeIntent : UiIntent {
 	data class ShowCard(val selectedEpisode: EpisodeModel) : HomeIntent()
 	data object CloseCard : HomeIntent()
 	data object MapMovedWhileCardVisible : HomeIntent()
+	data object StartProgrammaticCameraMove : HomeIntent()
+	data object EndProgrammaticCameraMove : HomeIntent()
 	data class LoadEpisode(
 		val start: EpisodeLatLng,
 		val end: EpisodeLatLng,

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
@@ -139,12 +139,15 @@ internal fun HomeRoute(
 	LaunchedEffect(
 		key1 = cameraPositionState,
 		key2 = uiState.selectedChip,
-		key3 = uiState.isCardVisible,
 	) {
 		snapshotFlow { cameraPositionState.position }
 			.distinctUntilChanged()
 			.sample(500)
 			.collect { _ ->
+				if (uiState.isCameraMovingProgrammatically) {
+					viewModel.onIntent(HomeIntent.EndProgrammaticCameraMove)
+					return@collect
+				}
 				if (!uiState.isCardVisible) {
 					loadEpisodesInBounds(cameraPositionState)
 				} else {
@@ -221,6 +224,7 @@ internal fun HomeRoute(
 			viewModel.onIntent(HomeIntent.ClickTextMarker(latLng.toEpisodeLatLng()))
 		},
 		onEpisodeMarkerClick = { episode ->
+			viewModel.onIntent(HomeIntent.StartProgrammaticCameraMove)
 			viewModel.onIntent(HomeIntent.ShowCard(episode))
 		},
 		onMapClick = {

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
@@ -344,24 +344,15 @@ private fun HomeScreen(
 
 			Spacer(modifier = Modifier.height(22.dp))
 
-			Row(
+			Box(
 				modifier = Modifier.fillMaxWidth(),
 			) {
-				Box(
-					modifier = Modifier.fillMaxWidth(),
-					contentAlignment = Alignment.CenterEnd,
-				) {
-					MapisodeFabOverlayButton(
-						onClick = onGroupFabClick,
-						modifier = Modifier.padding(end = 20.dp),
-					)
-				}
-
 				if (state.showRefreshButton) {
 					MapisodeText(
 						text = stringResource(R.string.refresh),
 						style = AppTypography.bodyLarge,
 						modifier = Modifier
+							.align(Alignment.Center)
 							.clip(RoundedCornerShape(10.dp))
 							.clickable { onRefreshClick() }
 							.background(
@@ -372,6 +363,13 @@ private fun HomeScreen(
 						color = Color.White,
 					)
 				}
+
+				MapisodeFabOverlayButton(
+					onClick = onGroupFabClick,
+					modifier = Modifier
+						.align(Alignment.CenterEnd)
+						.padding(end = 20.dp),
+				)
 			}
 
 			if (state.isCardVisible) {

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
@@ -8,12 +8,15 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -39,6 +42,7 @@ import com.boostcamp.mapisode.home.common.HomeConstant.EXTRA_RANGE
 import com.boostcamp.mapisode.home.common.HomeConstant.tempGroupList
 import com.boostcamp.mapisode.home.common.getChipIconTint
 import com.boostcamp.mapisode.home.common.mapCategoryToChipType
+import com.boostcamp.mapisode.home.component.EpisodeCard
 import com.boostcamp.mapisode.home.component.GroupBottomSheetContent
 import com.boostcamp.mapisode.home.component.MapisodeChip
 import com.boostcamp.mapisode.home.component.MapisodeFabOverlayButton
@@ -310,7 +314,7 @@ private fun HomeScreen(
 
 		Column(
 			modifier = Modifier
-				.fillMaxWidth()
+				.fillMaxSize()
 				.padding(top = 46.dp),
 			horizontalAlignment = Alignment.CenterHorizontally,
 		) {
@@ -339,6 +343,56 @@ private fun HomeScreen(
 					onClick = onGroupFabClick,
 					modifier = Modifier.padding(end = 20.dp),
 				)
+			}
+
+			if (state.isCardVisible) {
+				val pagerState = rememberPagerState(
+					initialPage = state.selectedEpisodeIndex,
+					initialPageOffsetFraction = 0f,
+					pageCount = { state.selectedEpisodes.size },
+				)
+
+				LaunchedEffect(pagerState.currentPage) {
+					val currentEpisode = state.selectedEpisodes.getOrNull(pagerState.currentPage)
+					currentEpisode?.let { episode ->
+						val position = LatLng(episode.location.latitude, episode.location.longitude)
+						cameraPositionState.position = CameraPosition(position, DEFAULT_ZOOM)
+					}
+				}
+
+				LaunchedEffect(state.selectedEpisodes) {
+					if (pagerState.currentPage != state.selectedEpisodeIndex) {
+						pagerState.scrollToPage(state.selectedEpisodeIndex)
+					}
+				}
+
+				Spacer(modifier = Modifier.weight(1f))
+
+				HorizontalPager(
+					state = pagerState,
+					modifier = Modifier
+						.fillMaxWidth()
+						.align(Alignment.CenterHorizontally),
+					verticalAlignment = Alignment.CenterVertically,
+					contentPadding = PaddingValues(horizontal = 20.dp),
+					pageSpacing = 10.dp,
+				) { page ->
+					val episode = state.selectedEpisodes[page]
+
+					Box(
+						modifier = Modifier.fillMaxWidth(),
+						contentAlignment = Alignment.Center,
+					) {
+						EpisodeCard(
+							episode = episode,
+							onClick = {
+								// TODO : 상세보기로 이동
+							},
+						)
+					}
+				}
+
+				Spacer(modifier = Modifier.height(20.dp))
 			}
 		}
 

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
@@ -5,6 +5,8 @@ import android.app.Activity
 import android.content.pm.PackageManager
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -17,6 +19,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -28,7 +31,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
@@ -36,6 +42,9 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.boostcamp.mapisode.common.util.toEpisodeLatLng
 import com.boostcamp.mapisode.designsystem.compose.MapisodeModalBottomSheet
+import com.boostcamp.mapisode.designsystem.compose.MapisodeText
+import com.boostcamp.mapisode.designsystem.theme.AppTypography
+import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 import com.boostcamp.mapisode.home.common.ChipType
 import com.boostcamp.mapisode.home.common.HomeConstant.DEFAULT_ZOOM
 import com.boostcamp.mapisode.home.common.HomeConstant.EXTRA_RANGE
@@ -335,14 +344,34 @@ private fun HomeScreen(
 
 			Spacer(modifier = Modifier.height(22.dp))
 
-			Box(
+			Row(
 				modifier = Modifier.fillMaxWidth(),
-				contentAlignment = Alignment.CenterEnd,
 			) {
-				MapisodeFabOverlayButton(
-					onClick = onGroupFabClick,
-					modifier = Modifier.padding(end = 20.dp),
-				)
+				Box(
+					modifier = Modifier.fillMaxWidth(),
+					contentAlignment = Alignment.CenterEnd,
+				) {
+					MapisodeFabOverlayButton(
+						onClick = onGroupFabClick,
+						modifier = Modifier.padding(end = 20.dp),
+					)
+				}
+
+				if (state.showRefreshButton) {
+					MapisodeText(
+						text = stringResource(R.string.refresh),
+						style = AppTypography.bodyLarge,
+						modifier = Modifier
+							.clip(RoundedCornerShape(10.dp))
+							.clickable { onRefreshClick() }
+							.background(
+								color = MapisodeTheme.colorScheme.fabBackground,
+								shape = RoundedCornerShape(10.dp),
+							)
+							.padding(vertical = 8.dp, horizontal = 12.dp),
+						color = Color.White,
+					)
+				}
 			}
 
 			if (state.isCardVisible) {

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeState.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeState.kt
@@ -30,4 +30,5 @@ data class HomeState(
 	val selectedMarkerPosition: LatLng? = null,
 	val isMapMovedWhileCardVisible: Boolean = false,
 	val showRefreshButton: Boolean = false,
+	val isCameraMovingProgrammatically: Boolean = false,
 ) : UiState

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeState.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeState.kt
@@ -24,4 +24,10 @@ data class HomeState(
 	val selectedChip: ChipType? = null,
 	val isBottomSheetVisible: Boolean = false,
 	val episodes: PersistentList<EpisodeModel> = persistentListOf(),
+	val isCardVisible: Boolean = false,
+	val selectedEpisodes: PersistentList<EpisodeModel> = persistentListOf(),
+	val selectedEpisodeIndex: Int = 0,
+	val selectedMarkerPosition: LatLng? = null,
+	val isMapMovedWhileCardVisible: Boolean = false,
+	val showRefreshButton: Boolean = false,
 ) : UiState

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeViewModel.kt
@@ -15,6 +15,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeViewModel.kt
@@ -15,7 +15,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.launch
-import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -75,6 +74,14 @@ class HomeViewModel @Inject constructor(private val episodeRepository: EpisodeRe
 
 			is HomeIntent.MapMovedWhileCardVisible -> {
 				mapMovedWhileCardVisible()
+			}
+
+			is HomeIntent.StartProgrammaticCameraMove -> {
+				setProgrammaticCameraMove(true)
+			}
+
+			is HomeIntent.EndProgrammaticCameraMove -> {
+				setProgrammaticCameraMove(false)
 			}
 		}
 	}
@@ -208,4 +215,9 @@ class HomeViewModel @Inject constructor(private val episodeRepository: EpisodeRe
 		episodeModel.location.distanceTo(referenceLocation)
 	}
 
+	private fun setProgrammaticCameraMove(isMoving: Boolean) {
+		intent {
+			copy(isCameraMovingProgrammatically = isMoving)
+		}
+	}
 }

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/component/EpisodeCard.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/component/EpisodeCard.kt
@@ -105,7 +105,6 @@ fun EpisodeCard(
 			}
 			// TODO 버튼 추가
 			// Spacer(modifier = Modifier.weight(1f))
-
 		}
 	}
 }

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/component/EpisodeCard.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/component/EpisodeCard.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -44,6 +45,7 @@ fun EpisodeCard(
 
 	Row(
 		modifier = modifier
+			.fillMaxWidth()
 			.clip(RoundedCornerShape(12.dp))
 			.background(
 				color = MapisodeTheme.colorScheme.surfaceBackground,
@@ -94,12 +96,13 @@ fun EpisodeCard(
 				color = MapisodeTheme.colorScheme.textContent,
 			)
 
-			MapisodeText(
-				text = tagString,
-				style = AppTypography.labelMedium.copy(fontSize = 10.dp),
-				color = MapisodeTheme.colorScheme.textContent,
-			)
-
+			if (episode.tags.isNotEmpty()) {
+				MapisodeText(
+					text = tagString,
+					style = AppTypography.labelMedium.copy(fontSize = 10.dp),
+					color = MapisodeTheme.colorScheme.textContent,
+				)
+			}
 			// TODO 버튼 추가
 			// Spacer(modifier = Modifier.weight(1f))
 

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/component/EpisodeCard.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/component/EpisodeCard.kt
@@ -1,0 +1,130 @@
+package com.boostcamp.mapisode.home.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil3.annotation.ExperimentalCoilApi
+import coil3.compose.AsyncImage
+import coil3.compose.AsyncImagePreviewHandler
+import coil3.compose.LocalAsyncImagePreviewHandler
+import coil3.test.FakeImage
+import com.boostcamp.mapisode.common.util.toFormattedString
+import com.boostcamp.mapisode.designsystem.compose.MapisodeText
+import com.boostcamp.mapisode.designsystem.theme.AppTypography
+import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
+import com.boostcamp.mapisode.home.R
+import com.boostcamp.mapisode.model.EpisodeModel
+import java.util.Date
+
+@Composable
+fun EpisodeCard(
+	episode: EpisodeModel,
+	modifier: Modifier = Modifier,
+	onClick: () -> Unit = {},
+) {
+	val tagString = episode.tags.joinToString(
+		prefix = stringResource(R.string.episode_card_tag_prefix),
+		separator = ", #",
+	)
+
+	Row(
+		modifier = modifier
+			.clip(RoundedCornerShape(12.dp))
+			.background(
+				color = MapisodeTheme.colorScheme.surfaceBackground,
+				shape = RoundedCornerShape(12.dp),
+			)
+			.padding(20.dp),
+	) {
+		AsyncImage(
+			model = episode.imageUrls.firstOrNull(),
+			contentDescription = stringResource(R.string.episode_card_image_description),
+			contentScale = ContentScale.Crop,
+			modifier = Modifier
+				.clip(RoundedCornerShape(8.dp))
+				.size(120.dp),
+		)
+
+		Spacer(modifier = Modifier.width(17.dp))
+
+		Column(
+			modifier = Modifier
+				.weight(1f)
+				.height(120.dp),
+		) {
+			MapisodeText(
+				text = episode.title,
+				style = AppTypography.bodyMedium.copy(fontWeight = FontWeight.Medium),
+				color = MapisodeTheme.colorScheme.textContent,
+			)
+
+			MapisodeText(
+				text = stringResource(
+					R.string.episode_card_date_prefix,
+					episode.createdAt.toFormattedString(),
+				),
+				style = AppTypography.labelMedium.copy(fontSize = 10.dp),
+				color = MapisodeTheme.colorScheme.textContent,
+			)
+
+			MapisodeText(
+				text = stringResource(R.string.episode_creator_tag_prefix, episode.createdBy),
+				style = AppTypography.labelMedium.copy(fontSize = 10.dp),
+				color = MapisodeTheme.colorScheme.textContent,
+			)
+
+			MapisodeText(
+				text = stringResource(R.string.episode_card_category_prefix, episode.category),
+				style = AppTypography.labelMedium.copy(fontSize = 10.dp),
+				color = MapisodeTheme.colorScheme.textContent,
+			)
+
+			MapisodeText(
+				text = tagString,
+				style = AppTypography.labelMedium.copy(fontSize = 10.dp),
+				color = MapisodeTheme.colorScheme.textContent,
+			)
+
+			// TODO 버튼 추가
+			// Spacer(modifier = Modifier.weight(1f))
+
+		}
+	}
+}
+
+@OptIn(ExperimentalCoilApi::class)
+@Preview(showBackground = true)
+@Composable
+fun EpisodeCardPreview() {
+	val previewHandler = AsyncImagePreviewHandler {
+		FakeImage(color = 0xFFE0E0E0.toInt())
+	}
+
+	CompositionLocalProvider(LocalAsyncImagePreviewHandler provides previewHandler) {
+		EpisodeCard(
+			episode = EpisodeModel(
+				imageUrls = listOf("https://avatars.githubusercontent.com/u/98825364?v=4?s=100"),
+				title = "Title",
+				createdAt = Date(),
+				createdBy = "AndroidDessertClub",
+				category = "Category",
+				tags = listOf("tag1", "tag2"),
+			),
+		)
+	}
+}

--- a/feature/home/src/main/res/values/strings.xml
+++ b/feature/home/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
 	<string name="group_my_episode_name">👑 나의 에피소드</string>
 	<string name="group_bottomsheet_title">그룹 선택</string>
 	<string name="error_load_episodes">에피소드를 불러오는데 실패했습니다.</string>
+	<string name="refresh">새로고침</string>
 
 	<!-- EpisodeCard -->
 	<string name="episode_card_tag_prefix">태그 : #</string>

--- a/feature/home/src/main/res/values/strings.xml
+++ b/feature/home/src/main/res/values/strings.xml
@@ -9,4 +9,11 @@
 	<string name="group_my_episode_name">👑 나의 에피소드</string>
 	<string name="group_bottomsheet_title">그룹 선택</string>
 	<string name="error_load_episodes">에피소드를 불러오는데 실패했습니다.</string>
+
+	<!-- EpisodeCard -->
+	<string name="episode_card_tag_prefix">태그 : #</string>
+	<string name="episode_card_date_prefix">날짜 : %1$s</string>
+	<string name="episode_creator_tag_prefix">생성자 : %1$s</string>
+	<string name="episode_card_category_prefix">카테고리 : %1$s</string>
+	<string name="episode_card_image_description">애피소드 썸네일</string>
 </resources>


### PR DESCRIPTION
- closed #113 

## *📍 Work Description*
- haversine 계산법으로 두 좌표 간 거리 계산하는 확장 함수 구현
- Date -> YYYY.mm.dd 변환 확장함수 구현

### 자세한 구현 내용
1. 유저가 마커를 누르면 애피소드 카드를 보여준다. 
2. 위 상황이 발생하면 더 이상 카메라 위치 변경 시 애피소드를 새로 갱신하지 않는다. 
3. 위 상황에서 얻은 애피소드 리스트를 가까운 순으로 정렬하고 상태로 저장한다.
4. 만약 위 상황에서 지도를 움직이면 새로고침 버튼이 뜬다. 이 버튼으로 애피소드를 현 카메라 시점으로 새로 갱신할 수 있으며, 카드의 리스트도 다시 불러온다.
5. 애피소드 카드가 띄워진 상태에서 스와이프를 통해 가까운 순으로 정렬된 애피소드로 이동할 수 있다. 이 때 지도의 빈 화면을 터치하면 이 상황이 해지되고, 다시 카메라 이동으로 애피소드를 갱신해 볼 수 있다. 

## *📸 Screenshot*

<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->

https://github.com/user-attachments/assets/77a625ca-94ff-498e-9a21-02b521bd5ae0


## *📢 To Reviewers*
- 만든 확장함수들 core:common에 있으니 요긴하게 쓰시기 바랍니다.
- 애피소드 카드 디자인 수정 및 버튼 추가는 태웅님 PR 머지되면 이어서 push 하겠습니다. 

## ⏲️Time

    - 6 h
