### PR TITLE
[FIX/#122] Auth / 자동 로그인 오류 수정

### DIFF
--- a/data/user/src/main/java/com/boostcamp/mapisode/user/UserRepositoryImpl.kt
+++ b/data/user/src/main/java/com/boostcamp/mapisode/user/UserRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.boostcamp.mapisode.model.UserModel
 import com.boostcamp.mapisode.user.model.toUserFirestoreModel
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.tasks.await
+import java.util.Date
 import javax.inject.Inject
 
 class UserRepositoryImpl @Inject constructor(database: FirebaseFirestore) : UserRepository {
@@ -13,16 +14,34 @@ class UserRepositoryImpl @Inject constructor(database: FirebaseFirestore) : User
 	override suspend fun createUser(userModel: UserModel) {
 		val userFirestoreModel = userModel.toUserFirestoreModel()
 
-		val userDocument = userCollection.document(userFirestoreModel.uid)
+		val userDocument = userCollection.document(userModel.uid)
 
 		try {
 			val document = userDocument.get().await()
-			if (document.exists()) {
-				throw Exception("User already exists")
-			}
+
+			if (document.exists()) throw Exception("User already exists")
+
 			userDocument.set(userFirestoreModel).await()
 		} catch (e: Exception) {
 			throw Exception("Failed to create user", e)
+		}
+	}
+
+	override suspend fun getUserInfo(uid: String): UserModel {
+		val userDocument = userCollection.document(uid)
+
+		try {
+			val user = userDocument.get().await()
+			return UserModel(
+				uid = user.id,
+				name = user.getString("name") ?: "",
+				email = user.getString("email") ?: "",
+				profileUrl = user.getString("profileUrl") ?: "",
+				joinedAt = user.getDate("joinedAt") ?: Date.from(java.time.Instant.now()),
+				groups = emptyList(), // 우선 빈 리스트를 넣도록 했습니다. 혹시나 사용하실 분은 수정해주세요.
+			)
+		} catch (e: Exception) {
+			throw Exception("Failed to get user", e)
 		}
 	}
 

--- a/data/user/src/main/java/com/boostcamp/mapisode/user/model/ModelConverter.kt
+++ b/data/user/src/main/java/com/boostcamp/mapisode/user/model/ModelConverter.kt
@@ -4,8 +4,8 @@ import com.boostcamp.mapisode.model.UserModel
 
 internal fun UserModel.toUserFirestoreModel(): UserFirestoreModel =
 	UserFirestoreModel(
-		uid = uid,
-		nickname = name,
+		name = name,
 		email = email,
-		profileUri = profileUrl,
+		profileUrl = profileUrl,
+		joinedAt = joinedAt,
 	)

--- a/data/user/src/main/java/com/boostcamp/mapisode/user/model/UserFirestoreModel.kt
+++ b/data/user/src/main/java/com/boostcamp/mapisode/user/model/UserFirestoreModel.kt
@@ -1,8 +1,12 @@
 package com.boostcamp.mapisode.user.model
 
+import com.boostcamp.mapisode.model.GroupModel
+import java.util.Date
+
 data class UserFirestoreModel(
-	val uid: String,
-	val nickname: String,
+	val name: String,
 	val email: String,
-	val profileUri: String,
+	val profileUrl: String,
+	val joinedAt: Date = Date.from(java.time.Instant.now()),
+	val groups: List<GroupModel> = emptyList(),
 )

--- a/domain/user/src/main/java/com/boostcamp/mapisode/user/UserRepository.kt
+++ b/domain/user/src/main/java/com/boostcamp/mapisode/user/UserRepository.kt
@@ -4,5 +4,7 @@ import com.boostcamp.mapisode.model.UserModel
 
 interface UserRepository {
 	suspend fun createUser(userModel: UserModel)
+
+	suspend fun getUserInfo(uid: String): UserModel
 	suspend fun isUserExist(uid: String): Boolean
 }

--- a/feature/login/src/main/java/com/boostcamp/mapisode/login/SignUpScreen.kt
+++ b/feature/login/src/main/java/com/boostcamp/mapisode/login/SignUpScreen.kt
@@ -96,8 +96,11 @@ fun SignUpScreen(
 					text = stringResource(R.string.login_next),
 					onClick = onSignUpClick,
 					modifier = Modifier
+						.weight(1f)
 						.fillMaxWidth(),
 				)
+
+				Spacer(modifier = Modifier.weight(0.6f))
 			}
 		}
 	}


### PR DESCRIPTION
- closed #122 

## *📍 Work Description*

- 유저가 존재하는 상태에서 자동로그인하면, datastore에 데이터가 저장되지 않던 문제 해결.
- 예를 들어, 다른 휴대전화에서 같은 아이디로 로그인했을 때, uid등이 datastore에 저장되지 않았습니다.이 pr을 통해, 값이 저장됩니다.
- 회원가입 화면 버튼 크기 정상화했습니다.

## *📢 To Reviewers*
- 항상 감사합니다!

## ⏲️Time

    - 1.5 h 
