### PR TITLE
[FEAT/#133] Designsystem / Custom CircularIndicator 제작

### DIFF
--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeCircularIndicator.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeCircularIndicator.kt
@@ -1,0 +1,51 @@
+package com.boostcamp.mapisode.designsystem.compose
+
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
+
+@Composable
+fun MapisodeCircularLoadingIndicator(
+	modifier: Modifier = Modifier,
+	circleSize: Dp = 50.dp,
+	borderWidth: Dp = 3.dp,
+	color: Color = MapisodeTheme.colorScheme.circularIndicator,
+	animationDuration: Int = 800,
+	cap: StrokeCap = StrokeCap.Butt,
+) {
+	val infiniteTransition = rememberInfiniteTransition(label = "무한 애니메이션")
+	val animatedProgress = infiniteTransition.animateFloat(
+		initialValue = -90f,
+		targetValue = 270f,
+		animationSpec = infiniteRepeatable(
+			animation = tween(durationMillis = animationDuration, easing = FastOutSlowInEasing),
+		),
+		label = "애니메이션 인디케이터",
+	)
+
+	Canvas(modifier = modifier.size(circleSize)) {
+		val arcSize = circleSize.toPx() - borderWidth.toPx()
+
+		drawArc(
+			color = color,
+			startAngle = animatedProgress.value,
+			sweepAngle = 240f,
+			useCenter = false,
+			style = Stroke(width = borderWidth.toPx(), cap = cap),
+			size = Size(arcSize, arcSize),
+		)
+	}
+}

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/theme/ColorScheme.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/theme/ColorScheme.kt
@@ -13,6 +13,9 @@ data class CustomColorScheme(
 	// Top App Bar
 	val topAppBarTitle: Color,
 
+	// Circular Indicator
+	val circularIndicator: Color,
+
 	// Scaffold
 	val scaffoldBackground: Color,
 
@@ -108,6 +111,9 @@ val lightColorScheme = CustomColorScheme(
 	// Top App Bar
 	topAppBarTitle = Neutral110,
 
+	// Circular Indicator
+	circularIndicator = Primary30,
+
 	// Scaffold
 	scaffoldBackground = Neutral10,
 
@@ -202,6 +208,9 @@ val darkColorScheme = CustomColorScheme(
 
 	// Top App Bar
 	topAppBarTitle = Neutral10,
+
+	// Circular Indicator
+	circularIndicator = Primary40,
 
 	// Scaffold
 	scaffoldBackground = Neutral110,


### PR DESCRIPTION
- closed #133 

## *📍 Work Description*

- 커스텀 원형 인디케이터 제작

## *📸 Screenshot*


https://github.com/user-attachments/assets/28bebd9d-583b-42b5-9000-38ecb33a3ef0

<img src="https://github.com/user-attachments/assets/24bdcdda-3fbe-4c69-bbb7-e99dd6f0ba1c" width=600>


## *📢 To Reviewers*
- Material 의 인디케이터처럼 인자 추가 없이 생으로 쓰셔도 됩니다.
- 사이즈, 색상, 두께, 회전 속도, 선 끝의 모양 설정이 가능합니다.
- StrokeCap.Butt 은 선 끝이 Butt 평평하게 각진 모양입니다.

- InfiniteTransition 타입의 animateFloat 확장함수를 사용하여 initialValue 부터 targetValue 까지 float 타입의 숫자 범위를 durationMillis 동안 주기적으로 도달하는 끝없는 transition 을 정의한다.
  - 이 함수는 단순히 숫자만을 반복하게 정의하는 함수다.
- canvas 의 drawArc 함수 내부에 그리는 시점 속성(startAngle) 에 변화되는 transition 을 대입하여 회전하는 애니메이션 효과를 부여한다.

<img src="https://github.com/user-attachments/assets/b8f885b0-064c-47ba-a704-5b4feeb58a34" width=600>

[Compose phases and performance](https://developer.android.com/develop/ui/compose/performance/phases)
- 인디케이터가 계속 실행될 때 리컴포지션이 될 줄 알았는데 에뮬레이터의 layout inspector를 확인한 결과 리컴포지션이 일어나고 있지 않았다.
- 확인 결과 draw 와 composition 의 차이를 알게 되었고, 추가적인 element가 없다면 recomposition 은 일어나지 않고 redraw 만 일어나고 한다.


## ⏲️Time

    - 1.5 시간
