### PR TITLE
[FIX/#136] TextField 내부 수정

### DIFF
--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeTextField.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeTextField.kt
@@ -6,8 +6,10 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -64,7 +66,6 @@ fun MapisodeTextField(
 	keyboardOptions: KeyboardOptions = KeyboardOptions(
 		imeAction = ImeAction.Done,
 	),
-	keyboardActions: KeyboardActions = KeyboardActions.Default,
 	singleLine: Boolean = false,
 	maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
 	minLines: Int = 1,
@@ -75,7 +76,7 @@ fun MapisodeTextField(
 	cursorColor: Color = MapisodeTheme.colorScheme.textFieldStroke,
 	errorContainerColor: Color = MapisodeTheme.colorScheme.seeIconColor,
 	errorTextColor: Color = MapisodeTheme.colorScheme.seeIconColor,
-	strokeColor: Color = MapisodeTheme.colorScheme.textFieldStroke,
+	strokeColor: Color = if (isError) errorTextColor else MapisodeTheme.colorScheme.textFieldStroke,
 	strokeWidth: Dp = 1.dp,
 ) {
 	@Suppress("NAME_SHADOWING")
@@ -83,7 +84,7 @@ fun MapisodeTextField(
 	val focusManager = LocalFocusManager.current
 	var isFocused by remember { mutableStateOf(false) }
 
-	Box(
+	Column(
 		modifier = modifier
 			.width(320.dp)
 			.height(42.dp)
@@ -91,77 +92,96 @@ fun MapisodeTextField(
 				minWidth = 320.dp,
 				minHeight = 42.dp,
 			)
-			.clickable(
-				interactionSource = interactionSource,
-				indication = null,
-				enabled = enabled && !readOnly,
-			) { }
 			.onFocusChanged { focusState ->
 				if (isFocused && !focusState.isFocused) {
 					onSubmitInput(value)
 				}
 				isFocused = focusState.isFocused
-			}
-			.border(strokeWidth, strokeColor, shape)
-			.background(if (isError) errorContainerColor else containerColor, shape)
-			.padding(vertical = 12.dp, horizontal = 16.dp),
+			},
 	) {
-		Row(
-			modifier = Modifier.fillMaxWidth(),
-			verticalAlignment = Alignment.CenterVertically,
-			horizontalArrangement = Arrangement.SpaceBetween,
-		) {
-			if (leadingIcon != null) {
-				leadingIcon()
+		if (label != null) {
+			Box(modifier = Modifier.padding(bottom = 4.dp)) {
+				label()
 			}
-			BasicTextField(
-				value = value,
-				onValueChange = onValueChange,
-				modifier = Modifier
-					.weight(1f)
-					.fillMaxWidth(),
-				enabled = enabled,
-				readOnly = readOnly,
-				textStyle = textStyle.copy(color = textColor).toTextStyle(),
-				cursorBrush = SolidColor(cursorColor),
-				visualTransformation = visualTransformation,
-				keyboardOptions = keyboardOptions,
-				keyboardActions = KeyboardActions(
-					onDone = {
-						focusManager.clearFocus()
+		}
+		Box(
+			modifier = Modifier
+				.clickable(
+					interactionSource = interactionSource,
+					indication = null,
+					enabled = enabled && !readOnly,
+				) { }
+				.border(strokeWidth, strokeColor, shape)
+				.background(
+					if (isError) {
+						errorContainerColor.copy(alpha = 0.1f)
+					} else {
+						containerColor
 					},
-				),
-				interactionSource = interactionSource,
-				singleLine = singleLine,
-				maxLines = maxLines,
-				minLines = minLines,
-				decorationBox = { innerTextField ->
-					Box(
-						modifier = Modifier.fillMaxWidth(),
-						contentAlignment = Alignment.CenterStart,
-					) {
-						if (prefix != null) {
-							Box(modifier = Modifier.padding(end = 8.dp)) {
-								prefix()
+					shape,
+				)
+				.padding(vertical = 12.dp, horizontal = 16.dp),
+		) {
+			Row(
+				verticalAlignment = Alignment.CenterVertically,
+				horizontalArrangement = Arrangement.SpaceBetween,
+			) {
+				if (leadingIcon != null) {
+					leadingIcon()
+				}
+				BasicTextField(
+					value = value,
+					onValueChange = onValueChange,
+					modifier = Modifier
+						.fillMaxSize()
+						.weight(0.8f),
+					enabled = enabled,
+					readOnly = readOnly,
+					textStyle = textStyle.copy(
+						color = if (isError) {
+							errorTextColor
+						} else {
+							textColor
+						},
+					).toTextStyle(),
+					cursorBrush = SolidColor(cursorColor),
+					visualTransformation = visualTransformation,
+					keyboardOptions = keyboardOptions,
+					keyboardActions = KeyboardActions(
+						onDone = { focusManager.clearFocus() },
+					),
+					interactionSource = interactionSource,
+					singleLine = singleLine,
+					maxLines = maxLines,
+					minLines = minLines,
+					decorationBox = { innerTextField ->
+						Box(
+							modifier = Modifier.fillMaxWidth(),
+							contentAlignment = Alignment.CenterStart,
+						) {
+							if (prefix != null) {
+								Box(modifier = Modifier.padding(end = 8.dp)) {
+									prefix()
+								}
+							}
+
+							if (value.isEmpty() && placeholder.isNotBlank()) {
+								MapisodePlaceHolder(value = placeholder)
+							}
+
+							innerTextField()
+
+							if (suffix != null) {
+								Box(modifier = Modifier.padding(start = 8.dp)) {
+									suffix()
+								}
 							}
 						}
-
-						if (value.isEmpty() && placeholder.isNotBlank()) {
-							MapisodePlaceHolder(value = placeholder)
-						}
-
-						innerTextField()
-
-						if (suffix != null) {
-							Box(modifier = Modifier.padding(start = 8.dp)) {
-								suffix()
-							}
-						}
-					}
-				},
-			)
-			if (trailingIcon != null) {
-				trailingIcon()
+					},
+				)
+				if (trailingIcon != null) {
+					trailingIcon()
+				}
 			}
 		}
 	}


### PR DESCRIPTION
- closed #136

## *📍 Work Description*

- 모든 영역에서 포커스를 가져오도록 수정
- 에러 활성화시 색상 변경
- 현재 적용된 텍스트 필드에 영향안가도록 수정

## *📸 Screenshot*

<img src="https://github.com/user-attachments/assets/2f2d0e9e-c27f-447f-a089-d63e4d7ebc81" width=300>

<img src="https://github.com/user-attachments/assets/c70a106f-b6db-4128-8ffa-baf967caca29" width=300>


## *📢 To Reviewers*
- 동역님이 세팅한 텍스트 필드 기준으로 영향안가도록 size는 손 안대고 설정했습니다.
- 초기 컴포넌트 제작시 내부에 고정적인 사이즈를 부여한 치명적인 문제를 지금 당장은 수정불가라서 이 점 고려해주세요
  - 초반에 여러번 주의를 들었지만 modifier의 무지함으로 발생한 문제

## ⏲️Time

    - 1시간
