### PR TITLE
[FEAT/#123] Group / UI 3차

### DIFF
--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/card/GroupInfoCard.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/card/GroupInfoCard.kt
@@ -24,6 +24,8 @@ import com.boostcamp.mapisode.designsystem.compose.MapisodeText
 import com.boostcamp.mapisode.designsystem.compose.Thickness
 import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 import com.boostcamp.mapisode.model.GroupModel
+import java.text.SimpleDateFormat
+import java.util.Locale
 
 @Composable
 fun GroupInfoCard(
@@ -60,7 +62,9 @@ fun GroupInfoCard(
 			Spacer(modifier = Modifier.padding(4.dp))
 
 			MapisodeText(
-				text = stringResource(R.string.group_created_date) + group.createdAt,
+				text = stringResource(R.string.group_created_date)
+					+ SimpleDateFormat("yyyy.MM.dd", Locale.getDefault())
+					.format(group.createdAt),
 				style = MapisodeTheme.typography.labelMedium,
 				maxLines = 1,
 			)

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/card/GroupInfoCard.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/card/GroupInfoCard.kt
@@ -64,7 +64,7 @@ fun GroupInfoCard(
 			MapisodeText(
 				text = stringResource(R.string.group_created_date) +
 					SimpleDateFormat("yyyy.MM.dd", Locale.getDefault())
-					.format(group.createdAt),
+						.format(group.createdAt),
 				style = MapisodeTheme.typography.labelMedium,
 				maxLines = 1,
 			)

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/card/GroupInfoCard.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/card/GroupInfoCard.kt
@@ -62,8 +62,8 @@ fun GroupInfoCard(
 			Spacer(modifier = Modifier.padding(4.dp))
 
 			MapisodeText(
-				text = stringResource(R.string.group_created_date)
-					+ SimpleDateFormat("yyyy.MM.dd", Locale.getDefault())
+				text = stringResource(R.string.group_created_date) +
+					SimpleDateFormat("yyyy.MM.dd", Locale.getDefault())
 					.format(group.createdAt),
 				style = MapisodeTheme.typography.labelMedium,
 				maxLines = 1,

--- a/core/firebase/src/main/java/com/boostcamp/mapisode/firebase/firestore/FirestoreConstants.kt
+++ b/core/firebase/src/main/java/com/boostcamp/mapisode/firebase/firestore/FirestoreConstants.kt
@@ -14,4 +14,5 @@ object FirestoreConstants {
 	const val FIELD_ADMIN_USER = "adminUser"
 	const val FIELD_MEMBERS = "members"
 	const val FIELD_CREATED_AT = "createdAt"
+	const val FIELD_CREATED_BY = "createdBy"
 }

--- a/core/model/src/main/kotlin/com/boostcamp/mapisode/model/GroupMemberModel.kt
+++ b/core/model/src/main/kotlin/com/boostcamp/mapisode/model/GroupMemberModel.kt
@@ -3,6 +3,7 @@ package com.boostcamp.mapisode.model
 import java.util.Date
 
 class GroupMemberModel(
+	val id: String = "",
 	val name: String,
 	val email: String,
 	val profileUrl: String,

--- a/data/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepositoryImpl.kt
+++ b/data/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepositoryImpl.kt
@@ -207,6 +207,7 @@ class GroupRepositoryImpl @Inject constructor(private val database: FirebaseFire
 			.toObject(UserFirestoreModel::class.java)
 			?: throw Exception("유저를 찾을 수 없습니다.")
 		GroupMemberModel(
+			id = userId,
 			name = firestoreModel.name,
 			email = firestoreModel.email,
 			profileUrl = firestoreModel.profileUrl,
@@ -217,22 +218,24 @@ class GroupRepositoryImpl @Inject constructor(private val database: FirebaseFire
 		throw e
 	}
 
-	override suspend fun getEpisodesByGroupIdAndUserId(groupId: String, userId: String): List<EpisodeModel> =
-		try {
-			val groupDocRef = database.collection(FirestoreConstants.COLLECTION_GROUP).document(groupId)
-			val userDocRef = database.collection(FirestoreConstants.COLLECTION_USER).document(userId)
-			val episodeReferences = database.collection(FirestoreConstants.COLLECTION_EPISODE)
-				.whereEqualTo(FirestoreConstants.FIELD_GROUP, groupDocRef)
-				.whereEqualTo(FirestoreConstants.FIELD_CREATED_BY, userDocRef)
-				.get()
-				.await()
-				.documents
+	override suspend fun getEpisodesByGroupIdAndUserId(groupId: String, userId: String):
+		List<EpisodeModel> = try {
+		val groupDocRef = database
+			.collection(FirestoreConstants.COLLECTION_GROUP).document(groupId)
+		val userDocRef = database
+			.collection(FirestoreConstants.COLLECTION_USER).document(userId)
+		val episodeReferences = database.collection(FirestoreConstants.COLLECTION_EPISODE)
+			.whereEqualTo(FirestoreConstants.FIELD_GROUP, groupDocRef)
+			.whereEqualTo(FirestoreConstants.FIELD_CREATED_BY, userDocRef)
+			.get()
+			.await()
+			.documents
 
-			episodeReferences.mapNotNull { document ->
-				document.toObject(GroupEpisodeFirestoreModel::class.java)?.toDomainModel(userId)
-					?: throw Exception("에피소드를 찾을 수 없습니다.")
-			}
-		} catch (e: Exception) {
-			throw e
+		episodeReferences.mapNotNull { document ->
+			document.toObject(GroupEpisodeFirestoreModel::class.java)?.toDomainModel(userId)
+				?: throw Exception("에피소드를 찾을 수 없습니다.")
 		}
+	} catch (e: Exception) {
+		throw e
+	}
 }

--- a/data/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/model/GroupEpisodeFirestoreModel.kt
+++ b/data/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/model/GroupEpisodeFirestoreModel.kt
@@ -1,0 +1,34 @@
+package com.boostcamp.mapisode.mygroup.model
+
+import com.boostcamp.mapisode.model.EpisodeLatLng
+import com.boostcamp.mapisode.model.EpisodeModel
+import com.google.firebase.Timestamp
+import com.google.firebase.firestore.DocumentReference
+import com.google.firebase.firestore.GeoPoint
+
+data class GroupEpisodeFirestoreModel(
+	val category: String = "",
+	val content: String = "",
+	val createdBy: DocumentReference? = null,
+	val group: DocumentReference? = null,
+	val imageUrls: List<String> = emptyList(),
+	val location: GeoPoint? = null,
+	val memoryDate: Timestamp = Timestamp.now(),
+	val tags: List<String> = emptyList(),
+	val title: String = "",
+	val createdAt: Timestamp = Timestamp.now(),
+) {
+	fun toDomainModel(id: String): EpisodeModel = EpisodeModel(
+		id = id,
+		category = category,
+		content = content,
+		createdBy = createdBy?.id ?: "",
+		group = group?.id ?: "",
+		imageUrls = imageUrls,
+		location = location?.let { EpisodeLatLng(it.latitude, it.longitude) } ?: EpisodeLatLng(),
+		memoryDate = memoryDate.toDate(),
+		tags = tags,
+		title = title,
+		createdAt = createdAt.toDate(),
+	)
+}

--- a/domain/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepository.kt
+++ b/domain/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepository.kt
@@ -1,5 +1,6 @@
 package com.boostcamp.mapisode.mygroup
 
+import com.boostcamp.mapisode.model.EpisodeModel
 import com.boostcamp.mapisode.model.GroupMemberModel
 import com.boostcamp.mapisode.model.GroupModel
 
@@ -15,4 +16,5 @@ interface GroupRepository {
 	suspend fun deleteGroup(groupId: String)
 
 	suspend fun getUserInfoByUserId(userId: String): GroupMemberModel
+	suspend fun getEpisodesByGroupIdAndUserId(groupId: String, userId: String): List<EpisodeModel>
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/model/GroupUiEpisodeModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/model/GroupUiEpisodeModel.kt
@@ -27,15 +27,13 @@ data class GroupUiEpisodeModel(
 	}
 }
 
-fun EpisodeModel.toGroupUiEpisodeModel(writer: String): GroupUiEpisodeModel {
-	return GroupUiEpisodeModel(
-		title = title,
-		imageUrls = imageUrls,
-		category = category,
-		createdBy = writer,
-		content = content,
-		address = address,
-		memoryDate = memoryDate,
-		createdAt = createdAt,
-	)
-}
+fun EpisodeModel.toGroupUiEpisodeModel(writer: String): GroupUiEpisodeModel = GroupUiEpisodeModel(
+	title = title,
+	imageUrls = imageUrls,
+	category = category,
+	createdBy = writer,
+	content = content,
+	address = address,
+	memoryDate = memoryDate,
+	createdAt = createdAt,
+)

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/model/GroupUiEpisodeModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/model/GroupUiEpisodeModel.kt
@@ -13,18 +13,16 @@ data class GroupUiEpisodeModel(
 	val memoryDate: Date = Date(),
 	val createdAt: Date = Date(),
 ) {
-	fun toEpisodeModel(): EpisodeModel {
-		return EpisodeModel(
-			title = title,
-			imageUrls = imageUrls,
-			category = category,
-			createdBy = createdBy,
-			content = content,
-			address = address,
-			memoryDate = memoryDate,
-			createdAt = createdAt,
-		)
-	}
+	fun toEpisodeModel(): EpisodeModel = EpisodeModel(
+		title = title,
+		imageUrls = imageUrls,
+		category = category,
+		createdBy = createdBy,
+		content = content,
+		address = address,
+		memoryDate = memoryDate,
+		createdAt = createdAt,
+	)
 }
 
 fun EpisodeModel.toGroupUiEpisodeModel(writer: String): GroupUiEpisodeModel = GroupUiEpisodeModel(

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/model/GroupUiEpisodeModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/model/GroupUiEpisodeModel.kt
@@ -1,0 +1,41 @@
+package com.boostcamp.mapisode.mygroup.model
+
+import com.boostcamp.mapisode.model.EpisodeModel
+import java.util.Date
+
+data class GroupUiEpisodeModel(
+	val title: String = "",
+	val imageUrls: List<String> = emptyList(),
+	val category: String = "",
+	val createdBy: String = "",
+	val content: String = "",
+	val address: String = "",
+	val memoryDate: Date = Date(),
+	val createdAt: Date = Date(),
+) {
+	fun toEpisodeModel(): EpisodeModel {
+		return EpisodeModel(
+			title = title,
+			imageUrls = imageUrls,
+			category = category,
+			createdBy = createdBy,
+			content = content,
+			address = address,
+			memoryDate = memoryDate,
+			createdAt = createdAt,
+		)
+	}
+}
+
+fun EpisodeModel.toGroupUiEpisodeModel(writer: String): GroupUiEpisodeModel {
+	return GroupUiEpisodeModel(
+		title = title,
+		imageUrls = imageUrls,
+		category = category,
+		createdBy = writer,
+		content = content,
+		address = address,
+		memoryDate = memoryDate,
+		createdAt = createdAt,
+	)
+}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/model/GroupUiMemberModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/model/GroupUiMemberModel.kt
@@ -1,0 +1,13 @@
+package com.boostcamp.mapisode.mygroup.model
+
+import java.util.Date
+
+data class GroupUiMemberModel(
+	val name: String,
+	val email: String,
+	val profileUrl: String,
+	val joinedAt: Date,
+	val groups: List<String>,
+	val recentCreatedAt: Date?,
+	val countEpisode: Int,
+)

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/model/GroupUiMemberModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/model/GroupUiMemberModel.kt
@@ -3,6 +3,7 @@ package com.boostcamp.mapisode.mygroup.model
 import java.util.Date
 
 data class GroupUiMemberModel(
+	val id: String,
 	val name: String,
 	val email: String,
 	val profileUrl: String,

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupCreationScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupCreationScreen.kt
@@ -241,7 +241,7 @@ fun GroupCreationField(
 			Spacer(modifier = Modifier.padding(5.dp))
 			MapisodeFilledButton(
 				modifier = Modifier
-					.sizeIn(maxWidth = 380.dp, maxHeight = 380.dp)
+					.sizeIn(maxWidth = 380.dp, maxHeight = 80.dp)
 					.fillMaxWidth()
 					.heightIn(52.dp),
 				onClick = {

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupDetailScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupDetailScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
+import com.boostcamp.mapisode.common.util.toFormattedString
 import com.boostcamp.mapisode.designsystem.R
 import com.boostcamp.mapisode.designsystem.compose.Direction
 import com.boostcamp.mapisode.designsystem.compose.MapisodeDialog
@@ -67,9 +68,9 @@ import com.boostcamp.mapisode.designsystem.compose.tab.MapisodeTabRow
 import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
 import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 import com.boostcamp.mapisode.model.EpisodeModel
-import com.boostcamp.mapisode.model.GroupMemberModel
 import com.boostcamp.mapisode.model.GroupModel
 import com.boostcamp.mapisode.mygroup.intent.GroupDetailIntent
+import com.boostcamp.mapisode.mygroup.model.GroupUiMemberModel
 import com.boostcamp.mapisode.mygroup.sideeffect.GroupDetailSideEffect
 import com.boostcamp.mapisode.mygroup.sideeffect.rememberFlowWithLifecycle
 import com.boostcamp.mapisode.mygroup.state.GroupDetailState
@@ -277,7 +278,7 @@ fun GroupDetailContent(
 @Composable
 fun GroupDetailContent(
 	group: GroupModel,
-	members: List<GroupMemberModel>,
+	members: List<GroupUiMemberModel>,
 	onIssueCodeClick: () -> Unit,
 	onGroupOutClick: () -> Unit,
 ) {
@@ -441,7 +442,7 @@ fun GroupEpisodesContent(
 
 @Composable
 fun GroupMemberContent(
-	member: GroupMemberModel,
+	member: GroupUiMemberModel,
 ) {
 	Row(
 		modifier = Modifier
@@ -475,14 +476,19 @@ fun GroupMemberContent(
 				style = MapisodeTheme.typography.labelLarge,
 				maxLines = 1,
 			)
+			Spacer(modifier = Modifier.padding(2.dp))
 			MapisodeText(
-				text = "Joined: ${member.joinedAt}",
+				text = stringResource(S.string.content_member_joined_at)
+					+ member.joinedAt.toFormattedString(),
 				style = MapisodeTheme.typography.labelMedium,
 				maxLines = 1,
 			)
 			MapisodeText(
-				text = member.email,
-				style = MapisodeTheme.typography.bodySmall,
+				text = buildString {
+					append(stringResource(S.string.content_recent_episode_upload))
+					append(member.recentCreatedAt?.toFormattedString() ?: "없음")
+				},
+				style = MapisodeTheme.typography.labelMedium,
 				maxLines = 1,
 			)
 		}
@@ -491,13 +497,14 @@ fun GroupMemberContent(
 			horizontalAlignment = Alignment.End,
 		) {
 			MapisodeText(
-				text = "123",
-				style = MapisodeTheme.typography.labelSmall,
+				text = stringResource(S.string.content_episode_count),
+				style = MapisodeTheme.typography.labelMedium,
 				maxLines = 1,
 			)
 			MapisodeText(
-				text = "123",
-				style = MapisodeTheme.typography.labelSmall,
+				text = member.countEpisode.toString()
+					+ stringResource(S.string.content_number_count),
+				style = MapisodeTheme.typography.labelMedium,
 				maxLines = 1,
 			)
 		}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupDetailScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupDetailScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -361,14 +362,14 @@ fun GroupDetailContent(
 		) {
 			if (members.isEmpty()) {
 				Box(
-					modifier = Modifier.padding(top = 150.dp),
+					modifier = Modifier.aspectRatio(1.2f),
 					contentAlignment = Alignment.Center,
 				) {
 					MapisodeCircularLoadingIndicator()
 				}
 			} else {
-				repeat(members.size) { index ->
-					GroupMemberContent(members[index])
+				members.forEach {
+					GroupMemberContent(it)
 					Spacer(modifier = Modifier.padding(5.dp))
 				}
 				MapisodeOutlinedButton(

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupDetailScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupDetailScreen.kt
@@ -285,10 +285,12 @@ fun GroupDetailContent(
 	onIssueCodeClick: () -> Unit,
 	onGroupOutClick: () -> Unit,
 ) {
+	val outerScrollState = rememberScrollState()
 	Column(
 		modifier = Modifier
 			.fillMaxSize()
-			.padding(horizontal = 20.dp, vertical = 10.dp),
+			.padding(horizontal = 20.dp, vertical = 10.dp)
+			.verticalScroll(outerScrollState),
 		horizontalAlignment = Alignment.CenterHorizontally,
 	) {
 		GroupInfoCard(
@@ -351,11 +353,9 @@ fun GroupDetailContent(
 
 		Spacer(modifier = Modifier.padding(2.dp))
 
-		val scrollState = rememberScrollState()
 		Column(
 			modifier = Modifier
-				.fillMaxWidth()
-				.verticalScroll(scrollState),
+				.fillMaxWidth(),
 			verticalArrangement = Arrangement.Top,
 			horizontalAlignment = Alignment.CenterHorizontally,
 		) {

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupDetailScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupDetailScreen.kt
@@ -494,8 +494,8 @@ fun GroupMemberContent(
 			)
 			Spacer(modifier = Modifier.padding(2.dp))
 			MapisodeText(
-				text = stringResource(S.string.content_member_joined_at)
-					+ member.joinedAt.toFormattedString(),
+				text = stringResource(S.string.content_member_joined_at) +
+					member.joinedAt.toFormattedString(),
 				style = MapisodeTheme.typography.labelMedium,
 				maxLines = 1,
 			)
@@ -518,8 +518,8 @@ fun GroupMemberContent(
 				maxLines = 1,
 			)
 			MapisodeText(
-				text = member.countEpisode.toString()
-					+ stringResource(S.string.content_number_count),
+				text = member.countEpisode.toString() +
+					stringResource(S.string.content_number_count),
 				style = MapisodeTheme.typography.labelMedium,
 				maxLines = 1,
 			)

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupDetailScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupDetailScreen.kt
@@ -25,8 +25,10 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -51,6 +53,7 @@ import coil3.compose.AsyncImage
 import com.boostcamp.mapisode.common.util.toFormattedString
 import com.boostcamp.mapisode.designsystem.R
 import com.boostcamp.mapisode.designsystem.compose.Direction
+import com.boostcamp.mapisode.designsystem.compose.MapisodeCircularLoadingIndicator
 import com.boostcamp.mapisode.designsystem.compose.MapisodeDialog
 import com.boostcamp.mapisode.designsystem.compose.MapisodeDivider
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
@@ -282,88 +285,102 @@ fun GroupDetailContent(
 	onIssueCodeClick: () -> Unit,
 	onGroupOutClick: () -> Unit,
 ) {
-	LazyColumn(
+	Column(
 		modifier = Modifier
 			.fillMaxSize()
 			.padding(horizontal = 20.dp, vertical = 10.dp),
 		horizontalAlignment = Alignment.CenterHorizontally,
-		verticalArrangement = Arrangement.spacedBy(10.dp),
-		contentPadding = PaddingValues(bottom = 20.dp),
 	) {
-		item {
-			GroupInfoCard(
-				group = group,
-			)
+		GroupInfoCard(
+			group = group,
+		)
 
-			Spacer(modifier = Modifier.padding(5.dp))
+		Spacer(modifier = Modifier.padding(5.dp))
 
-			MapisodeDivider(direction = Direction.Horizontal, thickness = Thickness.Thin)
+		MapisodeDivider(direction = Direction.Horizontal, thickness = Thickness.Thin)
 
-			Spacer(modifier = Modifier.padding(5.dp))
+		Spacer(modifier = Modifier.padding(5.dp))
 
+		MapisodeText(
+			modifier = Modifier
+				.fillMaxWidth()
+				.padding(start = 4.dp),
+			text = stringResource(S.string.group_description_label),
+			style = MapisodeTheme.typography.labelLarge,
+		)
+
+		Spacer(modifier = Modifier.padding(2.dp))
+
+		Box(
+			modifier = Modifier
+				.clip(RoundedCornerShape(8.dp))
+				.background(MapisodeTheme.colorScheme.textColoredContainer)
+				.padding(10.dp),
+		) {
 			MapisodeText(
 				modifier = Modifier
 					.fillMaxWidth()
+					.wrapContentHeight()
+					.heightIn(min = 50.dp)
 					.padding(start = 4.dp),
-				text = stringResource(S.string.group_description_label),
-				style = MapisodeTheme.typography.labelLarge,
+				text = group.description,
+				style = MapisodeTheme.typography.labelMedium,
 			)
+		}
 
-			Spacer(modifier = Modifier.padding(5.dp))
+		Spacer(modifier = Modifier.padding(10.dp))
 
-			Box(
-				modifier = Modifier
-					.clip(RoundedCornerShape(8.dp))
-					.background(MapisodeTheme.colorScheme.textColoredContainer)
-					.padding(10.dp),
-			) {
-				MapisodeText(
+		MapisodeFilledButton(
+			modifier = Modifier
+				.fillMaxWidth()
+				.heightIn(min = 52.dp, max = 80.dp),
+			onClick = { onIssueCodeClick() },
+			text = stringResource(S.string.btn_issue_code),
+			showRipple = true,
+		)
+
+		Spacer(modifier = Modifier.padding(10.dp))
+
+		MapisodeText(
+			modifier = Modifier
+				.fillMaxWidth()
+				.padding(start = 4.dp),
+			text = stringResource(S.string.label_detail_group_member),
+			style = MapisodeTheme.typography.labelLarge,
+		)
+
+		Spacer(modifier = Modifier.padding(2.dp))
+
+		val scrollState = rememberScrollState()
+		Column(
+			modifier = Modifier
+				.fillMaxWidth()
+				.verticalScroll(scrollState),
+			verticalArrangement = Arrangement.Top,
+			horizontalAlignment = Alignment.CenterHorizontally,
+		) {
+			if (members.isEmpty()) {
+				Box(
+					modifier = Modifier.padding(top = 150.dp),
+					contentAlignment = Alignment.Center,
+				) {
+					MapisodeCircularLoadingIndicator()
+				}
+			} else {
+				repeat(members.size) { index ->
+					GroupMemberContent(members[index])
+					Spacer(modifier = Modifier.padding(5.dp))
+				}
+				MapisodeOutlinedButton(
 					modifier = Modifier
 						.fillMaxWidth()
-						.wrapContentHeight()
-						.heightIn(min = 50.dp)
-						.padding(start = 4.dp),
-					text = group.description,
-					style = MapisodeTheme.typography.labelMedium,
+						.heightIn(min = 40.dp, max = 80.dp),
+					borderColor = MapisodeTheme.colorScheme.textColoredContainer,
+					onClick = { onGroupOutClick() },
+					text = stringResource(S.string.btn_group_out),
+					showRipple = true,
 				)
 			}
-
-			Spacer(modifier = Modifier.padding(10.dp))
-
-			MapisodeFilledButton(
-				modifier = Modifier
-					.fillMaxWidth()
-					.heightIn(min = 52.dp, max = 80.dp),
-				onClick = { onIssueCodeClick() },
-				text = stringResource(S.string.btn_issue_code),
-				showRipple = true,
-			)
-
-			Spacer(modifier = Modifier.padding(10.dp))
-
-			MapisodeText(
-				modifier = Modifier
-					.fillMaxWidth()
-					.padding(start = 4.dp),
-				text = stringResource(S.string.label_detail_group_member),
-				style = MapisodeTheme.typography.labelLarge,
-			)
-		}
-
-		items(members) { member ->
-			GroupMemberContent(member)
-		}
-
-		item {
-			MapisodeOutlinedButton(
-				modifier = Modifier
-					.fillMaxWidth()
-					.heightIn(min = 40.dp, max = 80.dp),
-				borderColor = MapisodeTheme.colorScheme.textColoredContainer,
-				onClick = { onGroupOutClick() },
-				text = stringResource(S.string.btn_group_out),
-				showRipple = true,
-			)
 		}
 	}
 }
@@ -433,7 +450,6 @@ fun GroupEpisodesContent(
 				}
 			}
 		}
-
 		items(sortedEpisodes) { episode ->
 			EpisodeCard(episode)
 		}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupDetailScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupDetailScreen.kt
@@ -331,7 +331,8 @@ fun GroupDetailContent(
 
 			MapisodeFilledButton(
 				modifier = Modifier
-					.fillMaxWidth(),
+					.fillMaxWidth()
+					.heightIn(min = 52.dp, max = 80.dp),
 				onClick = { onIssueCodeClick() },
 				text = stringResource(S.string.btn_issue_code),
 				showRipple = true,
@@ -355,7 +356,9 @@ fun GroupDetailContent(
 		item {
 			MapisodeOutlinedButton(
 				modifier = Modifier
-					.fillMaxWidth(),
+					.fillMaxWidth()
+					.heightIn(min = 40.dp, max = 80.dp),
+				borderColor = MapisodeTheme.colorScheme.textColoredContainer,
 				onClick = { onGroupOutClick() },
 				text = stringResource(S.string.btn_group_out),
 				showRipple = true,

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupDetailScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupDetailScreen.kt
@@ -67,9 +67,9 @@ import com.boostcamp.mapisode.designsystem.compose.tab.MapisodeTab
 import com.boostcamp.mapisode.designsystem.compose.tab.MapisodeTabRow
 import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
 import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
-import com.boostcamp.mapisode.model.EpisodeModel
 import com.boostcamp.mapisode.model.GroupModel
 import com.boostcamp.mapisode.mygroup.intent.GroupDetailIntent
+import com.boostcamp.mapisode.mygroup.model.GroupUiEpisodeModel
 import com.boostcamp.mapisode.mygroup.model.GroupUiMemberModel
 import com.boostcamp.mapisode.mygroup.sideeffect.GroupDetailSideEffect
 import com.boostcamp.mapisode.mygroup.sideeffect.rememberFlowWithLifecycle
@@ -370,7 +370,7 @@ fun GroupDetailContent(
 
 @Composable
 fun GroupEpisodesContent(
-	episodes: List<EpisodeModel>,
+	episodes: List<GroupUiEpisodeModel>,
 ) {
 	var expanded by remember { mutableStateOf(false) }
 	var selectedSortOption by remember { mutableIntStateOf(0) }
@@ -513,7 +513,7 @@ fun GroupMemberContent(
 
 @Composable
 fun EpisodeCard(
-	episode: EpisodeModel,
+	episode: GroupUiEpisodeModel,
 ) {
 	Row(
 		modifier = Modifier
@@ -549,8 +549,8 @@ fun EpisodeCard(
 
 			val textList = listOf(
 				stringResource(S.string.overview_created_by) + episode.createdBy,
-				stringResource(S.string.overview_location) + episode.location.toString(),
-				stringResource(S.string.overview_date) + episode.createdAt.time.toString(),
+				stringResource(S.string.overview_location) + episode.address,
+				stringResource(S.string.overview_date) + episode.createdAt.toFormattedString(),
 				stringResource(S.string.overview_content) + episode.content,
 			)
 

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupEditScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupEditScreen.kt
@@ -251,7 +251,7 @@ fun GroupEditField(
 			Spacer(modifier = Modifier.padding(5.dp))
 			MapisodeFilledButton(
 				modifier = Modifier
-					.sizeIn(maxWidth = 380.dp, maxHeight = 380.dp)
+					.sizeIn(maxWidth = 380.dp, maxHeight = 80.dp)
 					.fillMaxWidth()
 					.heightIn(52.dp),
 				onClick = {

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupJoinScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupJoinScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
@@ -182,7 +181,7 @@ fun GroupJoinContent(
 					MapisodeFilledButton(
 						modifier = Modifier
 							.fillParentMaxWidth()
-							.height(40.dp),
+							.heightIn(min = 52.dp, max = 80.dp),
 						onClick = {
 							onGetGroup(joinCodeText)
 						},
@@ -221,7 +220,7 @@ fun GroupJoinContent(
 					MapisodeDivider(direction = Direction.Horizontal, thickness = Thickness.Thin)
 					Spacer(modifier = Modifier.padding(5.dp))
 					MapisodeFilledButton(
-						modifier = Modifier.fillMaxWidth(),
+						modifier = Modifier.fillMaxWidth().heightIn(min = 52.dp, max = 80.dp),
 						onClick = { onJoinGroup() },
 						text = "참여하기",
 						showRipple = true,

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupDetailState.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupDetailState.kt
@@ -1,8 +1,8 @@
 package com.boostcamp.mapisode.mygroup.state
 
 import androidx.compose.runtime.Immutable
-import com.boostcamp.mapisode.model.EpisodeModel
 import com.boostcamp.mapisode.model.GroupModel
+import com.boostcamp.mapisode.mygroup.model.GroupUiEpisodeModel
 import com.boostcamp.mapisode.mygroup.model.GroupUiMemberModel
 import com.boostcamp.mapisode.ui.base.UiState
 
@@ -13,5 +13,5 @@ data class GroupDetailState(
 	val isGroupOwner: Boolean = false,
 	val group: GroupModel? = null,
 	val membersInfo: List<GroupUiMemberModel> = emptyList(),
-	val episodes: List<EpisodeModel> = emptyList(),
+	val episodes: List<GroupUiEpisodeModel> = emptyList(),
 ) : UiState

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupDetailState.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupDetailState.kt
@@ -2,8 +2,8 @@ package com.boostcamp.mapisode.mygroup.state
 
 import androidx.compose.runtime.Immutable
 import com.boostcamp.mapisode.model.EpisodeModel
-import com.boostcamp.mapisode.model.GroupMemberModel
 import com.boostcamp.mapisode.model.GroupModel
+import com.boostcamp.mapisode.mygroup.model.GroupUiMemberModel
 import com.boostcamp.mapisode.ui.base.UiState
 
 @Immutable
@@ -12,6 +12,6 @@ data class GroupDetailState(
 	val isGroupLoading: Boolean = false,
 	val isGroupOwner: Boolean = false,
 	val group: GroupModel? = null,
-	val membersInfo: List<GroupMemberModel> = emptyList(),
+	val membersInfo: List<GroupUiMemberModel> = emptyList(),
 	val episodes: List<EpisodeModel> = emptyList(),
 ) : UiState

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupDetailViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupDetailViewModel.kt
@@ -16,7 +16,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -186,7 +185,6 @@ class GroupDetailViewModel @Inject constructor(
 					copy(
 						episodes = episodes.map {
 							val name = currentState.membersInfo.firstOrNull { member ->
-								Timber.e("member.id: ${member.id}, it.id: ${it.createdBy}")
 								member.id == it.createdBy
 							}?.name ?: ""
 							it.toGroupUiEpisodeModel(name)

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupDetailViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupDetailViewModel.kt
@@ -8,6 +8,7 @@ import com.boostcamp.mapisode.mygroup.GroupRepository
 import com.boostcamp.mapisode.mygroup.R
 import com.boostcamp.mapisode.mygroup.intent.GroupDetailIntent
 import com.boostcamp.mapisode.mygroup.model.GroupUiMemberModel
+import com.boostcamp.mapisode.mygroup.model.toGroupUiEpisodeModel
 import com.boostcamp.mapisode.mygroup.sideeffect.GroupDetailSideEffect
 import com.boostcamp.mapisode.mygroup.state.GroupDetailState
 import com.boostcamp.mapisode.ui.base.BaseViewModel
@@ -15,6 +16,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -141,6 +143,7 @@ class GroupDetailViewModel @Inject constructor(
 				val numberOfEpisode = userEpisodeModel.size
 				memberInfo.add(
 					GroupUiMemberModel(
+						id = userModel.id,
 						name = userModel.name,
 						email = userModel.email,
 						profileUrl = userModel.profileUrl,
@@ -181,7 +184,13 @@ class GroupDetailViewModel @Inject constructor(
 				val episodes = episodeRepository.getEpisodesByGroup(groupId.value)
 				intent {
 					copy(
-						episodes = episodes,
+						episodes = episodes.map {
+							val name = currentState.membersInfo.firstOrNull { member ->
+								Timber.e("member.id: ${member.id}, it.id: ${it.createdBy}")
+								member.id == it.createdBy
+							}?.name ?: ""
+							it.toGroupUiEpisodeModel(name)
+						},
 					)
 				}
 			} catch (e: Exception) {

--- a/feature/mygroup/src/main/res/values/strings.xml
+++ b/feature/mygroup/src/main/res/values/strings.xml
@@ -5,8 +5,8 @@
 	<string name="group_join_textinput_label">초대 코드</string>
 	<string name="group_join_textfield_hint">초대 코드를 입력해주세요</string>
 	<string name="group_join_btn_direction">확인</string>
-	<string name="group_members_number">"멤버수 : "</string>
-	<string name="group_user_number">"동료 : "</string>
+	<string name="group_members_number">"멤버수 :&#32;"</string>
+	<string name="group_user_number">"동료 :&#32;"</string>
 	<string name="group_overview">그룹 개요</string>
 	<string name="group_descript">그룹 설명</string>
     <string name="group_join_not_exist">그룹이 존재하지 않습니다.</string>
@@ -29,10 +29,10 @@
 	<string name="dialog_group_out_positive">예</string>
 	<string name="dialog_group_out_negative">아니오</string>
 	<string name="label_episode">에피소드</string>
-	<string name="overview_created_by">글쓴이 : </string>
-	<string name="overview_location">위치 : </string>
-	<string name="overview_date">작성일 : </string>
-	<string name="overview_content">내용 : </string>
+	<string name="overview_created_by">글쓴이 :&#32;</string>
+	<string name="overview_location">위치 :&#32;</string>
+	<string name="overview_date">작성일 :&#32;</string>
+	<string name="overview_content">내용 :&#32;</string>
 	<string name="message_error_edit_input">입력 조건을 만족해주세요.</string>
 	<string name="message_error_edit_group">그룹 수정에 실패했습니다.</string>
 	<string name="message_error_creation_group_success">그룹 생성에 성공했습니다.</string>

--- a/feature/mygroup/src/main/res/values/strings.xml
+++ b/feature/mygroup/src/main/res/values/strings.xml
@@ -29,12 +29,17 @@
 	<string name="dialog_group_out_positive">예</string>
 	<string name="dialog_group_out_negative">아니오</string>
 	<string name="label_episode">에피소드</string>
-	<string name="overview_created_by">글쓴이 :&#32;</string>
-	<string name="overview_location">위치 :&#32;</string>
-	<string name="overview_date">작성일 :&#32;</string>
-	<string name="overview_content">내용 :&#32;</string>
+	<string name="overview_created_by">"글쓴이 :&#32;"</string>
+	<string name="overview_location">"위치 :&#32;"</string>
+	<string name="overview_date">"작성일 :&#32;"</string>
+	<string name="overview_content">"내용 :&#32;"</string>
 	<string name="message_error_edit_input">입력 조건을 만족해주세요.</string>
 	<string name="message_error_edit_group">그룹 수정에 실패했습니다.</string>
 	<string name="message_error_creation_group_success">그룹 생성에 성공했습니다.</string>
 	<string name="message_error_creation_group_fail">그룹 생성에 실패했습니다.</string>
+	<string name="content_member_joined_at">"참여 날짜 :&#32;"</string>
+	<string name="message_user_not_found">사용자를 찾을 수 없습니다.</string>
+	<string name="content_episode_count">에피소드 게시수</string>
+	<string name="content_number_count">개</string>
+	<string name="content_recent_episode_upload">"최근 업로드 :&#32;"</string>
 </resources>


### PR DESCRIPTION
- closed #123 

## *📍 Work Description*

- 그룹 화면 내 모든 텍스트 format 설정
- 그룹 멤버 리스트 지연 로드 중간에 인디케이터 설정
- 그룹 설명 화면 column 설정

## *📸 Screenshot*

https://github.com/user-attachments/assets/cf7743a8-e246-439d-b398-4c2d8ef41d90

## *📢 To Reviewers*
- 혹시 모를 화면 전환까지 염두하여 화면 전체를 스크롤 가능하게 했습니다.
- 그룹 멤버원들 리스트와 그룹 탈퇴 버튼을 한 컴포넌트 내에 두고 동시에 나타나도록 했습니다.
<br>
- 그룹에 속한 멤버들의 에피소드 정보를 가져오는데 시간소모가 컸습니다.

## ⏲️Time

    - 8시간
