### PR TITLE
[FIX/#142] Group / 회원 탈퇴 오류 수정

### DIFF
--- a/data/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepositoryImpl.kt
+++ b/data/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepositoryImpl.kt
@@ -138,8 +138,6 @@ class GroupRepositoryImpl @Inject constructor(private val database: FirebaseFire
 				val members = groupSnapshot.get(
 					FirestoreConstants.FIELD_MEMBERS,
 				) as MutableList<DocumentReference>
-				members.remove(database.collection(FirestoreConstants.COLLECTION_USER).document(userId))
-				transaction.update(groupDocRef, FirestoreConstants.FIELD_MEMBERS, members)
 
 				// user의 그룹 필드에서 그룹 제거
 				val userDocRef = database.collection(FirestoreConstants.COLLECTION_USER)
@@ -148,6 +146,10 @@ class GroupRepositoryImpl @Inject constructor(private val database: FirebaseFire
 				val groups = userSnapshot.get(
 					FirestoreConstants.FIELD_GROUPS,
 				) as MutableList<DocumentReference>
+
+				members.remove(database.collection(FirestoreConstants.COLLECTION_USER).document(userId))
+				transaction.update(groupDocRef, FirestoreConstants.FIELD_MEMBERS, members)
+
 				groups.remove(
 					database.collection(FirestoreConstants.COLLECTION_GROUP)
 						.document(groupId),


### PR DESCRIPTION
- closed #142 

## *📍 Work Description*

- firestore 로 그룹 탈퇴 요청 함수에서 트랜잭션 로직 순서 수정

## *📸 Screenshot*

<img src="https://github.com/user-attachments/assets/5028cd8f-8e8c-41b6-85fe-02d771d4b46b" width=800>

https://github.com/user-attachments/assets/ff4b021f-e936-4648-a2b2-617c065f6420

## *📢 To Reviewers*
- group collection의 멤버 정보와 user collection의 참여 그룹 정보를 read 하는 과정을 전부 마친 후에 delete를 시도해야 했다.
- delete 과정에서 read 를 하여 얻은 객체를 인자로 필요하기 때문에 순서가 지켜져야 했다.

## ⏲️Time

    - 1시간
