### PR TITLE
[FEAT/#81][FEAT/#98] 그룹 전환 이벤트 및 캐싱 관련 로직 구현

### DIFF
--- a/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/UserPreferenceDataStore.kt
+++ b/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/UserPreferenceDataStore.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.Flow
 interface UserPreferenceDataStore {
 	fun getUserPreferencesFlow(): Flow<UserPreferences>
 	fun getUserId(): Flow<String?>
+	fun getRecentSelectedGroup(): Flow<String?>
 	suspend fun checkLoggedIn(): Boolean
 
 	suspend fun updateUserId(userId: String)

--- a/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/UserPreferencesDataStoreImpl.kt
+++ b/core/datastore/src/main/kotlin/com/boostcamp/mapisode/datastore/UserPreferencesDataStoreImpl.kt
@@ -39,6 +39,10 @@ class UserPreferencesDataStoreImpl @Inject constructor(
 		preferences[PreferenceKeys.USER_ID]
 	}
 
+	override fun getRecentSelectedGroup(): Flow<String?> = dataStore.data.map { preferences ->
+		preferences[PreferenceKeys.RECENT_SELECTED_GROUP]
+	}
+
 	override suspend fun checkLoggedIn(): Boolean = dataStore.data.map { preferences ->
 		preferences[PreferenceKeys.IS_LOGGED_IN] ?: false
 	}.first()

--- a/data/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepositoryImpl.kt
+++ b/data/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepositoryImpl.kt
@@ -22,7 +22,8 @@ class GroupRepositoryImpl @Inject constructor(private val database: FirebaseFire
 	GroupRepository {
 	private val groupCollection = database.collection(FirestoreConstants.COLLECTION_GROUP)
 	private val userCollection = database.collection(FirestoreConstants.COLLECTION_USER)
-	private val inviteCodesCollection = database.collection(FirestoreConstants.COLLECTION_INVITE_CODES)
+	private val inviteCodesCollection =
+		database.collection(FirestoreConstants.COLLECTION_INVITE_CODES)
 
 	override suspend fun getGroupByGroupId(groupId: String): GroupModel = try {
 		groupCollection.document(groupId)
@@ -38,7 +39,8 @@ class GroupRepositoryImpl @Inject constructor(private val database: FirebaseFire
 		val userSnapshot = userCollection.document(userId).get().await()
 
 		@Suppress("UNCHECKED_CAST")
-		val groupReferences = (userSnapshot[FirestoreConstants.FIELD_GROUPS] as List<DocumentReference>)
+		val groupReferences =
+			(userSnapshot[FirestoreConstants.FIELD_GROUPS] as List<DocumentReference>)
 
 		groupReferences.mapNotNull { documentRef ->
 			groupCollection.document(documentRef.id)
@@ -147,7 +149,9 @@ class GroupRepositoryImpl @Inject constructor(private val database: FirebaseFire
 					FirestoreConstants.FIELD_GROUPS,
 				) as MutableList<DocumentReference>
 
-				members.remove(database.collection(FirestoreConstants.COLLECTION_USER).document(userId))
+				members.remove(
+					database.collection(FirestoreConstants.COLLECTION_USER).document(userId),
+				)
 				transaction.update(groupDocRef, FirestoreConstants.FIELD_MEMBERS, members)
 
 				groups.remove(

--- a/domain/episode/src/main/java/com/boostcamp/mapisode/episode/EpisodeRepository.kt
+++ b/domain/episode/src/main/java/com/boostcamp/mapisode/episode/EpisodeRepository.kt
@@ -20,4 +20,6 @@ interface EpisodeRepository {
 	suspend fun getEpisodeById(episodeId: String): EpisodeModel?
 
 	suspend fun createEpisode(episodeModel: EpisodeModel): String
+
+	suspend fun getMostRecentEpisodeByGroup(groupId: String): EpisodeModel?
 }

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -11,6 +11,7 @@ android {
 dependencies {
 	implementation(projects.domain.episode)
 	implementation(projects.domain.user)
+	implementation(projects.domain.mygroup)
 	implementation(libs.bundles.naverMap)
 	implementation(libs.bundles.coil)
 }

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeIntent.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeIntent.kt
@@ -7,6 +7,8 @@ import com.boostcamp.mapisode.ui.base.UiIntent
 import com.naver.maps.geometry.LatLng
 
 sealed class HomeIntent : UiIntent {
+	data object LoadInitialData : HomeIntent()
+	data object LoadGroups : HomeIntent()
 	data object RequestLocationPermission : HomeIntent()
 	data class SetInitialLocation(val latLng: LatLng) : HomeIntent()
 	data class UpdateLocationPermission(val isGranted: Boolean) : HomeIntent() // 위치 권한 설정 여부 업데이트
@@ -20,6 +22,7 @@ sealed class HomeIntent : UiIntent {
 	data object StartProgrammaticCameraMove : HomeIntent()
 	data object EndProgrammaticCameraMove : HomeIntent()
 	data class NavigateToEpisode(val episodeId: String) : HomeIntent()
+	data class SelectGroup(val groupId: String) : HomeIntent()
 	data class LoadEpisode(
 		val start: EpisodeLatLng,
 		val end: EpisodeLatLng,

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeSideEffect.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeSideEffect.kt
@@ -2,6 +2,7 @@ package com.boostcamp.mapisode.home
 
 import com.boostcamp.mapisode.model.EpisodeLatLng
 import com.boostcamp.mapisode.ui.base.SideEffect
+import com.naver.maps.geometry.LatLng
 
 sealed class HomeSideEffect : SideEffect {
 	data class ShowToast(val messageResId: Int) : HomeSideEffect()
@@ -9,4 +10,5 @@ sealed class HomeSideEffect : SideEffect {
 	data object RequestLocationPermission : HomeSideEffect()
 	data class NavigateToEpisode(val latLng: EpisodeLatLng) : HomeSideEffect()
 	data class NavigateToEpisodeDetail(val episodeId: String) : HomeSideEffect()
+	data class MoveCameraToPosition(val position: LatLng) : HomeSideEffect()
 }

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeState.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeState.kt
@@ -3,6 +3,7 @@ package com.boostcamp.mapisode.home
 import com.boostcamp.mapisode.home.common.ChipType
 import com.boostcamp.mapisode.home.common.HomeConstant.DEFAULT_ZOOM
 import com.boostcamp.mapisode.model.EpisodeModel
+import com.boostcamp.mapisode.model.GroupModel
 import com.boostcamp.mapisode.ui.base.UiState
 import com.naver.maps.geometry.LatLng
 import com.naver.maps.map.CameraPosition
@@ -31,4 +32,6 @@ data class HomeState(
 	val isMapMovedWhileCardVisible: Boolean = false,
 	val showRefreshButton: Boolean = false,
 	val isCameraMovingProgrammatically: Boolean = false,
+	val groups: PersistentList<GroupModel> = persistentListOf(),
+	val selectedGroupId: String? = null,
 ) : UiState

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeViewModel.kt
@@ -115,7 +115,7 @@ class HomeViewModel @Inject constructor(
 		viewModelScope.launch {
 			try {
 				val cachedGroupId = userPreferenceDataStore.getRecentSelectedGroup().firstOrNull()
-					?: userPreferenceDataStore.getUserId().firstOrNull() ?: throw Exception()
+					?: throw Exception()
 
 				intent {
 					copy(selectedGroupId = cachedGroupId)

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/common/HomeConstant.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/common/HomeConstant.kt
@@ -1,31 +1,38 @@
 package com.boostcamp.mapisode.home.common
 
-import com.boostcamp.mapisode.model.GroupItem
+import com.boostcamp.mapisode.model.GroupModel
 import kotlinx.collections.immutable.persistentListOf
+import java.util.Date
 
 object HomeConstant {
 	const val DEFAULT_ZOOM = 16.0
 	val tempGroupList = persistentListOf(
-		GroupItem(
+		GroupModel(
+			id = "1",
 			adminUser = "",
 			name = "그룹1",
 			description = "그룹1 설명",
 			imageUrl = "https://avatars.githubusercontent.com/u/98825364?v=4?s=100",
-			createdAt = "2021-09-01",
+			createdAt = Date(),
+			members = emptyList(),
 		),
-		GroupItem(
+		GroupModel(
+			id = "2",
 			adminUser = "",
 			name = "그룹2",
 			description = "그룹2 설명",
 			imageUrl = "https://avatars.githubusercontent.com/u/98825364?v=4?s=100",
-			createdAt = "2021-09-01",
+			createdAt = Date(),
+			members = emptyList(),
 		),
-		GroupItem(
+		GroupModel(
+			id = "3",
 			adminUser = "",
 			name = "그룹3",
 			description = "그룹3 설명",
 			imageUrl = "https://avatars.githubusercontent.com/u/98825364?v=4?s=100",
-			createdAt = "2021-09-01",
+			createdAt = Date(),
+			members = emptyList(),
 		),
 	)
 	const val EXTRA_RANGE = 0.01 // 약 1 ~ 1.5km

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/component/GroupBottomSheetContent.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/component/GroupBottomSheetContent.kt
@@ -10,12 +10,17 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import coil3.annotation.ExperimentalCoilApi
+import coil3.compose.AsyncImagePreviewHandler
+import coil3.compose.LocalAsyncImagePreviewHandler
+import coil3.test.FakeImage
 import com.boostcamp.mapisode.designsystem.R
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIconButton
@@ -29,7 +34,6 @@ import com.boostcamp.mapisode.home.R as Home
 
 @Composable
 fun GroupBottomSheetContent(
-	myProfileImage: String,
 	groupList: PersistentList<GroupItem>,
 	modifier: Modifier = Modifier,
 	onDismiss: () -> Unit = {},
@@ -64,13 +68,6 @@ fun GroupBottomSheetContent(
 			verticalArrangement = Arrangement.spacedBy(20.dp),
 			horizontalArrangement = Arrangement.Center,
 		) {
-			item {
-				GroupCard(
-					groupImage = myProfileImage,
-					groupName = stringResource(Home.string.group_my_episode_name),
-				)
-			}
-
 			items(groupList) { group ->
 				GroupCard(
 					groupImage = group.imageUrl,
@@ -81,13 +78,19 @@ fun GroupBottomSheetContent(
 	}
 }
 
+@OptIn(ExperimentalCoilApi::class)
 @Preview(showBackground = true)
 @Composable
 fun GroupBottomSheetContentPreview() {
-	MapisodeTheme {
-		GroupBottomSheetContent(
-			myProfileImage = "",
-			groupList = tempGroupList,
-		)
+	val previewHandler = AsyncImagePreviewHandler {
+		FakeImage(color = 0xFFE0E0E0.toInt())
+	}
+
+	CompositionLocalProvider(LocalAsyncImagePreviewHandler provides previewHandler) {
+		MapisodeTheme {
+			GroupBottomSheetContent(
+				groupList = tempGroupList,
+			)
+		}
 	}
 }

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/component/GroupBottomSheetContent.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/component/GroupBottomSheetContent.kt
@@ -74,7 +74,7 @@ fun GroupBottomSheetContent(
 					groupId = group.id,
 					groupImage = group.imageUrl,
 					groupName = group.name,
-					onClick = onGroupClick
+					onClick = onGroupClick,
 				)
 			}
 		}

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/component/GroupBottomSheetContent.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/component/GroupBottomSheetContent.kt
@@ -28,15 +28,16 @@ import com.boostcamp.mapisode.designsystem.compose.MapisodeText
 import com.boostcamp.mapisode.designsystem.theme.AppTypography
 import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 import com.boostcamp.mapisode.home.common.HomeConstant.tempGroupList
-import com.boostcamp.mapisode.model.GroupItem
+import com.boostcamp.mapisode.model.GroupModel
 import kotlinx.collections.immutable.PersistentList
 import com.boostcamp.mapisode.home.R as Home
 
 @Composable
 fun GroupBottomSheetContent(
-	groupList: PersistentList<GroupItem>,
+	groupList: PersistentList<GroupModel>,
 	modifier: Modifier = Modifier,
 	onDismiss: () -> Unit = {},
+	onGroupClick: (String) -> Unit = {},
 ) {
 	Column(
 		modifier = modifier.fillMaxWidth(),
@@ -70,8 +71,10 @@ fun GroupBottomSheetContent(
 		) {
 			items(groupList) { group ->
 				GroupCard(
+					groupId = group.id,
 					groupImage = group.imageUrl,
 					groupName = group.name,
+					onClick = onGroupClick
 				)
 			}
 		}

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/component/GroupCard.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/component/GroupCard.kt
@@ -25,12 +25,13 @@ fun GroupCard(
 	groupImage: String,
 	groupName: String,
 	modifier: Modifier = Modifier,
-	onClick: () -> Unit = {},
+	groupId: String = "",
+	onClick: (String) -> Unit = {},
 ) {
 	Column(
 		modifier = modifier
 			.fillMaxWidth()
-			.clickable(onClick = onClick),
+			.clickable(onClick = { onClick(groupId) }),
 		horizontalAlignment = Alignment.CenterHorizontally,
 	) {
 		Box(

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/component/GroupCard.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/component/GroupCard.kt
@@ -48,7 +48,7 @@ fun GroupCard(
 			)
 		}
 
-		Spacer(modifier = Modifier.size(4.dp))
+		Spacer(modifier = Modifier.size(6.dp))
 
 		MapisodeText(
 			text = groupName,

--- a/feature/home/src/main/res/values/strings.xml
+++ b/feature/home/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
 	<string name="group_my_episode_name">👑 나의 에피소드</string>
 	<string name="group_bottomsheet_title">그룹 선택</string>
 	<string name="error_load_episodes">에피소드를 불러오는데 실패했습니다.</string>
+	<string name="error_group_load_episodes">에피소드를 불러오는데 실패했습니다.</string>
 	<string name="refresh">새로고침</string>
 
 	<!-- EpisodeCard -->


### PR DESCRIPTION
- closed #81 
- closed #98

## *📍 Work Description*

- 회원가입 시 userId를 recentGroupId에 저장한 것이 구현되어있다고 가정
- 회원가입 시 userId로 group을 생성한다고 가정
- 바텀 시트에서 내 애피소드를 구분 짓지 않음 (내 에피소드 = 그룹 으로 간주하기 때문)
- 유저가 화면에 처음 진입했을 때, 캐싱된 그룹에서 가장 최근에 생성된 애피소드로 카메라 이동
- 만약 앱을 처음 사용하는 유저라면 현재 위치에 있음
- 유저가 그룹을 전환했을 때도, 그 그룹에서 가장 최근에 생성된 애피소드 위치로 이동. 만약 없으면 카메라 이동 X 


## *📸 Screenshot*

<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->

https://github.com/user-attachments/assets/142d52ac-e3ff-4829-8a62-e26c15710fb7


## *📢 To Reviewers*
- 빠른 리뷰 부탁드립니다. 

## ⏲️Time

    - 3 h
