### PR TITLE
[REFACTOR/#132] 에피소드 생성 화면 / type-safe 네비게이션으로 전환 및 일부 기능 개선

### DIFF
--- a/core/navigation/src/main/java/com/boostcamp/mapisode/navigation/NewEpisodeRoute.kt
+++ b/core/navigation/src/main/java/com/boostcamp/mapisode/navigation/NewEpisodeRoute.kt
@@ -1,0 +1,17 @@
+package com.boostcamp.mapisode.navigation
+
+import kotlinx.serialization.Serializable
+
+sealed interface NewEpisodeRoute : Route {
+	@Serializable
+	data object PickPhoto : NewEpisodeRoute
+
+	@Serializable
+	data object WriteInfo : NewEpisodeRoute
+
+	@Serializable
+	data object PickLocation : NewEpisodeRoute
+
+	@Serializable
+	data object WriteContent : NewEpisodeRoute
+}

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/EpisodeScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/EpisodeScreen.kt
@@ -4,5 +4,4 @@ import androidx.compose.runtime.Composable
 
 @Composable
 internal fun EpisodeRoute() {
-
 }

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/EpisodeScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/EpisodeScreen.kt
@@ -1,88 +1,8 @@
 package com.boostcamp.mapisode.episode
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
-import androidx.navigation.compose.rememberNavController
-import com.boostcamp.mapisode.episode.intent.NewEpisodeIntent
-import com.boostcamp.mapisode.episode.intent.NewEpisodeViewModel
-import com.naver.maps.map.compose.CameraPositionState
-import com.naver.maps.map.compose.rememberCameraPositionState
 
 @Composable
-internal fun EpisodeRoute(
-	viewModel: NewEpisodeViewModel = hiltViewModel(),
-) {
-	val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-	val newEpisodeNavController = rememberNavController()
-	val cameraPositionState: CameraPositionState = rememberCameraPositionState {
-		position = uiState.cameraPosition
-	}
+internal fun EpisodeRoute() {
 
-	NavHost(newEpisodeNavController, startDestination = "new_episode_pics") {
-		composable("new_episode_pics") {
-			NewEpisodePicsScreen(
-				navController = newEpisodeNavController,
-				updatePics = { uris ->
-					viewModel.onIntent(NewEpisodeIntent.SetEpisodePics(uris))
-				},
-			)
-		}
-
-		composable("new_episode_info") {
-			NewEpisodeInfoScreen(
-				navController = newEpisodeNavController,
-				state = uiState,
-				loadMyGroups = {
-					viewModel.onIntent(NewEpisodeIntent.LoadMyGroups)
-				},
-				updateEpisodeInfo = { episodeInfo ->
-					viewModel.onIntent(NewEpisodeIntent.SetEpisodeInfo(episodeInfo))
-				},
-				updateGroup = { group ->
-					viewModel.onIntent(NewEpisodeIntent.SetEpisodeGroup(group))
-				},
-				updateCategory = { category ->
-					viewModel.onIntent(NewEpisodeIntent.SetEpisodeCategory(category))
-				},
-				updateTags = { tags ->
-					viewModel.onIntent(NewEpisodeIntent.SetEpisodeTags(tags))
-				},
-				updateDate = { date ->
-					viewModel.onIntent(NewEpisodeIntent.SetEpisodeDate(date))
-				},
-			)
-		}
-
-		composable("pick_location") {
-			PickLocationScreen(
-				state = uiState,
-				cameraPositionState = cameraPositionState,
-				navController = newEpisodeNavController,
-				updateLocation = { latLng ->
-					viewModel.onIntent(NewEpisodeIntent.SetEpisodeLocation(latLng))
-				},
-				updateAddress = { latLng ->
-					viewModel.onIntent(NewEpisodeIntent.SetEpisodeAddress(latLng))
-				},
-				updateIsCameraMoving = { isCameraMoving ->
-					viewModel.onIntent(NewEpisodeIntent.SetIsCameraMoving(isCameraMoving))
-				},
-			)
-		}
-
-		composable("new_episode_content") {
-			NewEpisodeContentScreen(
-				state = uiState,
-				navController = newEpisodeNavController,
-				submitEpisode = { episodeContent ->
-					viewModel.onIntent(NewEpisodeIntent.SetEpisodeContent(episodeContent))
-					viewModel.onIntent(NewEpisodeIntent.CreateNewEpisode)
-				},
-			)
-		}
-	}
 }

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeContentScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeContentScreen.kt
@@ -65,6 +65,10 @@ internal fun NewEpisodeContentScreen(
 						Toast.LENGTH_SHORT,
 					).show()
 				}
+
+				is NewEpisodeSideEffect.NavigateBackToHome -> {
+					onPopBackToMain()
+				}
 			}
 		}
 	}
@@ -140,7 +144,6 @@ internal fun NewEpisodeContentScreen(
 						viewModel.onIntent(NewEpisodeIntent.CreateNewEpisode)
 						titleValue = TextFieldValue("")
 						descriptionValue = TextFieldValue("")
-						onPopBackToMain()
 					} catch (e: Exception) {
 						Timber.e(e)
 					}

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeContentScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeContentScreen.kt
@@ -2,6 +2,7 @@ package com.boostcamp.mapisode.episode
 
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -14,8 +15,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -26,6 +29,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
+import com.boostcamp.mapisode.designsystem.compose.MapisodeCircularLoadingIndicator
 import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
 import com.boostcamp.mapisode.designsystem.compose.MapisodeText
 import com.boostcamp.mapisode.designsystem.compose.Surface
@@ -54,6 +58,7 @@ internal fun NewEpisodeContentScreen(
 	var descriptionValue by rememberSaveable(stateSaver = TextFieldValue.Saver) {
 		mutableStateOf(TextFieldValue(uiState.episodeContent.description))
 	}
+	var isLoading by remember { mutableStateOf(false) }
 
 	LaunchedEffect(Unit) {
 		viewModel.sideEffect.collect { sideEffect ->
@@ -67,6 +72,7 @@ internal fun NewEpisodeContentScreen(
 				}
 
 				is NewEpisodeSideEffect.NavigateBackToHome -> {
+					isLoading = false
 					onPopBackToMain()
 				}
 			}
@@ -87,6 +93,14 @@ internal fun NewEpisodeContentScreen(
 		},
 		isStatusBarPaddingExist = true,
 	) { innerPadding ->
+		if (isLoading) {
+			Box(
+				modifier = Modifier.fillMaxSize(),
+				contentAlignment = Alignment.Center,
+			) {
+				MapisodeCircularLoadingIndicator()
+			}
+		}
 		Column(
 			modifier = Modifier
 				.padding(innerPadding)
@@ -141,6 +155,7 @@ internal fun NewEpisodeContentScreen(
 						),
 					)
 					try {
+						isLoading = true
 						viewModel.onIntent(NewEpisodeIntent.CreateNewEpisode)
 						titleValue = TextFieldValue("")
 						descriptionValue = TextFieldValue("")

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodePicsScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodePicsScreen.kt
@@ -1,6 +1,7 @@
 package com.boostcamp.mapisode.episode
 
 import android.net.Uri
+import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
@@ -10,33 +11,52 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIconButton
 import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
 import com.boostcamp.mapisode.designsystem.compose.button.MapisodeFilledButton
 import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
+import com.boostcamp.mapisode.episode.intent.NewEpisodeIntent
+import com.boostcamp.mapisode.episode.intent.NewEpisodeSideEffect
+import com.boostcamp.mapisode.episode.intent.NewEpisodeViewModel
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 
 @Composable
 internal fun NewEpisodePicsScreen(
-	navController: NavController,
-	updatePics: (PersistentList<Uri>) -> Unit,
+	viewModel: NewEpisodeViewModel = hiltViewModel(),
+	onNavigateToInfo: () -> Unit,
 ) {
+	val context = LocalContext.current
+
+	LaunchedEffect(Unit) {
+		viewModel.sideEffect.collect { sideEffect ->
+			when (sideEffect) {
+				is NewEpisodeSideEffect.ShowToast -> {
+					Toast.makeText(
+						context,
+						sideEffect.messageResId,
+						Toast.LENGTH_LONG,
+					).show()
+				}
+			}
+		}
+	}
+
 	MapisodeScaffold(
 		topBar = {
 			TopAppBar(
 				title = stringResource(R.string.new_episode_menu_title),
 				actions = {
 					MapisodeIconButton(
-						onClick = {
-							navController.navigate("new_episode_info")
-						},
+						onClick = {},
 						enabled = false,
 					) {
 						MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_arrow_forward_ios)
@@ -53,9 +73,9 @@ internal fun NewEpisodePicsScreen(
 			contentAlignment = Alignment.Center,
 		) {
 			PickEpisodePhotoButton { uris ->
-				updatePics(uris)
+				viewModel.onIntent(NewEpisodeIntent.SetEpisodePics(uris))
 				if (uris.isNotEmpty()) {
-					navController.navigate("new_episode_info")
+					onNavigateToInfo()
 				}
 			}
 		}

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodePicsScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodePicsScreen.kt
@@ -46,6 +46,8 @@ internal fun NewEpisodePicsScreen(
 						Toast.LENGTH_LONG,
 					).show()
 				}
+
+				else -> {}
 			}
 		}
 	}

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeTopBar.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeTopBar.kt
@@ -2,19 +2,21 @@ package com.boostcamp.mapisode.episode
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
-import androidx.navigation.NavController
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIconButton
 import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
 
 @Composable
-internal fun NewEpisodeTopbar(navController: NavController) {
+internal fun NewEpisodeTopBar(
+	onClickBack: () -> Unit,
+	onClickClear: () -> Unit,
+) {
 	TopAppBar(
 		title = stringResource(R.string.new_episode_menu_create_episode),
 		navigationIcon = {
 			MapisodeIconButton(
 				onClick = {
-					navController.navigateUp()
+					onClickBack()
 				},
 			) {
 				MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_arrow_back_ios)
@@ -23,7 +25,7 @@ internal fun NewEpisodeTopbar(navController: NavController) {
 		actions = {
 			MapisodeIconButton(
 				onClick = {
-					navController.popBackStack("new_episode_pics", false)
+					onClickClear()
 				},
 			) {
 				MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_clear)

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/intent/NewEpisodeIntent.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/intent/NewEpisodeIntent.kt
@@ -19,4 +19,5 @@ sealed class NewEpisodeIntent : UiIntent {
 	data class SetEpisodeInfo(val episodeInfo: NewEpisodeInfo) : NewEpisodeIntent()
 	data class SetEpisodeContent(val episodeContent: NewEpisodeContent) : NewEpisodeIntent()
 	data object CreateNewEpisode : NewEpisodeIntent()
+	data object ClearEpisode : NewEpisodeIntent()
 }

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/intent/NewEpisodeSideEffect.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/intent/NewEpisodeSideEffect.kt
@@ -4,4 +4,5 @@ import com.boostcamp.mapisode.ui.base.SideEffect
 
 sealed class NewEpisodeSideEffect : SideEffect {
 	data class ShowToast(val messageResId: Int) : NewEpisodeSideEffect()
+	data object NavigateBackToHome : NewEpisodeSideEffect()
 }

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/intent/NewEpisodeSideEffect.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/intent/NewEpisodeSideEffect.kt
@@ -2,4 +2,6 @@ package com.boostcamp.mapisode.episode.intent
 
 import com.boostcamp.mapisode.ui.base.SideEffect
 
-sealed class NewEpisodeSideEffect : SideEffect
+sealed class NewEpisodeSideEffect : SideEffect {
+	data class ShowToast(val messageResId: Int) : NewEpisodeSideEffect()
+}

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/intent/NewEpisodeViewModel.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/intent/NewEpisodeViewModel.kt
@@ -10,7 +10,6 @@ import com.boostcamp.mapisode.network.repository.NaverMapsRepository
 import com.boostcamp.mapisode.ui.base.BaseViewModel
 import com.naver.maps.map.CameraPosition
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -135,18 +134,18 @@ class NewEpisodeViewModel @Inject constructor(
 			}
 
 			is NewEpisodeIntent.CreateNewEpisode -> {
-				try {
-					viewModelScope.launch {
+				viewModelScope.launch {
+					try {
 						val userId =
 							requireNotNull(userPreferenceDataStore.getUserId().firstOrNull())
 						val episodeModel = uiState.value.toDomainModel(userId)
 						episodeRepository.createEpisode(episodeModel)
 						clearEpisodeState()
 						postSideEffect(NewEpisodeSideEffect.ShowToast(R.string.new_episode_create_episode_success))
-						delay(100)
+						postSideEffect(NewEpisodeSideEffect.NavigateBackToHome)
+					} catch (e: Exception) {
+						postSideEffect(NewEpisodeSideEffect.ShowToast(R.string.new_episode_create_episode_fail))
 					}
-				} catch (e: Exception) {
-					postSideEffect(NewEpisodeSideEffect.ShowToast(R.string.new_episode_create_episode_fail))
 				}
 			}
 

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/navigation/EpisodeNavigation.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/navigation/EpisodeNavigation.kt
@@ -1,11 +1,17 @@
 package com.boostcamp.mapisode.episode.navigation
 
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
-import com.boostcamp.mapisode.episode.EpisodeRoute
+import com.boostcamp.mapisode.episode.NewEpisodeContentScreen
+import com.boostcamp.mapisode.episode.NewEpisodeInfoScreen
+import com.boostcamp.mapisode.episode.NewEpisodePicsScreen
+import com.boostcamp.mapisode.episode.PickLocationScreen
 import com.boostcamp.mapisode.navigation.MainRoute
+import com.boostcamp.mapisode.navigation.NewEpisodeRoute
 
 fun NavController.navigateEpisode(
 	navOptions: NavOptions? = null,
@@ -13,8 +19,69 @@ fun NavController.navigateEpisode(
 	navigate(MainRoute.Episode, navOptions)
 }
 
-fun NavGraphBuilder.addEpisodeNavGraph() {
+fun NavController.navigatePickPhoto(
+	navOptions: NavOptions? = null,
+) {
+	navigate(NewEpisodeRoute.PickPhoto, navOptions)
+}
+
+fun NavController.navigateWriteInfo(
+	navOptions: NavOptions? = null,
+) {
+	navigate(NewEpisodeRoute.WriteInfo, navOptions)
+}
+
+fun NavController.navigatePickLocation(
+	navOptions: NavOptions? = null,
+) {
+	navigate(NewEpisodeRoute.PickLocation, navOptions)
+}
+
+fun NavController.navigateWriteContent(
+	navOptions: NavOptions? = null,
+) {
+	navigate(NewEpisodeRoute.WriteContent, navOptions)
+}
+
+fun NavGraphBuilder.addEpisodeNavGraph(
+	getBackStackEntry: () -> NavBackStackEntry,
+	onPopBackToMain: () -> Unit,
+	onPopBack: () -> Unit,
+	onNavigateToInfo: () -> Unit,
+	onClickPickLocation: () -> Unit,
+	onNavigateToContent: () -> Unit,
+) {
 	composable<MainRoute.Episode> {
-		EpisodeRoute()
+		NewEpisodePicsScreen(
+			viewModel = hiltViewModel(getBackStackEntry()),
+			onNavigateToInfo = onNavigateToInfo,
+		)
+	}
+
+	composable<NewEpisodeRoute.WriteInfo> {
+		NewEpisodeInfoScreen(
+			viewModel = hiltViewModel(getBackStackEntry()),
+			onPopBack = onPopBack,
+			onPopBackToMain = onPopBackToMain,
+			onClickPickLocation = onClickPickLocation,
+			onNavigateToContent = onNavigateToContent,
+		)
+	}
+
+	composable<NewEpisodeRoute.PickLocation> {
+		PickLocationScreen(
+			viewModel = hiltViewModel(getBackStackEntry()),
+			onPopBackToInfo = onPopBack,
+		)
+	}
+
+	composable<NewEpisodeRoute.WriteContent> {
+		NewEpisodeContentScreen(
+			viewModel = hiltViewModel(getBackStackEntry()),
+			onPopBack = onPopBack,
+			onPopBackToMain = onPopBackToMain,
+		)
 	}
 }
+
+

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/navigation/EpisodeNavigation.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/navigation/EpisodeNavigation.kt
@@ -83,5 +83,3 @@ fun NavGraphBuilder.addEpisodeNavGraph(
 		)
 	}
 }
-
-

--- a/feature/episode/src/main/res/values/strings.xml
+++ b/feature/episode/src/main/res/values/strings.xml
@@ -3,6 +3,10 @@
 	<string name="new_episode_menu_title">새 에피소드</string>
 	<string name="new_episode_menu_create_episode">에피소드 생성</string>
 	<string name="new_episode_menu_add_pictures">사진 추가</string>
+	<string name="new_episode_menu_ok">확인</string>
+	<string name="new_episode_menu_cancel">취소</string>
+
+	<string name="new_episode_pictures_empty">사진을 선택해 주세요.</string>
 
 	<string name="new_episode_info_location">장소</string>
 	<string name="new_episode_info_group">그룹</string>
@@ -28,4 +32,6 @@
 	<string name="new_episode_content_placeholder_description">내용을 입력해주세요</string>
 
 	<string name="new_episode_create_episode">생성하기</string>
+	<string name="new_episode_create_episode_success">에피소드 생성이 완료되었습니다.</string>
+	<string name="new_episode_create_episode_fail">에피소드 생성에 실패하였습니다.</string>
 </resources>

--- a/feature/main/src/main/java/com/boostcamp/mapisode/main/MainNavigator.kt
+++ b/feature/main/src/main/java/com/boostcamp/mapisode/main/MainNavigator.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.navigation.NavBackStackEntry
 import androidx.compose.runtime.setValue
 import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hasRoute
@@ -12,6 +13,9 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navOptions
+import com.boostcamp.mapisode.episode.navigation.navigatePickLocation
+import com.boostcamp.mapisode.episode.navigation.navigateWriteContent
+import com.boostcamp.mapisode.episode.navigation.navigateWriteInfo
 import com.boostcamp.mapisode.home.navigation.navigateEpisodeDetail
 import com.boostcamp.mapisode.mygroup.navigation.navigateGroupCreation
 import com.boostcamp.mapisode.mygroup.navigation.navigateGroupDetail
@@ -63,6 +67,25 @@ internal class MainNavigator(
 
 	fun navigateToEpisodeDetail(episodeId: String) {
 		navController.navigateEpisodeDetail(episodeId)
+	}
+
+	fun getEpisodeBackStackEntry(): NavBackStackEntry =
+		navController.getBackStackEntry(startDestination)
+
+	fun popBackEpisodeToMain() {
+		navController.popBackStack(MainRoute.Episode, inclusive = true)
+	}
+
+	fun navigateWriteInfo() {
+		navController.navigateWriteInfo()
+	}
+
+	fun navigatePickLocation() {
+		navController.navigatePickLocation()
+	}
+
+	fun navigateWriteContent() {
+		navController.navigateWriteContent()
 	}
 
 	fun navigateGroupJoin() {

--- a/feature/main/src/main/java/com/boostcamp/mapisode/main/MainNavigator.kt
+++ b/feature/main/src/main/java/com/boostcamp/mapisode/main/MainNavigator.kt
@@ -4,8 +4,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.navigation.NavBackStackEntry
 import androidx.compose.runtime.setValue
+import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavGraph.Companion.findStartDestination

--- a/feature/main/src/main/java/com/boostcamp/mapisode/main/component/MainNavHost.kt
+++ b/feature/main/src/main/java/com/boostcamp/mapisode/main/component/MainNavHost.kt
@@ -34,7 +34,14 @@ internal fun MainNavHost(
 				navigateToMain = navigator::navigateToMain,
 				endSplash = navigator::endSplash,
 			)
-			addEpisodeNavGraph()
+			addEpisodeNavGraph(
+				getBackStackEntry = navigator::getEpisodeBackStackEntry,
+				onPopBackToMain = navigator::popBackEpisodeToMain,
+				onPopBack = navigator::popBackStackIfNotHome,
+				onNavigateToInfo = navigator::navigateWriteInfo,
+				onNavigateToContent = navigator::navigateWriteContent,
+				onClickPickLocation = navigator::navigatePickLocation,
+			)
 			addGroupNavGraph(
 				onBackClick = navigator::popBackStackIfNotHome,
 				onGroupJoinClick = navigator::navigateGroupJoin,


### PR DESCRIPTION
- closed #132

## *📍 Work Description*
- type-safe 네비게이션으로 전환
- 상황에 따른 토스트 메시지 출력 추가
- 에피소드 작성 성공 시 홈 화면으로 돌아가기

## *📸 Screenshot*
### 사진을 선택하지 않았을 시
[132-1.webm](https://github.com/user-attachments/assets/1d991eec-7f39-44ce-85fa-99337a061af2)
### 에피소드 작성 후 홈 화면으로 이동
[132-2.webm](https://github.com/user-attachments/assets/b907f4bd-ff0e-4c12-9448-c00194759700)

## *📢 To Reviewers*
- 개선해야 될 점 말씀해주시고 궁금한 것도 질문해주세요!

## ⏲️Time
    - 6 시간
