### PR TITLE
[FEAT/#145] Auth / datastore, firestore 연동

### DIFF
--- a/feature/login/build.gradle.kts
+++ b/feature/login/build.gradle.kts
@@ -9,4 +9,5 @@ android {
 dependencies {
 	implementation(projects.core.auth)
 	implementation(projects.domain.user)
+	implementation(projects.domain.mygroup)
 }

--- a/feature/login/src/main/java/com/boostcamp/mapisode/login/AuthViewModel.kt
+++ b/feature/login/src/main/java/com/boostcamp/mapisode/login/AuthViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.viewModelScope
 import com.boostcamp.mapisode.auth.GoogleOauth
 import com.boostcamp.mapisode.auth.LoginState
 import com.boostcamp.mapisode.datastore.UserPreferenceDataStore
+import com.boostcamp.mapisode.model.GroupModel
 import com.boostcamp.mapisode.model.UserModel
 import com.boostcamp.mapisode.mygroup.GroupRepository
 import com.boostcamp.mapisode.ui.base.BaseViewModel
@@ -121,8 +122,8 @@ class AuthViewModel @Inject constructor(
 				)
 
 				userRepository.createUser(user)
-//				createMyEpisodeGroup(user.uid)
-//				joinMyGroup(user.uid)
+				createMyEpisodeGroup(user.uid)
+				joinMyGroup(user.uid)
 
 				storeUserData(
 					userModel = user,
@@ -159,30 +160,30 @@ class AuthViewModel @Inject constructor(
 			userDataStore.updateRecentSelectedGroup(recentGroup)
 		}
 	}
-//
-//	private fun createMyEpisodeGroup(
-//		uid: String,
-//	) {
-//		viewModelScope.launch {
-//			groupRepository.createGroup(
-//				GroupModel(
-//					id = "my-episode",
-//					adminUser = uid,
-//					createdAt = Date.from(java.time.Instant.now()),
-//					description = "내가 작성한 에피소드",
-//					imageUrl = "",
-//					name = "\uD83D\uDC51 나의 에피소드",
-//					members = listOf(uid),
-//				),
-//			)
-//		}
-//	}
-//
-//	private fun joinMyGroup(uid: String) {
-//		viewModelScope.launch {
-//			groupRepository.joinGroup(uid, uid)
-//		}
-//	}
+
+	private fun createMyEpisodeGroup(
+		uid: String,
+	) {
+		viewModelScope.launch {
+			groupRepository.createGroup(
+				GroupModel(
+					id = uid,
+					adminUser = uid,
+					createdAt = Date.from(java.time.Instant.now()),
+					description = "내가 작성한 에피소드",
+					imageUrl = "",
+					name = "\uD83D\uDC51 나의 에피소드",
+					members = listOf(uid),
+				),
+			)
+		}
+	}
+
+	private fun joinMyGroup(uid: String) {
+		viewModelScope.launch {
+			groupRepository.joinGroup(uid, uid)
+		}
+	}
 
 	private fun handleLoginSuccess() {
 		viewModelScope.launch {

--- a/feature/login/src/main/java/com/boostcamp/mapisode/login/AuthViewModel.kt
+++ b/feature/login/src/main/java/com/boostcamp/mapisode/login/AuthViewModel.kt
@@ -51,7 +51,7 @@ class AuthViewModel @Inject constructor(
 		false
 	}
 
-	private suspend fun getRecentSelectedGroup(uid: String): String? = try {
+	private suspend fun getRecentSelectedGroup(): String? = try {
 		userDataStore.getRecentSelectedGroup().firstOrNull()
 	} catch (e: Exception) {
 		null
@@ -65,7 +65,7 @@ class AuthViewModel @Inject constructor(
 						is LoginState.Success -> {
 							if (isUserExist(loginState.authDataInfo.uid)) {
 								val user = getUserInfo(loginState.authDataInfo.uid)
-								val recentGroup = getRecentSelectedGroup(user.uid) ?: user.uid
+								val recentGroup = getRecentSelectedGroup() ?: user.uid
 
 								storeUserData(
 									userModel = user,
@@ -161,7 +161,7 @@ class AuthViewModel @Inject constructor(
 		}
 	}
 
-	private fun createMyEpisodeGroup(
+	private suspend fun createMyEpisodeGroup(
 		uid: String,
 	) {
 		viewModelScope.launch {
@@ -176,7 +176,7 @@ class AuthViewModel @Inject constructor(
 					members = listOf(uid),
 				),
 			)
-		}
+		}.join()
 	}
 
 	private fun joinMyGroup(uid: String) {

--- a/feature/login/src/main/java/com/boostcamp/mapisode/login/AuthViewModel.kt
+++ b/feature/login/src/main/java/com/boostcamp/mapisode/login/AuthViewModel.kt
@@ -123,7 +123,6 @@ class AuthViewModel @Inject constructor(
 
 				userRepository.createUser(user)
 				createMyEpisodeGroup(user)
-				joinMyGroup(user.uid)
 
 				storeUserData(
 					userModel = user,

--- a/feature/login/src/main/java/com/boostcamp/mapisode/login/AuthViewModel.kt
+++ b/feature/login/src/main/java/com/boostcamp/mapisode/login/AuthViewModel.kt
@@ -122,7 +122,7 @@ class AuthViewModel @Inject constructor(
 				)
 
 				userRepository.createUser(user)
-				createMyEpisodeGroup(user.uid)
+				createMyEpisodeGroup(user)
 				joinMyGroup(user.uid)
 
 				storeUserData(
@@ -161,19 +161,17 @@ class AuthViewModel @Inject constructor(
 		}
 	}
 
-	private suspend fun createMyEpisodeGroup(
-		uid: String,
-	) {
+	private suspend fun createMyEpisodeGroup(user: UserModel) {
 		viewModelScope.launch {
 			groupRepository.createGroup(
 				GroupModel(
-					id = uid,
-					adminUser = uid,
+					id = user.uid,
+					adminUser = user.uid,
 					createdAt = Date.from(java.time.Instant.now()),
 					description = "내가 작성한 에피소드",
-					imageUrl = "",
+					imageUrl = user.profileUrl,
 					name = "\uD83D\uDC51 나의 에피소드",
-					members = listOf(uid),
+					members = listOf(user.uid),
 				),
 			)
 		}.join()


### PR DESCRIPTION
- closed #145 

## *📍 Work Description*

- 회원가입시, uid로 그룹 만들기
- datastore에 RecentSelectedGroup 저장
- user에 그룹 추가( 나의 에피소드를 0번 인덱스로! )

## *📸 Screenshot*

### firebase Authentication 

<img src="https://github.com/user-attachments/assets/e244cf4b-60c8-40b3-ad7b-74ebc98dcc84" width=700 />

### Uid 기반으로 Group 생성

<img src="https://github.com/user-attachments/assets/2d601a28-f086-43fb-895c-34ae5ddaadcd" width=500 />

### firebase Authentication 기반으로 유저 생성

<img src="https://github.com/user-attachments/assets/a147f7d4-c6db-48f4-8e2d-cd5d64906baf" width=500 />

## *📢 To Reviewers*
- 오후 회의 내용에 대한 pr입니다.

## ⏲️Time

    - 1.5 h
