### PR TITLE
[FEAT/#128] 에피소드 목록 보기 구현

### DIFF
--- a/core/designsystem/src/main/res/drawable/ic_list_bulleted.xml
+++ b/core/designsystem/src/main/res/drawable/ic_list_bulleted.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:autoMirrored="true" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M4,10.5c-0.83,0 -1.5,0.67 -1.5,1.5s0.67,1.5 1.5,1.5 1.5,-0.67 1.5,-1.5 -0.67,-1.5 -1.5,-1.5zM4,4.5c-0.83,0 -1.5,0.67 -1.5,1.5S3.17,7.5 4,7.5 5.5,6.83 5.5,6 4.83,4.5 4,4.5zM4,16.5c-0.83,0 -1.5,0.68 -1.5,1.5s0.68,1.5 1.5,1.5 1.5,-0.68 1.5,-1.5 -0.67,-1.5 -1.5,-1.5zM7,19h14v-2L7,17v2zM7,13h14v-2L7,11v2zM7,5v2h14L21,5L7,5z"/>
+    
+</vector>

--- a/core/model/src/main/kotlin/com/boostcamp/mapisode/model/EpisodeModel.kt
+++ b/core/model/src/main/kotlin/com/boostcamp/mapisode/model/EpisodeModel.kt
@@ -7,6 +7,7 @@ data class EpisodeModel(
 	val category: String = "",
 	val content: String = "",
 	val createdBy: String = "",
+	val createdByName: String = "",
 	val group: String = "",
 	val imageUrls: List<String> = emptyList(),
 	val address: String = "",

--- a/core/navigation/src/main/java/com/boostcamp/mapisode/navigation/HomeRoute.kt
+++ b/core/navigation/src/main/java/com/boostcamp/mapisode/navigation/HomeRoute.kt
@@ -6,4 +6,7 @@ import kotlinx.serialization.Serializable
 sealed interface HomeRoute : Route {
 	@Serializable
 	data class Detail(val episodeId: String) : HomeRoute
+
+	@Serializable
+	data class List(val groupId: String) : HomeRoute
 }

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
@@ -393,12 +393,22 @@ private fun HomeScreen(
 					)
 				}
 
-				MapisodeFabOverlayButton(
-					onClick = onGroupFabClick,
+				Column(
 					modifier = Modifier
 						.align(Alignment.CenterEnd)
 						.padding(end = 20.dp),
-				)
+					verticalArrangement = Arrangement.spacedBy(16.dp),
+					horizontalAlignment = Alignment.End,
+				) {
+					MapisodeFabOverlayButton(
+						onClick = onGroupFabClick,
+					)
+
+					MapisodeFabOverlayButton(
+						onClick = onGroupFabClick,
+						iconId = Design.drawable.ic_list_bulleted,
+					)
+				}
 			}
 
 			if (state.isCardVisible) {

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
@@ -233,8 +233,13 @@ internal fun HomeRoute(
 			viewModel.onIntent(HomeIntent.ShowBottomSheet)
 			viewModel.onIntent(HomeIntent.LoadGroups)
 		},
-		onListFabClick = {
-
+		onListFabClick = { groupId ->
+			if (groupId != null) onListFabClick(groupId)
+			else Toast.makeText(
+				context,
+				context.getString(R.string.error_group_load_episodes),
+				Toast.LENGTH_SHORT,
+			).show()
 		},
 		onCreateNewEpisode = { latLng ->
 			viewModel.onIntent(HomeIntent.ClickTextMarker(latLng.toEpisodeLatLng()))
@@ -271,7 +276,7 @@ private fun HomeScreen(
 	cameraPositionState: CameraPositionState,
 	onChipSelected: (ChipType) -> Unit = {},
 	onGroupFabClick: () -> Unit = {},
-	onListFabClick: () -> Unit = {},
+	onListFabClick: (String?) -> Unit = {},
 	onCreateNewEpisode: (LatLng) -> Unit = {},
 	onEpisodeMarkerClick: (EpisodeModel) -> Unit = {},
 	onMapClick: () -> Unit = {},
@@ -410,7 +415,7 @@ private fun HomeScreen(
 					)
 
 					MapisodeFabOverlayButton(
-						onClick = onListFabClick,
+						onClick = { onListFabClick(state.selectedGroupId) },
 						iconId = Design.drawable.ic_list_bulleted,
 					)
 				}

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
@@ -234,12 +234,15 @@ internal fun HomeRoute(
 			viewModel.onIntent(HomeIntent.LoadGroups)
 		},
 		onListFabClick = { groupId ->
-			if (groupId != null) onListFabClick(groupId)
-			else Toast.makeText(
-				context,
-				context.getString(R.string.error_group_load_episodes),
-				Toast.LENGTH_SHORT,
-			).show()
+			if (groupId != null) {
+				onListFabClick(groupId)
+			} else {
+				Toast.makeText(
+					context,
+					context.getString(R.string.error_group_load_episodes),
+					Toast.LENGTH_SHORT,
+				).show()
+			}
 		},
 		onCreateNewEpisode = { latLng ->
 			viewModel.onIntent(HomeIntent.ClickTextMarker(latLng.toEpisodeLatLng()))

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
@@ -83,6 +83,7 @@ internal fun HomeRoute(
 	viewModel: HomeViewModel = hiltViewModel(),
 	onTextMarkerClick: (EpisodeLatLng) -> Unit = {},
 	onEpisodeClick: (String) -> Unit = {},
+	onListFabClick: (String) -> Unit = {},
 ) {
 	val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 	val context = LocalContext.current
@@ -232,6 +233,9 @@ internal fun HomeRoute(
 			viewModel.onIntent(HomeIntent.ShowBottomSheet)
 			viewModel.onIntent(HomeIntent.LoadGroups)
 		},
+		onListFabClick = {
+
+		},
 		onCreateNewEpisode = { latLng ->
 			viewModel.onIntent(HomeIntent.ClickTextMarker(latLng.toEpisodeLatLng()))
 		},
@@ -267,6 +271,7 @@ private fun HomeScreen(
 	cameraPositionState: CameraPositionState,
 	onChipSelected: (ChipType) -> Unit = {},
 	onGroupFabClick: () -> Unit = {},
+	onListFabClick: () -> Unit = {},
 	onCreateNewEpisode: (LatLng) -> Unit = {},
 	onEpisodeMarkerClick: (EpisodeModel) -> Unit = {},
 	onMapClick: () -> Unit = {},
@@ -405,7 +410,7 @@ private fun HomeScreen(
 					)
 
 					MapisodeFabOverlayButton(
-						onClick = onGroupFabClick,
+						onClick = onListFabClick,
 						iconId = Design.drawable.ic_list_bulleted,
 					)
 				}

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/common/SortOption.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/common/SortOption.kt
@@ -1,0 +1,9 @@
+package com.boostcamp.mapisode.home.common
+
+import com.boostcamp.mapisode.home.R as S
+
+enum class SortOption(val label: Int) {
+	LATEST(S.string.sort_option_recent),
+	OLDEST(S.string.sort_option_oldest),
+	NAME(S.string.sort_option_name),
+}

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/component/EpisodeCard.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/component/EpisodeCard.kt
@@ -92,7 +92,7 @@ fun EpisodeCard(
 			Spacer(modifier = Modifier.height(2.dp))
 
 			MapisodeText(
-				text = stringResource(R.string.episode_creator_tag_prefix, episode.createdBy),
+				text = stringResource(R.string.episode_creator_tag_prefix, episode.createdByName),
 				style = AppTypography.labelMedium.copy(fontSize = 10.dp),
 				color = MapisodeTheme.colorScheme.textContent,
 				maxLines = 1,

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/component/EpisodeListCard.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/component/EpisodeListCard.kt
@@ -1,0 +1,89 @@
+package com.boostcamp.mapisode.home.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import com.boostcamp.mapisode.common.util.toFormattedString
+import com.boostcamp.mapisode.designsystem.compose.MapisodeText
+import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
+import okhttp3.internal.immutableListOf
+import java.util.Date
+import com.boostcamp.mapisode.home.R as S
+
+@Composable
+fun EpisodeListCard(
+	imageUrl: String,
+	title: String,
+	createdBy: String,
+	address: String,
+	createdAt: Date,
+	content: String,
+) {
+	Row(
+		modifier = Modifier
+			.fillMaxWidth()
+			.height(130.dp)
+			.background(Color.White, shape = RoundedCornerShape(8.dp))
+			.border(1.dp, Color.LightGray, shape = RoundedCornerShape(8.dp))
+			.padding(10.dp),
+	) {
+		AsyncImage(
+			model = imageUrl,
+			contentDescription = "Episode Image",
+			modifier = Modifier
+				.size(110.dp)
+				.clip(RoundedCornerShape(8.dp)),
+			contentScale = ContentScale.Crop,
+		)
+
+		Spacer(modifier = Modifier.width(10.dp))
+
+		Column(
+			modifier = Modifier.fillMaxSize(),
+			verticalArrangement = Arrangement.Center,
+		) {
+			MapisodeText(
+				text = title,
+				style = MapisodeTheme.typography.titleMedium
+					.copy(fontWeight = FontWeight.SemiBold),
+				maxLines = 1,
+			)
+
+			Spacer(modifier = Modifier.height(4.dp))
+
+			val textList = immutableListOf(
+				stringResource(S.string.overview_created_by) + createdBy,
+				stringResource(S.string.overview_location) + address,
+				stringResource(S.string.overview_date) + createdAt.toFormattedString(),
+				stringResource(S.string.overview_content) + content,
+			)
+
+			textList.forEach { text ->
+				MapisodeText(
+					text = text,
+					style = MapisodeTheme.typography.labelMedium,
+					maxLines = 1,
+				)
+			}
+		}
+	}
+}

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/list/EpisodeListIntent.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/list/EpisodeListIntent.kt
@@ -4,6 +4,7 @@ import com.boostcamp.mapisode.home.common.SortOption
 import com.boostcamp.mapisode.ui.base.UiIntent
 
 sealed class EpisodeListIntent : UiIntent {
+	data class LoadInitialData(val groupId: String) : EpisodeListIntent()
 	data class LoadEpisodeList(val groupId: String) : EpisodeListIntent()
 	data class ChangeSortOption(val sortOption: SortOption) : EpisodeListIntent()
 }

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/list/EpisodeListIntent.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/list/EpisodeListIntent.kt
@@ -1,1 +1,7 @@
 package com.boostcamp.mapisode.home.list
+
+import com.boostcamp.mapisode.ui.base.UiIntent
+
+sealed class EpisodeListIntent : UiIntent {
+	data class LoadEpisodeList(val groupId: String) : EpisodeListIntent()
+}

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/list/EpisodeListIntent.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/list/EpisodeListIntent.kt
@@ -1,7 +1,9 @@
 package com.boostcamp.mapisode.home.list
 
+import com.boostcamp.mapisode.home.common.SortOption
 import com.boostcamp.mapisode.ui.base.UiIntent
 
 sealed class EpisodeListIntent : UiIntent {
 	data class LoadEpisodeList(val groupId: String) : EpisodeListIntent()
+	data class ChangeSortOption(val sortOption: SortOption) : EpisodeListIntent()
 }

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/list/EpisodeListIntent.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/list/EpisodeListIntent.kt
@@ -1,0 +1,1 @@
+package com.boostcamp.mapisode.home.list

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/list/EpisodeListScreen.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/list/EpisodeListScreen.kt
@@ -48,6 +48,7 @@ fun EpisodeListRoute(
 	val context = LocalContext.current
 
 	LaunchedEffect(Unit) {
+		viewModel.onIntent(EpisodeListIntent.LoadInitialData(groupId))
 		viewModel.onIntent(EpisodeListIntent.LoadEpisodeList(groupId))
 	}
 
@@ -89,13 +90,12 @@ fun EpisodeListScreen(
 	var expanded by rememberSaveable { mutableStateOf(false) }
 	val sortOptions = SortOption.entries.toImmutableList()
 
-
 	MapisodeScaffold(
 		isStatusBarPaddingExist = true,
 		isNavigationBarPaddingExist = true,
 		topBar = {
 			TopAppBar(
-				title = "", // TODO 그룹 이름 가져오기,
+				title = state.groupName,
 				navigationIcon = {
 					MapisodeIconButton(
 						onClick = { onBackClick() },
@@ -169,7 +169,7 @@ fun EpisodeListScreen(
 				EpisodeListCard(
 					imageUrl = episode.imageUrls.first(),
 					title = episode.title,
-					createdBy = episode.createdBy,
+					createdBy = episode.createdByName,
 					address = episode.address,
 					createdAt = episode.createdAt,
 					content = episode.content,

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/list/EpisodeListScreen.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/list/EpisodeListScreen.kt
@@ -1,10 +1,58 @@
 package com.boostcamp.mapisode.home.list
 
+import android.widget.Toast
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.boostcamp.mapisode.designsystem.compose.MapisodeCircularLoadingIndicator
 
 @Composable
 fun EpisodeListRoute(
 	groupId: String,
+	viewModel: EpisodeListViewModel = hiltViewModel(),
+	onBackClick: () -> Unit,
+) {
+	val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+	val context = LocalContext.current
+
+	LaunchedEffect(Unit) {
+		viewModel.onIntent(EpisodeListIntent.LoadEpisodeList(groupId))
+	}
+
+	LaunchedEffect(Unit) {
+		viewModel.sideEffect.collect { sideEffect ->
+			when (sideEffect) {
+				is EpisodeListSideEffect.ShowToast -> {
+					val message = context.getString(sideEffect.messageResId)
+					Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+				}
+			}
+		}
+	}
+
+	if (uiState.isLoading) {
+		Box(
+			modifier = Modifier.fillMaxSize(),
+			contentAlignment = Alignment.Center,
+		) {
+			MapisodeCircularLoadingIndicator()
+		}
+	} else {
+		EpisodeListScreen(state = uiState, onBackClick = onBackClick)
+	}
+}
+
+@Composable
+fun EpisodeListScreen(
+	state: EpisodeListState,
+	onBackClick: () -> Unit,
 ) {
 
 }

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/list/EpisodeListScreen.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/list/EpisodeListScreen.kt
@@ -1,17 +1,42 @@
 package com.boostcamp.mapisode.home.list
 
 import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.boostcamp.mapisode.designsystem.R
 import com.boostcamp.mapisode.designsystem.compose.MapisodeCircularLoadingIndicator
+import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
+import com.boostcamp.mapisode.designsystem.compose.MapisodeIconButton
+import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
+import com.boostcamp.mapisode.designsystem.compose.MapisodeText
+import com.boostcamp.mapisode.designsystem.compose.menu.MapisodeDropdownMenu
+import com.boostcamp.mapisode.designsystem.compose.menu.MapisodeDropdownMenuItem
+import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
+import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
+import com.boostcamp.mapisode.home.common.SortOption
+import com.boostcamp.mapisode.home.component.EpisodeListCard
+import okhttp3.internal.toImmutableList
 
 @Composable
 fun EpisodeListRoute(
@@ -45,7 +70,13 @@ fun EpisodeListRoute(
 			MapisodeCircularLoadingIndicator()
 		}
 	} else {
-		EpisodeListScreen(state = uiState, onBackClick = onBackClick)
+		EpisodeListScreen(
+			state = uiState,
+			onBackClick = onBackClick,
+			onSortOptionChange = { sortOption ->
+				viewModel.onIntent(EpisodeListIntent.ChangeSortOption(sortOption))
+			},
+		)
 	}
 }
 
@@ -53,6 +84,97 @@ fun EpisodeListRoute(
 fun EpisodeListScreen(
 	state: EpisodeListState,
 	onBackClick: () -> Unit,
+	onSortOptionChange: (SortOption) -> Unit = {},
 ) {
+	var expanded by rememberSaveable { mutableStateOf(false) }
+	val sortOptions = SortOption.entries.toImmutableList()
 
+
+	MapisodeScaffold(
+		isStatusBarPaddingExist = true,
+		isNavigationBarPaddingExist = true,
+		topBar = {
+			TopAppBar(
+				title = "", // TODO 그룹 이름 가져오기,
+				navigationIcon = {
+					MapisodeIconButton(
+						onClick = { onBackClick() },
+					) {
+						MapisodeIcon(
+							id = R.drawable.ic_arrow_back_ios,
+						)
+					}
+				},
+				actions = {},
+			)
+		},
+	) {
+		LazyColumn(
+			modifier = Modifier
+				.fillMaxSize()
+				.padding(it),
+			verticalArrangement = Arrangement.spacedBy(10.dp),
+			contentPadding = PaddingValues(vertical = 10.dp, horizontal = 20.dp),
+		) {
+			item {
+				Row(
+					modifier = Modifier.fillParentMaxWidth(),
+					verticalAlignment = Alignment.CenterVertically,
+					horizontalArrangement = Arrangement.SpaceBetween,
+				) {
+					MapisodeText(
+						text = "에피소드",
+						style = MapisodeTheme.typography.labelLarge,
+					)
+					MapisodeIconButton(
+						onClick = { expanded = true },
+					) {
+						Row(
+							verticalAlignment = Alignment.CenterVertically,
+						) {
+							MapisodeText(
+								text = stringResource(state.selectedSortOption.label),
+							)
+							MapisodeIcon(
+								id = R.drawable.ic_arrow_drop_down,
+							)
+						}
+
+						MapisodeDropdownMenu(
+							expanded = expanded,
+							onDismissRequest = { expanded = false },
+							modifier = Modifier.wrapContentWidth(),
+							offset = DpOffset(0.dp, 0.dp).minus(DpOffset(16.dp, 16.dp)),
+						) {
+							sortOptions.forEach { option ->
+								MapisodeDropdownMenuItem(
+									onClick = {
+										onSortOptionChange(option)
+										expanded = false
+									},
+								) {
+									MapisodeText(
+										text = stringResource(option.label),
+									)
+								}
+							}
+						}
+					}
+				}
+			}
+			items(
+				items = state.episodes,
+				key = { episode -> episode.id },
+			) { episode ->
+				EpisodeListCard(
+					imageUrl = episode.imageUrls.first(),
+					title = episode.title,
+					createdBy = episode.createdBy,
+					address = episode.address,
+					createdAt = episode.createdAt,
+					content = episode.content,
+				)
+			}
+		}
+	}
 }

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/list/EpisodeListScreen.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/list/EpisodeListScreen.kt
@@ -1,0 +1,10 @@
+package com.boostcamp.mapisode.home.list
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun EpisodeListRoute(
+	groupId: String,
+) {
+
+}

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/list/EpisodeListSideEffect.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/list/EpisodeListSideEffect.kt
@@ -1,1 +1,7 @@
 package com.boostcamp.mapisode.home.list
+
+import com.boostcamp.mapisode.ui.base.SideEffect
+
+sealed class EpisodeListSideEffect : SideEffect {
+	data class ShowToast(val messageResId: Int) : EpisodeListSideEffect()
+}

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/list/EpisodeListSideEffect.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/list/EpisodeListSideEffect.kt
@@ -1,0 +1,1 @@
+package com.boostcamp.mapisode.home.list

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/list/EpisodeListState.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/list/EpisodeListState.kt
@@ -1,5 +1,6 @@
 package com.boostcamp.mapisode.home.list
 
+import com.boostcamp.mapisode.home.common.SortOption
 import com.boostcamp.mapisode.model.EpisodeModel
 import com.boostcamp.mapisode.ui.base.UiState
 import kotlinx.collections.immutable.PersistentList
@@ -8,4 +9,5 @@ import kotlinx.collections.immutable.persistentListOf
 data class EpisodeListState(
 	val isLoading: Boolean = true,
 	val episodes: PersistentList<EpisodeModel> = persistentListOf(),
+	val selectedSortOption: SortOption = SortOption.LATEST,
 ) : UiState

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/list/EpisodeListState.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/list/EpisodeListState.kt
@@ -1,1 +1,11 @@
 package com.boostcamp.mapisode.home.list
+
+import com.boostcamp.mapisode.model.EpisodeModel
+import com.boostcamp.mapisode.ui.base.UiState
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.persistentListOf
+
+data class EpisodeListState(
+	val isLoading: Boolean = true,
+	val episodes: PersistentList<EpisodeModel> = persistentListOf(),
+) : UiState

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/list/EpisodeListState.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/list/EpisodeListState.kt
@@ -1,0 +1,1 @@
+package com.boostcamp.mapisode.home.list

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/list/EpisodeListState.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/list/EpisodeListState.kt
@@ -10,4 +10,5 @@ data class EpisodeListState(
 	val isLoading: Boolean = true,
 	val episodes: PersistentList<EpisodeModel> = persistentListOf(),
 	val selectedSortOption: SortOption = SortOption.LATEST,
+	val groupName: String = "",
 ) : UiState

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/list/EpisodeListViewModel.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/list/EpisodeListViewModel.kt
@@ -20,8 +20,7 @@ import javax.inject.Inject
 class EpisodeListViewModel @Inject constructor(
 	private val episodeRepository: EpisodeRepository,
 	private val groupRepository: GroupRepository,
-) :
-	BaseViewModel<EpisodeListIntent, EpisodeListState, EpisodeListSideEffect>(EpisodeListState()) {
+) : BaseViewModel<EpisodeListIntent, EpisodeListState, EpisodeListSideEffect>(EpisodeListState()) {
 
 	private val userNameCache = ConcurrentHashMap<String, String>()
 

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/list/EpisodeListViewModel.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/list/EpisodeListViewModel.kt
@@ -3,8 +3,11 @@ package com.boostcamp.mapisode.home.list
 import androidx.lifecycle.viewModelScope
 import com.boostcamp.mapisode.episode.EpisodeRepository
 import com.boostcamp.mapisode.home.R
+import com.boostcamp.mapisode.home.common.SortOption
+import com.boostcamp.mapisode.model.EpisodeModel
 import com.boostcamp.mapisode.ui.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -15,6 +18,7 @@ class EpisodeListViewModel @Inject constructor(private val episodeRepository: Ep
 	override fun onIntent(intent: EpisodeListIntent) {
 		when (intent) {
 			is EpisodeListIntent.LoadEpisodeList -> loadEpisodeList(intent.groupId)
+			is EpisodeListIntent.ChangeSortOption -> changeSortOption(intent.sortOption)
 		}
 	}
 
@@ -27,5 +31,28 @@ class EpisodeListViewModel @Inject constructor(private val episodeRepository: Ep
 				postSideEffect(EpisodeListSideEffect.ShowToast(R.string.episode_detail_load_error))
 			}
 		}
+	}
+
+	private fun changeSortOption(sortOption: SortOption) {
+		val sortedEpisodes = sortEpisodes(currentState.episodes, sortOption)
+		intent {
+			copy(
+				selectedSortOption = sortOption,
+				episodes = sortedEpisodes,
+			)
+		}
+	}
+
+	private fun sortEpisodes(
+		episodes: List<EpisodeModel>,
+		sortOption: SortOption,
+	): PersistentList<EpisodeModel> {
+		val sortedList = when (sortOption) {
+			SortOption.LATEST -> episodes.sortedByDescending { it.createdAt }
+			SortOption.OLDEST -> episodes.sortedBy { it.createdAt }
+			SortOption.NAME -> episodes.sortedBy { it.title }
+		}
+
+		return sortedList.toPersistentList()
 	}
 }

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/list/EpisodeListViewModel.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/list/EpisodeListViewModel.kt
@@ -1,0 +1,31 @@
+package com.boostcamp.mapisode.home.list
+
+import androidx.lifecycle.viewModelScope
+import com.boostcamp.mapisode.episode.EpisodeRepository
+import com.boostcamp.mapisode.home.R
+import com.boostcamp.mapisode.ui.base.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class EpisodeListViewModel @Inject constructor(private val episodeRepository: EpisodeRepository) :
+	BaseViewModel<EpisodeListIntent, EpisodeListState, EpisodeListSideEffect>(EpisodeListState()) {
+	override fun onIntent(intent: EpisodeListIntent) {
+		when (intent) {
+			is EpisodeListIntent.LoadEpisodeList -> loadEpisodeList(intent.groupId)
+		}
+	}
+
+	private fun loadEpisodeList(groupId: String) {
+		viewModelScope.launch {
+			try {
+				val episodes = episodeRepository.getEpisodesByGroup(groupId).toPersistentList()
+				intent { copy(episodes = episodes) }
+			} catch (e: Exception) {
+				postSideEffect(EpisodeListSideEffect.ShowToast(R.string.episode_detail_load_error))
+			}
+		}
+	}
+}

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/navigation/HomeNavigation.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/navigation/HomeNavigation.kt
@@ -7,6 +7,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import com.boostcamp.mapisode.home.HomeRoute
 import com.boostcamp.mapisode.home.detail.EpisodeDetailRoute
+import com.boostcamp.mapisode.home.list.EpisodeListRoute
 import com.boostcamp.mapisode.model.EpisodeLatLng
 import com.boostcamp.mapisode.navigation.HomeRoute
 import com.boostcamp.mapisode.navigation.MainRoute
@@ -24,20 +25,34 @@ fun NavController.navigateEpisodeDetail(
 	navigate(HomeRoute.Detail(episodeId), navOptions)
 }
 
+fun NavController.navigateEpisodeList(
+	groupId: String,
+	navOptions: NavOptions? = null,
+) {
+	navigate(HomeRoute.List(groupId), navOptions)
+}
+
 fun NavGraphBuilder.addHomeNavGraph(
 	onTextMarkerClick: (EpisodeLatLng) -> Unit,
 	onEpisodeClick: (String) -> Unit,
+	onListFabClick: (String) -> Unit,
 	onBackClick: () -> Unit,
 ) {
 	composable<MainRoute.Home> {
 		HomeRoute(
 			onTextMarkerClick = onTextMarkerClick,
 			onEpisodeClick = onEpisodeClick,
+			onListFabClick = onListFabClick,
 		)
 	}
 
 	composable<HomeRoute.Detail> { backStackEntry ->
 		val episodeId = backStackEntry.toRoute<HomeRoute.Detail>().episodeId
 		EpisodeDetailRoute(episodeId = episodeId, onBackClick = onBackClick)
+	}
+
+	composable<HomeRoute.List> { backStackEntry ->
+		val groupId = backStackEntry.toRoute<HomeRoute.List>().groupId
+		EpisodeListRoute(groupId = groupId)
 	}
 }

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/navigation/HomeNavigation.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/navigation/HomeNavigation.kt
@@ -53,6 +53,6 @@ fun NavGraphBuilder.addHomeNavGraph(
 
 	composable<HomeRoute.List> { backStackEntry ->
 		val groupId = backStackEntry.toRoute<HomeRoute.List>().groupId
-		EpisodeListRoute(groupId = groupId)
+		EpisodeListRoute(groupId = groupId, onBackClick = onBackClick)
 	}
 }

--- a/feature/home/src/main/res/values/strings.xml
+++ b/feature/home/src/main/res/values/strings.xml
@@ -21,4 +21,13 @@
 	<string name="episode_card_detail">자세히</string>
 	<string name="episode_detail_not_found_error">애피소드를 찾을 수 없습니다.</string>
 	<string name="episode_detail_load_error">데이터를 불러오는 중 오류가 발생했습니다.</string>
+
+	<!-- EpisodeList -->
+	<string name="overview_created_by">"글쓴이 :&#32;"</string>
+	<string name="overview_location">"위치 :&#32;"</string>
+	<string name="overview_date">"작성일 :&#32;"</string>
+	<string name="overview_content">"내용 :&#32;"</string>
+	<string name="sort_option_recent">최신순</string>
+	<string name="sort_option_oldest">과거순</string>
+	<string name="sort_option_name">이름순</string>
 </resources>

--- a/feature/main/src/main/java/com/boostcamp/mapisode/main/MainNavigator.kt
+++ b/feature/main/src/main/java/com/boostcamp/mapisode/main/MainNavigator.kt
@@ -70,7 +70,7 @@ internal class MainNavigator(
 		navController.navigateEpisodeDetail(episodeId)
 	}
 
-	fun navigateToEpisodeList(groupId: String) {
+	fun navigateToEpisodeList(groupId: String?) {
 		navController.navigateEpisodeList(groupId)
 	}
 

--- a/feature/main/src/main/java/com/boostcamp/mapisode/main/MainNavigator.kt
+++ b/feature/main/src/main/java/com/boostcamp/mapisode/main/MainNavigator.kt
@@ -17,6 +17,7 @@ import com.boostcamp.mapisode.episode.navigation.navigatePickLocation
 import com.boostcamp.mapisode.episode.navigation.navigateWriteContent
 import com.boostcamp.mapisode.episode.navigation.navigateWriteInfo
 import com.boostcamp.mapisode.home.navigation.navigateEpisodeDetail
+import com.boostcamp.mapisode.home.navigation.navigateEpisodeList
 import com.boostcamp.mapisode.mygroup.navigation.navigateGroupCreation
 import com.boostcamp.mapisode.mygroup.navigation.navigateGroupDetail
 import com.boostcamp.mapisode.mygroup.navigation.navigateGroupEdit
@@ -67,6 +68,10 @@ internal class MainNavigator(
 
 	fun navigateToEpisodeDetail(episodeId: String) {
 		navController.navigateEpisodeDetail(episodeId)
+	}
+
+	fun navigateToEpisodeList(groupId: String) {
+		navController.navigateEpisodeList(groupId)
 	}
 
 	fun getEpisodeBackStackEntry(): NavBackStackEntry =

--- a/feature/main/src/main/java/com/boostcamp/mapisode/main/MainNavigator.kt
+++ b/feature/main/src/main/java/com/boostcamp/mapisode/main/MainNavigator.kt
@@ -70,7 +70,7 @@ internal class MainNavigator(
 		navController.navigateEpisodeDetail(episodeId)
 	}
 
-	fun navigateToEpisodeList(groupId: String?) {
+	fun navigateToEpisodeList(groupId: String) {
 		navController.navigateEpisodeList(groupId)
 	}
 

--- a/feature/main/src/main/java/com/boostcamp/mapisode/main/component/MainNavHost.kt
+++ b/feature/main/src/main/java/com/boostcamp/mapisode/main/component/MainNavHost.kt
@@ -28,6 +28,7 @@ internal fun MainNavHost(
 			addHomeNavGraph(
 				onTextMarkerClick = { navigator.navigate(MainNavTab.EPISODE) },
 				onEpisodeClick = navigator::navigateToEpisodeDetail,
+				onListFabClick = navigator::navigateToEpisodeList,
 				onBackClick = navigator::popBackStackIfNotHome,
 			)
 			addAuthNavGraph(


### PR DESCRIPTION
- closed #128 

## *📍 Work Description*

- 홈-에피소드 카드에 생성자 id가 아닌 닉네임이 뜨도록 변경
- 홈에서 목록 FAB으로 현재 그룹의 에피소드 목록을 볼 수 있음
- 에피소드 목록은 최신순/과거순/이름순으로 정렬 가능 
- 캐싱을 사용해서 같은 생성자에 대해 중복된 요청을 하지 않습니다. 

## *📸 Screenshot*

<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->

https://github.com/user-attachments/assets/1513544a-cbc7-47b6-8c45-702f4177fbb4


## *📢 To Reviewers*
- EpisodeModel에 createdBy는 id니 createdByName을 추가해서 사용할 수 있게 하였습니다. 

## ⏲️Time

    - 4 h
