### PR TITLE
[FIX/#164] : Designsystem / bottom app bar 애니매이션 수정

### DIFF
--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/BottomAppBar.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/BottomAppBar.kt
@@ -1,8 +1,8 @@
 package com.boostcamp.mapisode.designsystem.compose
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -27,8 +27,8 @@ fun BottomBar(
 ) {
 	AnimatedVisibility(
 		visible = visible,
-		enter = fadeIn(),
-		exit = fadeOut(),
+		enter = expandVertically(),
+		exit = shrinkVertically(),
 	) {
 		Surface(
 			color = backgroundColor,


### PR DESCRIPTION
- closed #164 

## *📍 Work Description*

- 바텀 네비게이션 감추기, 나타내기 애니매이션 수정

## *📸 Screenshot*

https://github.com/user-attachments/assets/679e97b0-e502-40b9-b879-81734458a827

https://github.com/user-attachments/assets/b293e484-c1ec-413b-b3c4-e716b6c8a166

https://github.com/user-attachments/assets/03e76f13-96dc-4cd1-a616-6b234449f6c8

https://github.com/user-attachments/assets/21f401dc-da12-4c39-a5d0-7956bfc31b77


## *📢 To Reviewers*
- 기본(fade in/out) -> 애니매이션 삭제 -> 수평 shrink/expand -> 수직 shrink/expand
- 애니매이션중에서 가장 깔끔한 수직애니매이션을 적용했습니다.
- 애니매이션을 없애면 탭간 이동시에 컴포지션 단계에서 네비게이션 영역에서 순간 검게 나타나는 현상이 있어서 애니매이션을 유지했습니다.

## ⏲️Time

    - 1 시간
