### PR TITLE
[FEAT/#163] 에피소드 생성 / 지도에서 초기 위치 설정하여 반영하는 기능 구현

### DIFF
--- a/core/navigation/build.gradle.kts
+++ b/core/navigation/build.gradle.kts
@@ -10,4 +10,5 @@ android {
 
 dependencies {
 	implementation(libs.kotlinx.serialization.json)
+	implementation(projects.core.model)
 }

--- a/core/navigation/src/main/java/com/boostcamp/mapisode/navigation/MainRoute.kt
+++ b/core/navigation/src/main/java/com/boostcamp/mapisode/navigation/MainRoute.kt
@@ -8,7 +8,7 @@ sealed interface MainRoute : Route {
 	data object Home : MainRoute
 
 	@Serializable
-	data object Episode : MainRoute
+	data class Episode(val lat: Double? = null, val lng: Double? = null) : MainRoute
 
 	@Serializable
 	data object Group : MainRoute

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodePicsScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodePicsScreen.kt
@@ -26,15 +26,23 @@ import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
 import com.boostcamp.mapisode.episode.intent.NewEpisodeIntent
 import com.boostcamp.mapisode.episode.intent.NewEpisodeSideEffect
 import com.boostcamp.mapisode.episode.intent.NewEpisodeViewModel
+import com.boostcamp.mapisode.model.EpisodeLatLng
+import com.naver.maps.geometry.LatLng
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 
 @Composable
 internal fun NewEpisodePicsScreen(
+	initialLatLng: EpisodeLatLng? = null,
 	viewModel: NewEpisodeViewModel = hiltViewModel(),
 	onNavigateToInfo: () -> Unit,
 ) {
 	val context = LocalContext.current
+	initialLatLng?.let { latLng ->
+		val mapsLatLng = LatLng(latLng.latitude, latLng.longitude)
+		viewModel.onIntent(NewEpisodeIntent.SetEpisodeLocation(mapsLatLng))
+		viewModel.onIntent(NewEpisodeIntent.SetEpisodeAddress(mapsLatLng))
+	}
 
 	LaunchedEffect(Unit) {
 		viewModel.sideEffect.collect { sideEffect ->

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/PickLocationScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/PickLocationScreen.kt
@@ -84,7 +84,7 @@ internal fun PickLocationScreen(
 				modifier = Modifier.fillMaxHeight(0.75f),
 				cameraPositionState = cameraPositionState,
 				properties = MapProperties(
-					locationTrackingMode = LocationTrackingMode.Follow,
+					locationTrackingMode = LocationTrackingMode.NoFollow,
 				),
 				uiSettings = MapUiSettings(
 					isZoomControlEnabled = false,

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/navigation/EpisodeNavigation.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/navigation/EpisodeNavigation.kt
@@ -56,12 +56,13 @@ fun NavGraphBuilder.addEpisodeNavGraph(
 	composable<MainRoute.Episode> { backStackEntry ->
 		val lat = backStackEntry.toRoute<MainRoute.Episode>().lat
 		val lng = backStackEntry.toRoute<MainRoute.Episode>().lng
-		val initialLatLng: EpisodeLatLng? =
+		val initialLatLng: () -> EpisodeLatLng? = {
 			if (lat == null || lng == null) null
 			else EpisodeLatLng(lat, lng)
+		}
 
 		NewEpisodePicsScreen(
-			initialLatLng = initialLatLng,
+			initialLatLng = initialLatLng(),
 			viewModel = hiltViewModel(getBackStackEntry()),
 			onNavigateToInfo = onNavigateToInfo,
 		)

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/navigation/EpisodeNavigation.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/navigation/EpisodeNavigation.kt
@@ -56,8 +56,9 @@ fun NavGraphBuilder.addEpisodeNavGraph(
 	composable<MainRoute.Episode> { backStackEntry ->
 		val lat = backStackEntry.toRoute<MainRoute.Episode>().lat
 		val lng = backStackEntry.toRoute<MainRoute.Episode>().lng
-		val initialLatLng: EpisodeLatLng? = if (lat == null || lng == null) null
-		else EpisodeLatLng(lat, lng)
+		val initialLatLng: EpisodeLatLng? =
+			if (lat == null || lng == null) null
+			else EpisodeLatLng(lat, lng)
 
 		NewEpisodePicsScreen(
 			initialLatLng = initialLatLng,

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/navigation/EpisodeNavigation.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/navigation/EpisodeNavigation.kt
@@ -57,8 +57,11 @@ fun NavGraphBuilder.addEpisodeNavGraph(
 		val lat = backStackEntry.toRoute<MainRoute.Episode>().lat
 		val lng = backStackEntry.toRoute<MainRoute.Episode>().lng
 		val initialLatLng: () -> EpisodeLatLng? = {
-			if (lat == null || lng == null) null
-			else EpisodeLatLng(lat, lng)
+			if (lat == null || lng == null) {
+				null
+			} else {
+				EpisodeLatLng(lat, lng)
+			}
 		}
 
 		NewEpisodePicsScreen(

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/navigation/EpisodeNavigation.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/navigation/EpisodeNavigation.kt
@@ -6,14 +6,16 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import androidx.navigation.toRoute
 import com.boostcamp.mapisode.episode.NewEpisodeContentScreen
 import com.boostcamp.mapisode.episode.NewEpisodeInfoScreen
 import com.boostcamp.mapisode.episode.NewEpisodePicsScreen
 import com.boostcamp.mapisode.episode.PickLocationScreen
+import com.boostcamp.mapisode.model.EpisodeLatLng
 import com.boostcamp.mapisode.navigation.MainRoute
 import com.boostcamp.mapisode.navigation.NewEpisodeRoute
 
-fun NavController.navigateEpisode(
+fun NavController.navigateToEpisode(
 	navOptions: NavOptions? = null,
 ) {
 	navigate(MainRoute.Episode, navOptions)
@@ -51,8 +53,14 @@ fun NavGraphBuilder.addEpisodeNavGraph(
 	onClickPickLocation: () -> Unit,
 	onNavigateToContent: () -> Unit,
 ) {
-	composable<MainRoute.Episode> {
+	composable<MainRoute.Episode> { backStackEntry ->
+		val lat = backStackEntry.toRoute<MainRoute.Episode>().lat
+		val lng = backStackEntry.toRoute<MainRoute.Episode>().lng
+		val initialLatLng: EpisodeLatLng? = if (lat == null || lng == null) null
+		else EpisodeLatLng(lat, lng)
+
 		NewEpisodePicsScreen(
+			initialLatLng = initialLatLng,
 			viewModel = hiltViewModel(getBackStackEntry()),
 			onNavigateToInfo = onNavigateToInfo,
 		)

--- a/feature/main/src/main/java/com/boostcamp/mapisode/main/MainNavTab.kt
+++ b/feature/main/src/main/java/com/boostcamp/mapisode/main/MainNavTab.kt
@@ -17,7 +17,7 @@ internal enum class MainNavTab(
 	EPISODE(
 		iconResId = R.drawable.ic_edit_note,
 		contentDescription = "새 에피소드",
-		route = MainRoute.Episode,
+		route = MainRoute.Episode(),
 	),
 	GROUP(
 		iconResId = R.drawable.ic_groups_2,
@@ -28,7 +28,8 @@ internal enum class MainNavTab(
 		iconResId = R.drawable.ic_account_circle,
 		contentDescription = "마이페이지",
 		route = MainRoute.Mypage,
-	), ;
+	),
+	;
 
 	companion object {
 		@Composable

--- a/feature/main/src/main/java/com/boostcamp/mapisode/main/MainNavigator.kt
+++ b/feature/main/src/main/java/com/boostcamp/mapisode/main/MainNavigator.kt
@@ -18,6 +18,7 @@ import com.boostcamp.mapisode.episode.navigation.navigateWriteContent
 import com.boostcamp.mapisode.episode.navigation.navigateWriteInfo
 import com.boostcamp.mapisode.home.navigation.navigateEpisodeDetail
 import com.boostcamp.mapisode.home.navigation.navigateEpisodeList
+import com.boostcamp.mapisode.model.EpisodeLatLng
 import com.boostcamp.mapisode.mygroup.navigation.navigateGroupCreation
 import com.boostcamp.mapisode.mygroup.navigation.navigateGroupDetail
 import com.boostcamp.mapisode.mygroup.navigation.navigateGroupEdit
@@ -39,7 +40,7 @@ internal class MainNavigator(
 			currentDestination?.hasRoute(tab::class) == true
 		}
 
-	fun navigate(tab: MainNavTab) {
+	fun navigate(tab: MainNavTab, latLng: EpisodeLatLng? = null) {
 		val navOptions = navOptions {
 			popUpTo(navController.graph.findStartDestination().id) {
 				saveState = true
@@ -50,7 +51,14 @@ internal class MainNavigator(
 
 		when (tab) {
 			MainNavTab.HOME -> navController.navigate(MainNavTab.HOME.route, navOptions)
-			MainNavTab.EPISODE -> navController.navigate(MainNavTab.EPISODE.route, navOptions)
+			MainNavTab.EPISODE -> navController.navigate(
+				MainRoute.Episode(
+					lat = latLng?.latitude,
+					lng = latLng?.longitude,
+				),
+				navOptions,
+			)
+
 			MainNavTab.GROUP -> navController.navigate(MainNavTab.GROUP.route, navOptions)
 			MainNavTab.MYPAGE -> navController.navigate(MainNavTab.MYPAGE.route, navOptions)
 		}

--- a/feature/main/src/main/java/com/boostcamp/mapisode/main/MainNavigator.kt
+++ b/feature/main/src/main/java/com/boostcamp/mapisode/main/MainNavigator.kt
@@ -86,7 +86,7 @@ internal class MainNavigator(
 		navController.getBackStackEntry(startDestination)
 
 	fun popBackEpisodeToMain() {
-		navController.popBackStack(MainRoute.Episode, inclusive = true)
+		navController.popBackStack(Route.Auth, inclusive = false)
 	}
 
 	fun navigateWriteInfo() {

--- a/feature/main/src/main/java/com/boostcamp/mapisode/main/component/MainNavHost.kt
+++ b/feature/main/src/main/java/com/boostcamp/mapisode/main/component/MainNavHost.kt
@@ -26,7 +26,9 @@ internal fun MainNavHost(
 			startDestination = navigator.startDestination,
 		) {
 			addHomeNavGraph(
-				onTextMarkerClick = { navigator.navigate(MainNavTab.EPISODE) },
+				onTextMarkerClick = { latLng ->
+					navigator.navigate(MainNavTab.EPISODE, latLng)
+				},
 				onEpisodeClick = navigator::navigateToEpisodeDetail,
 				onListFabClick = navigator::navigateToEpisodeList,
 				onBackClick = navigator::popBackStackIfNotHome,


### PR DESCRIPTION
- closed #163

## *📍 Work Description*
- 메인 화면에서 지도 롱클릭 후 에피소드 생성 버튼 클릭시 해당 위치가 반영되는 기능 구현

## *📸 Screenshot*
[163-1.webm](https://github.com/user-attachments/assets/1cfe4dca-f7d1-468a-9e60-ac663e53f56f)

## *📢 To Reviewers*
- 작성하면서 약간 코드의 일관성을 해친 부분이 있는데, 수정 방안을 리뷰해주셔도 좋을 것 같습니다!

## ⏲️Time

    - 2 시간
