### PR TITLE
[REFACTOR/#170] 에피소드 생성 화면에 MapisodePhotopicker 적용

### DIFF
--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodePicsScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodePicsScreen.kt
@@ -2,33 +2,19 @@ package com.boostcamp.mapisode.episode
 
 import android.net.Uri
 import android.widget.Toast
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.PickVisualMediaRequest
-import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
-import com.boostcamp.mapisode.designsystem.compose.MapisodeIconButton
-import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
-import com.boostcamp.mapisode.designsystem.compose.button.MapisodeFilledButton
-import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
+import com.boostcamp.mapisode.episode.common.NewEpisodeConstant.MAX_PHOTO_COUNTS
 import com.boostcamp.mapisode.episode.intent.NewEpisodeIntent
 import com.boostcamp.mapisode.episode.intent.NewEpisodeSideEffect
 import com.boostcamp.mapisode.episode.intent.NewEpisodeViewModel
 import com.boostcamp.mapisode.model.EpisodeLatLng
+import com.boostcamp.mapisode.ui.photopicker.MapisodePhotoPicker
 import com.naver.maps.geometry.LatLng
-import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 
 @Composable
@@ -36,6 +22,7 @@ internal fun NewEpisodePicsScreen(
 	initialLatLng: EpisodeLatLng? = null,
 	viewModel: NewEpisodeViewModel = hiltViewModel(),
 	onNavigateToInfo: () -> Unit,
+	onBackPressed: () -> Unit,
 ) {
 	val context = LocalContext.current
 	initialLatLng?.let { latLng ->
@@ -60,59 +47,29 @@ internal fun NewEpisodePicsScreen(
 		}
 	}
 
-	MapisodeScaffold(
-		topBar = {
-			TopAppBar(
-				title = stringResource(R.string.new_episode_menu_title),
-				actions = {
-					MapisodeIconButton(
-						onClick = {},
-						enabled = false,
-					) {
-						MapisodeIcon(com.boostcamp.mapisode.designsystem.R.drawable.ic_arrow_forward_ios)
-					}
-				},
-			)
-		},
-		isStatusBarPaddingExist = true,
-	) { innerPadding ->
-		Box(
-			Modifier
-				.fillMaxSize()
-				.padding(innerPadding),
-			contentAlignment = Alignment.Center,
-		) {
-			PickEpisodePhotoButton { uris ->
-				viewModel.onIntent(NewEpisodeIntent.SetEpisodePics(uris))
-				if (uris.isNotEmpty()) {
-					onNavigateToInfo()
-				}
-			}
-		}
-	}
-}
-
-@Composable
-fun PickEpisodePhotoButton(
-	onPickPhotos: (PersistentList<Uri>) -> Unit,
-) {
-	val photoPickLauncher = rememberLauncherForActivityResult(
-		contract = ActivityResultContracts.PickMultipleVisualMedia(4),
-		onResult = { uris ->
-			onPickPhotos(uris.toPersistentList())
-		},
-	)
-
-	MapisodeFilledButton(
+	MapisodePhotoPicker(
 		modifier = Modifier
-			.fillMaxWidth()
-			.padding(horizontal = 20.dp)
-			.fillMaxHeight(0.1f),
-		onClick = {
-			photoPickLauncher.launch(
-				PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly),
+			.fillMaxSize(),
+		numOfPhoto = MAX_PHOTO_COUNTS,
+		onPhotoSelected = { photoInfos ->
+			viewModel.onIntent(
+				NewEpisodeIntent.SetEpisodePics(
+					photoInfos
+						.map { Uri.parse(it.uri) }
+						.toPersistentList(),
+				),
 			)
+			onNavigateToInfo()
 		},
-		text = stringResource(R.string.new_episode_menu_add_pictures),
+		onBackPressed = {
+			onBackPressed()
+		},
+		onPermissionDenied = {
+			Toast.makeText(
+				context,
+				R.string.new_episode_pictures_permission_denied,
+				Toast.LENGTH_LONG,
+			).show()
+		},
 	)
 }

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/common/NewEpisodeConstant.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/common/NewEpisodeConstant.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.unit.dp
 
 object NewEpisodeConstant {
 	const val MAP_DEFAULT_ZOOM = 16.0
+	const val MAX_PHOTO_COUNTS = 4
 
 	val textFieldModifier = Modifier
 		.fillMaxWidth()

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/common/NewEpisodeConstant.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/common/NewEpisodeConstant.kt
@@ -18,16 +18,4 @@ object NewEpisodeConstant {
 		.fillMaxWidth()
 		.fillMaxHeight(0.3f)
 	val textFieldVerticalArrangement = Arrangement.spacedBy(12.dp)
-
-	private const val CATEGORY_NAME_EAT = "먹을 것"
-	private const val CATEGORY_NAME_SEE = "볼 것"
-	private const val CATEGORY_NAME_OTHER = "나머지"
-	private const val CATEGORY_VALUE_EAT = "EAT"
-	private const val CATEGORY_VALUE_SEE = "SEE"
-	private const val CATEGORY_VALUE_OTHER = "OTHER"
-	val categoryMap = mapOf(
-		CATEGORY_NAME_EAT to CATEGORY_VALUE_EAT,
-		CATEGORY_NAME_SEE to CATEGORY_VALUE_SEE,
-		CATEGORY_NAME_OTHER to CATEGORY_VALUE_OTHER,
-	)
 }

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/navigation/EpisodeNavigation.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/navigation/EpisodeNavigation.kt
@@ -68,6 +68,7 @@ fun NavGraphBuilder.addEpisodeNavGraph(
 			initialLatLng = initialLatLng(),
 			viewModel = hiltViewModel(getBackStackEntry()),
 			onNavigateToInfo = onNavigateToInfo,
+			onBackPressed = onPopBack,
 		)
 	}
 

--- a/feature/episode/src/main/res/values/strings.xml
+++ b/feature/episode/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
 	<string name="new_episode_menu_cancel">취소</string>
 
 	<string name="new_episode_pictures_empty">사진을 선택해 주세요.</string>
+	<string name="new_episode_pictures_permission_denied">사진에 대한 권한이 거부되었어요. 권한을 다시 요청해 주세요.</string>
 
 	<string name="new_episode_info_location">장소</string>
 	<string name="new_episode_info_group">그룹</string>


### PR DESCRIPTION
- closed #170 

## *📍 Work Description*

- 7aae400da47c31defdb6f5f5a135edf581c63040 (커스텀 포토피커로 교체)

## *📸 Screenshot*
<image width=270 src="https://github.com/user-attachments/assets/d4a33380-f5a7-4351-b81e-8a5d88685858"/>

## *📢 To Reviewers*
- 다시 한 번 @shinythinking 님께 감사드립니다~ 적용하기도 편하고 무엇보다 이쁘네요!

## ⏲️Time
    - 0.5 시간
