### PR TITLE
[FIX/#165]  Home 에피소드 못 불러오는 에러 해결

### DIFF
--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeViewModel.kt
@@ -120,13 +120,20 @@ class HomeViewModel @Inject constructor(
 		viewModelScope.launch {
 			try {
 				val cachedGroupId = userPreferenceDataStore.getRecentSelectedGroup().firstOrNull()
-					?: throw Exception()
+				if (cachedGroupId != null) {
+					intent {
+						copy(selectedGroupId = cachedGroupId)
+					}
 
-				intent {
-					copy(selectedGroupId = cachedGroupId)
+					selectGroup(cachedGroupId)
+				} else {
+					val userId =
+						userPreferenceDataStore.getUserId().firstOrNull() ?: throw Exception()
+					intent {
+						copy(selectedGroupId = userId)
+					}
+					selectGroup(userId)
 				}
-
-				selectGroup(cachedGroupId)
 			} catch (e: Exception) {
 				postSideEffect(HomeSideEffect.ShowToast(R.string.error_load_episodes))
 			}


### PR DESCRIPTION
- closed #165 

## *📍 Work Description*
- 캐싱된 그룹 id 가져오지 못할 때 유저 id 활용


## *📢 To Reviewers*
- 캐싱하고 바로 가져오는게 딜레이가 있나 봅니다.

## ⏲️Time

    - 0.5 h
