### PR TITLE
[REFACTOR/#177] 에피소드 생성 화면 중 취소 버튼 클릭시 Dialog 표시하도록 변경

### DIFF
--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/ClearDialog.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/ClearDialog.kt
@@ -1,0 +1,20 @@
+package com.boostcamp.mapisode.episode
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.boostcamp.mapisode.designsystem.compose.MapisodeDialog
+
+@Composable
+internal fun ClearDialog(
+	onResultRequest: (Boolean) -> Unit,
+	onDismissRequest: () -> Unit,
+) {
+	MapisodeDialog(
+		onResultRequest = onResultRequest,
+		onDismissRequest = onDismissRequest,
+		titleText = stringResource(R.string.new_episode_clear_dialog_title),
+		contentText = stringResource(R.string.new_episode_clear_dialog_content),
+		cancelText = stringResource(R.string.new_episode_clear_dialog_cancel),
+		confirmText = stringResource(R.string.new_episode_clear_dialog_confirm),
+	)
+}

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeContentScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeContentScreen.kt
@@ -59,6 +59,7 @@ internal fun NewEpisodeContentScreen(
 		mutableStateOf(TextFieldValue(uiState.episodeContent.description))
 	}
 	var isLoading by remember { mutableStateOf(false) }
+	var showClearDialog by rememberSaveable { mutableStateOf(false) }
 
 	LaunchedEffect(Unit) {
 		viewModel.sideEffect.collect { sideEffect ->
@@ -79,6 +80,20 @@ internal fun NewEpisodeContentScreen(
 		}
 	}
 
+	if (showClearDialog) {
+		ClearDialog(
+			onResultRequest = { result ->
+				if (result) {
+					viewModel.onIntent(NewEpisodeIntent.ClearEpisode)
+					onPopBackToMain()
+				}
+			},
+			onDismissRequest = {
+				showClearDialog = false
+			},
+		)
+	}
+
 	MapisodeScaffold(
 		topBar = {
 			NewEpisodeTopBar(
@@ -86,8 +101,7 @@ internal fun NewEpisodeContentScreen(
 					onPopBack()
 				},
 				onClickClear = {
-					viewModel.onIntent(NewEpisodeIntent.ClearEpisode)
-					onPopBackToMain()
+					showClearDialog = true
 				},
 			)
 		},

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeInfoScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/NewEpisodeInfoScreen.kt
@@ -58,9 +58,24 @@ internal fun NewEpisodeInfoScreen(
 	}
 	var showDatePickerDialog by remember { mutableStateOf(false) }
 	val datePickerState = rememberDatePickerState()
+	var showClearDialog by rememberSaveable { mutableStateOf(false) }
 
 	LaunchedEffect(Unit) {
 		viewModel.onIntent(NewEpisodeIntent.LoadMyGroups)
+	}
+
+	if (showClearDialog) {
+		ClearDialog(
+			onResultRequest = { result ->
+				if (result) {
+					viewModel.onIntent(NewEpisodeIntent.ClearEpisode)
+					onPopBackToMain()
+				}
+			},
+			onDismissRequest = {
+				showClearDialog = false
+			},
+		)
 	}
 
 	MapisodeScaffold(
@@ -70,8 +85,7 @@ internal fun NewEpisodeInfoScreen(
 					onPopBack()
 				},
 				onClickClear = {
-					viewModel.onIntent(NewEpisodeIntent.ClearEpisode)
-					onPopBackToMain()
+					showClearDialog = true
 				},
 			)
 		},

--- a/feature/episode/src/main/res/values/strings.xml
+++ b/feature/episode/src/main/res/values/strings.xml
@@ -9,6 +9,11 @@
 	<string name="new_episode_pictures_empty">사진을 선택해 주세요.</string>
 	<string name="new_episode_pictures_permission_denied">사진에 대한 권한이 거부되었어요. 권한을 다시 요청해 주세요.</string>
 
+	<string name="new_episode_clear_dialog_title">에피소드 작성 취소</string>
+	<string name="new_episode_clear_dialog_content">현재 작성한 정보가 사라져요. 정말로 취소하시겠어요?</string>
+	<string name="new_episode_clear_dialog_confirm">네</string>
+	<string name="new_episode_clear_dialog_cancel">아니오</string>
+
 	<string name="new_episode_info_location">장소</string>
 	<string name="new_episode_info_group">그룹</string>
 	<string name="new_episode_info_category">카테고리</string>


### PR DESCRIPTION
- closed #177 

## *📍 Work Description*
- 3464973d3fde30586ed2e856bdfe29ad55fe6506 에피소드 생성 화면 중 취소 버튼 클릭시 Dialog 표시하도록 변경

## *📸 Screenshot*
[episode6.webm](https://github.com/user-attachments/assets/fd1571e9-7c02-4d1f-80c2-6cba2f826201)

## *📢 To Reviewers*
- "에피소드를 불러오는 데 실패하였습니다." 는 메시지는 버그가 아니므로 무시해주셔도 됩니다! (제 로그인 문제)

## ⏲️Time
    - 0.5시간
