### PR TITLE
[FIX/#174] Group / 포토피커 적용

### DIFF
--- a/data/mygroup/build.gradle.kts
+++ b/data/mygroup/build.gradle.kts
@@ -12,4 +12,5 @@ dependencies {
 	implementation(projects.core.firebase)
 	implementation(platform(libs.firebase.bom))
 	implementation(libs.firebase.firestore)
+	implementation(libs.firebase.storage)
 }

--- a/domain/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepository.kt
+++ b/domain/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/GroupRepository.kt
@@ -12,7 +12,7 @@ interface GroupRepository {
 	suspend fun issueInvitationCode(groupId: String): String
 	suspend fun leaveGroup(userId: String, groupId: String)
 	suspend fun createGroup(groupModel: GroupModel)
-	suspend fun updateGroup(groupId: String, groupModel: GroupModel)
+	suspend fun updateGroup(groupModel: GroupModel)
 	suspend fun deleteGroup(groupId: String)
 
 	suspend fun getUserInfoByUserId(userId: String): GroupMemberModel

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupCreationIntent.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupCreationIntent.kt
@@ -10,7 +10,6 @@ sealed class GroupCreationIntent : UiIntent {
 	data class OnGroupCreationClick(val title: String, val content: String, val imageUrl: String) :
 		GroupCreationIntent()
 
-	data object OnGroupCreationError : GroupCreationIntent()
 	data object OnPhotoPickerClick : GroupCreationIntent()
 	data class OnGroupImageSelect(val imageUrl: String) : GroupCreationIntent()
 	data object OnBackToGroupCreation : GroupCreationIntent()

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupCreationIntent.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupCreationIntent.kt
@@ -5,8 +5,12 @@ import com.boostcamp.mapisode.ui.base.UiIntent
 
 @Immutable
 sealed class GroupCreationIntent : UiIntent {
+	data object Initialize: GroupCreationIntent()
 	data object OnBackClick : GroupCreationIntent()
 	data class OnGroupCreationClick(val title: String, val content: String, val imageUrl: String) :
 		GroupCreationIntent()
 	data object OnGroupCreationError : GroupCreationIntent()
+	data object OnPhotoPickerClick : GroupCreationIntent()
+	data class OnGroupImageSelect(val imageUrl: String) : GroupCreationIntent()
+	data object OnBackToGroupCreation : GroupCreationIntent()
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupCreationIntent.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupCreationIntent.kt
@@ -5,10 +5,11 @@ import com.boostcamp.mapisode.ui.base.UiIntent
 
 @Immutable
 sealed class GroupCreationIntent : UiIntent {
-	data object Initialize: GroupCreationIntent()
+	data object Initialize : GroupCreationIntent()
 	data object OnBackClick : GroupCreationIntent()
 	data class OnGroupCreationClick(val title: String, val content: String, val imageUrl: String) :
 		GroupCreationIntent()
+
 	data object OnGroupCreationError : GroupCreationIntent()
 	data object OnPhotoPickerClick : GroupCreationIntent()
 	data class OnGroupImageSelect(val imageUrl: String) : GroupCreationIntent()

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupEditIntent.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/intent/GroupEditIntent.kt
@@ -5,8 +5,12 @@ import com.boostcamp.mapisode.ui.base.UiIntent
 
 @Immutable
 sealed class GroupEditIntent : UiIntent {
-	data class LoadGroups(val groupId: String) : GroupEditIntent()
+	data class Initialize(val groupId: String) : GroupEditIntent()
 	data object OnBackClick : GroupEditIntent()
 	data class OnGroupEditClick(val title: String, val content: String, val imageUrl: String) :
 		GroupEditIntent()
+	data object OnPhotoPickerClick : GroupEditIntent()
+	data class OnGroupImageSelect(val imageUrl: String) : GroupEditIntent()
+	data object OnBackToGroupCreation : GroupEditIntent()
+	data object DenyPhotoPermission : GroupEditIntent()
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/model/GroupCreationModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/model/GroupCreationModel.kt
@@ -1,0 +1,39 @@
+package com.boostcamp.mapisode.mygroup.model
+
+import androidx.compose.runtime.Immutable
+import com.boostcamp.mapisode.model.GroupModel
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
+import java.util.Date
+
+@Immutable
+data class GroupCreationModel(
+	val id: String = "",
+	val adminUser: String = "",
+	val createdAt: Date = Date(),
+	val description: String = "",
+	val imageUrl: String = "",
+	val name: String = "",
+	val members: PersistentList<String> = persistentListOf(),
+) {
+	fun toGroupModel(): GroupModel = GroupModel(
+		id = id,
+		adminUser = adminUser,
+		createdAt = createdAt,
+		description = description,
+		imageUrl = imageUrl,
+		name = name,
+		members = members,
+	)
+}
+
+fun GroupModel.toGroupCreationModel(): GroupCreationModel = GroupCreationModel(
+	id = id,
+	adminUser = adminUser,
+	createdAt = createdAt,
+	description = description,
+	imageUrl = imageUrl,
+	name = name,
+	members = members.toPersistentList(),
+)

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/model/GroupEditModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/model/GroupEditModel.kt
@@ -1,0 +1,39 @@
+package com.boostcamp.mapisode.mygroup.model
+
+import androidx.compose.runtime.Immutable
+import com.boostcamp.mapisode.model.GroupModel
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
+import java.util.Date
+
+@Immutable
+data class GroupEditModel(
+	val id: String = "",
+	val adminUser: String = "",
+	val createdAt: Date = Date(),
+	val description: String = "",
+	val imageUrl: String = "",
+	val name: String = "",
+	val members: PersistentList<String> = persistentListOf(),
+) {
+	fun toGroupModel(): GroupModel = GroupModel(
+		id = id,
+		adminUser = adminUser,
+		createdAt = createdAt,
+		description = description,
+		imageUrl = imageUrl,
+		name = name,
+		members = members,
+	)
+}
+
+fun GroupModel.toGroupEditModel(): GroupEditModel = GroupEditModel(
+	id = id,
+	adminUser = adminUser,
+	createdAt = createdAt,
+	description = description,
+	imageUrl = imageUrl,
+	name = name,
+	members = members.toPersistentList(),
+)

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupCreationScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupCreationScreen.kt
@@ -59,7 +59,7 @@ fun GroupCreationScreen(
 		initialValue = GroupCreationSideEffect.Idle,
 	).value
 
-	if(uiState.value.isInitializing) {
+	if (uiState.value.isInitializing) {
 		viewModel.onIntent(GroupCreationIntent.Initialize)
 	}
 
@@ -212,7 +212,8 @@ fun GroupCreationField(
 						AsyncImage(
 							model = profileUrl,
 							contentDescription = "그룹 이미지",
-							modifier = Modifier.fillMaxSize()
+							modifier = Modifier
+								.fillMaxSize()
 								.aspectRatio(1f),
 						)
 					}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupCreationScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupCreationScreen.kt
@@ -1,5 +1,6 @@
 package com.boostcamp.mapisode.mygroup.screen
 
+import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
@@ -24,6 +25,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -54,6 +56,7 @@ fun GroupCreationScreen(
 	onBackClick: () -> Unit,
 	viewModel: GroupCreationViewModel = hiltViewModel(),
 ) {
+	val context = LocalContext.current
 	val uiState = viewModel.uiState.collectAsStateWithLifecycle()
 	val effect = rememberFlowWithLifecycle(
 		flow = viewModel.sideEffect,
@@ -77,12 +80,10 @@ fun GroupCreationScreen(
 			is GroupCreationSideEffect.NavigateToGroupScreen -> {
 				onBackClick()
 			}
-		}
-	}
-
-	LaunchedEffect(Unit) {
-		if (uiState.value.isGroupEditError) {
-			viewModel.onIntent(GroupCreationIntent.OnGroupCreationError)
+			is GroupCreationSideEffect.ShowToast -> {
+				Toast.makeText(context, effect.messageResId, Toast.LENGTH_SHORT).show()
+			}
+			else -> {}
 		}
 	}
 

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupCreationScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupCreationScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -51,6 +52,7 @@ import com.boostcamp.mapisode.mygroup.sideeffect.GroupCreationSideEffect
 import com.boostcamp.mapisode.mygroup.sideeffect.rememberFlowWithLifecycle
 import com.boostcamp.mapisode.mygroup.viewmodel.GroupCreationViewModel
 import com.boostcamp.mapisode.ui.photopicker.MapisodePhotoPicker
+import com.boostcamp.mapisode.mygroup.R as S
 
 @Composable
 fun GroupCreationScreen(
@@ -58,21 +60,23 @@ fun GroupCreationScreen(
 	viewModel: GroupCreationViewModel = hiltViewModel(),
 ) {
 	val context = LocalContext.current
-	val uiState = viewModel.uiState.collectAsStateWithLifecycle()
+	val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 	val effect = rememberFlowWithLifecycle(
 		flow = viewModel.sideEffect,
 		initialValue = GroupCreationSideEffect.Idle,
 	).value
 
-	if (uiState.value.isInitializing) {
-		viewModel.onIntent(GroupCreationIntent.Initialize)
-	}
-
 	BackHandler {
-		if (uiState.value.isSelectingGroupImage) {
+		if (uiState.isSelectingGroupImage) {
 			viewModel.onIntent(GroupCreationIntent.OnBackToGroupCreation)
 		} else {
 			viewModel.onIntent(GroupCreationIntent.OnBackClick)
+		}
+	}
+
+	LaunchedEffect(Unit) {
+		if (!uiState.isInitializing) {
+			viewModel.onIntent(GroupCreationIntent.Initialize)
 		}
 	}
 
@@ -81,14 +85,16 @@ fun GroupCreationScreen(
 			is GroupCreationSideEffect.NavigateToGroupScreen -> {
 				onBackClick()
 			}
+
 			is GroupCreationSideEffect.ShowToast -> {
 				Toast.makeText(context, effect.messageResId, Toast.LENGTH_SHORT).show()
 			}
+
 			else -> {}
 		}
 	}
 
-	if (uiState.value.isSelectingGroupImage) {
+	if (uiState.isSelectingGroupImage) {
 		MapisodePhotoPicker(
 			numOfPhoto = 1,
 			onPhotoSelected = { photoList ->
@@ -106,7 +112,7 @@ fun GroupCreationScreen(
 		)
 	} else {
 		GroupCreationContent(
-			imageUrl = uiState.value.group.imageUrl,
+			imageUrl = uiState.group.imageUrl,
 			onBackClick = onBackClick,
 			onGroupEditClick = { title, content, imageUrl ->
 				viewModel.onIntent(
@@ -147,7 +153,7 @@ fun GroupCreationContent(
 		isNavigationBarPaddingExist = true,
 		topBar = {
 			TopAppBar(
-				title = "그룹 생성",
+				title = stringResource(S.string.group_creation_topbar_title),
 				navigationIcon = {
 					MapisodeIconButton(
 						onClick = {
@@ -204,7 +210,7 @@ fun GroupCreationField(
 			item {
 				Column {
 					MapisodeText(
-						text = "그룹 대표 이미지",
+						text = stringResource(S.string.group_creation_image_label),
 						style = MapisodeTheme.typography.titleMedium
 							.copy(fontWeight = FontWeight.SemiBold),
 					)
@@ -217,8 +223,8 @@ fun GroupCreationField(
 							.fillMaxWidth()
 							.aspectRatio(1f),
 						onClick = { onPhotoPickerClick() },
-						showImage = profileUrl == "",
-						text = "이미지를 선택하세요",
+						showImage = profileUrl.isEmpty(),
+						text = stringResource(S.string.group_creation_select_image_guide),
 					) {
 						AsyncImage(
 							model = profileUrl,
@@ -238,7 +244,7 @@ fun GroupCreationField(
 						.fillMaxWidth(),
 				) {
 					MapisodeText(
-						text = "이름",
+						text = stringResource(S.string.group_creation_name_label),
 						style = MapisodeTheme.typography.titleMedium
 							.copy(fontWeight = FontWeight.SemiBold),
 					)
@@ -261,7 +267,7 @@ fun GroupCreationField(
 						.fillMaxWidth(),
 				) {
 					MapisodeText(
-						text = "설명",
+						text = stringResource(S.string.group_creation_description_label),
 						style = MapisodeTheme.typography.titleMedium
 							.copy(fontWeight = FontWeight.SemiBold),
 					)
@@ -300,7 +306,7 @@ fun GroupCreationField(
 				onClick = {
 					onGroupEditClick(name, description, profileUrl)
 				},
-				text = "생성하기",
+				text = stringResource(S.string.group_creation_create_button),
 				showRipple = true,
 			)
 		}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupCreationScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupCreationScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.font.FontWeight
@@ -68,7 +69,7 @@ fun GroupCreationScreen(
 	}
 
 	BackHandler {
-		if (uiState.value.isSelectingGroupImage ) {
+		if (uiState.value.isSelectingGroupImage) {
 			viewModel.onIntent(GroupCreationIntent.OnBackToGroupCreation)
 		} else {
 			viewModel.onIntent(GroupCreationIntent.OnBackClick)
@@ -216,7 +217,7 @@ fun GroupCreationField(
 							.fillMaxWidth()
 							.aspectRatio(1f),
 						onClick = { onPhotoPickerClick() },
-						showImage = false,
+						showImage = profileUrl == "",
 						text = "이미지를 선택하세요",
 					) {
 						AsyncImage(
@@ -225,6 +226,7 @@ fun GroupCreationField(
 							modifier = Modifier
 								.fillMaxSize()
 								.aspectRatio(1f),
+							contentScale = ContentScale.FillBounds,
 						)
 					}
 				}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupCreationScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupCreationScreen.kt
@@ -1,5 +1,6 @@
 package com.boostcamp.mapisode.mygroup.screen
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
@@ -61,6 +62,14 @@ fun GroupCreationScreen(
 
 	if (uiState.value.isInitializing) {
 		viewModel.onIntent(GroupCreationIntent.Initialize)
+	}
+
+	BackHandler {
+		if (uiState.value.isSelectingGroupImage ) {
+			viewModel.onIntent(GroupCreationIntent.OnBackToGroupCreation)
+		} else {
+			viewModel.onIntent(GroupCreationIntent.OnBackClick)
+		}
 	}
 
 	LaunchedEffect(effect) {

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupEditScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupEditScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.font.FontWeight
@@ -68,7 +69,7 @@ fun GroupEditScreen(
 	).value
 
 	BackHandler {
-		if (uiState.value.isSelectingGroupImage ) {
+		if (uiState.value.isSelectingGroupImage) {
 			viewModel.onIntent(GroupEditIntent.OnBackToGroupCreation)
 		} else {
 			viewModel.onIntent(GroupEditIntent.OnBackClick)
@@ -230,6 +231,7 @@ fun GroupEditField(
 							model = profileUrl,
 							contentDescription = "그룹 이미지",
 							modifier = Modifier.fillMaxSize(),
+							contentScale = ContentScale.FillBounds,
 						)
 					}
 				}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupEditScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupEditScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -54,6 +55,7 @@ import com.boostcamp.mapisode.mygroup.state.GroupEditState
 import com.boostcamp.mapisode.mygroup.viewmodel.GroupEditViewModel
 import com.boostcamp.mapisode.navigation.GroupRoute
 import com.boostcamp.mapisode.ui.photopicker.MapisodePhotoPicker
+import com.boostcamp.mapisode.mygroup.R as S
 
 @Composable
 fun GroupEditScreen(
@@ -62,14 +64,14 @@ fun GroupEditScreen(
 	viewModel: GroupEditViewModel = hiltViewModel(),
 ) {
 	val context = LocalContext.current
-	val uiState = viewModel.uiState.collectAsStateWithLifecycle()
+	val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 	val effect = rememberFlowWithLifecycle(
 		flow = viewModel.sideEffect,
 		initialValue = GroupEditSideEffect.Idle,
 	).value
 
 	BackHandler {
-		if (uiState.value.isSelectingGroupImage) {
+		if (uiState.isSelectingGroupImage) {
 			viewModel.onIntent(GroupEditIntent.OnBackToGroupCreation)
 		} else {
 			viewModel.onIntent(GroupEditIntent.OnBackClick)
@@ -77,7 +79,7 @@ fun GroupEditScreen(
 	}
 
 	LaunchedEffect(Unit) {
-		if (uiState.value.isInitializing) {
+		if (!uiState.isInitializing) {
 			viewModel.onIntent(GroupEditIntent.Initialize(edit.groupId))
 		}
 	}
@@ -87,6 +89,7 @@ fun GroupEditScreen(
 			is GroupEditSideEffect.NavigateToGroupDetailScreen -> {
 				onBackClick()
 			}
+
 			is GroupEditSideEffect.ShowToast -> {
 				Toast.makeText(context, effect.messageResId, Toast.LENGTH_SHORT).show()
 			}
@@ -95,7 +98,7 @@ fun GroupEditScreen(
 		}
 	}
 
-	if (uiState.value.isSelectingGroupImage) {
+	if (uiState.isSelectingGroupImage) {
 		MapisodePhotoPicker(
 			numOfPhoto = 1,
 			onPhotoSelected = { photoList ->
@@ -113,7 +116,7 @@ fun GroupEditScreen(
 		)
 	} else {
 		GroupEditContent(
-			uiState = uiState.value,
+			uiState = uiState,
 			onBackClick = onBackClick,
 			onGroupEditClick = { title, content, imageUrl ->
 				viewModel.onIntent(
@@ -154,7 +157,7 @@ fun GroupEditContent(
 		isNavigationBarPaddingExist = true,
 		topBar = {
 			TopAppBar(
-				title = "그룹 편집",
+				title = stringResource(S.string.group_edit_topbar_title),
 				navigationIcon = {
 					MapisodeIconButton(
 						onClick = {
@@ -211,7 +214,7 @@ fun GroupEditField(
 			item {
 				Column {
 					MapisodeText(
-						text = "그룹 대표 이미지",
+						text = stringResource(S.string.group_creation_image_label),
 						style = MapisodeTheme.typography.titleMedium
 							.copy(fontWeight = FontWeight.SemiBold),
 					)
@@ -225,7 +228,7 @@ fun GroupEditField(
 							.aspectRatio(1f),
 						onClick = { onPhotoPickerClick() },
 						showImage = false,
-						text = "이미지를 선택하세요",
+						text = stringResource(S.string.group_creation_select_image_guide),
 					) {
 						AsyncImage(
 							model = profileUrl,
@@ -243,7 +246,7 @@ fun GroupEditField(
 						.fillMaxWidth(),
 				) {
 					MapisodeText(
-						text = "이름",
+						text = stringResource(S.string.group_creation_name_label),
 						style = MapisodeTheme.typography.titleMedium
 							.copy(fontWeight = FontWeight.SemiBold),
 					)
@@ -266,7 +269,7 @@ fun GroupEditField(
 						.fillMaxWidth(),
 				) {
 					MapisodeText(
-						text = "설명",
+						text = stringResource(S.string.group_creation_description_label),
 						style = MapisodeTheme.typography.titleMedium
 							.copy(fontWeight = FontWeight.SemiBold),
 					)
@@ -305,7 +308,7 @@ fun GroupEditField(
 				onClick = {
 					onGroupEditClick(name, description, profileUrl)
 				},
-				text = "편집하기",
+				text = stringResource(S.string.group_edit_button),
 				showRipple = true,
 			)
 		}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupEditScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupEditScreen.kt
@@ -1,6 +1,7 @@
 package com.boostcamp.mapisode.mygroup.screen
 
 import android.widget.Toast
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
@@ -65,6 +66,14 @@ fun GroupEditScreen(
 		flow = viewModel.sideEffect,
 		initialValue = GroupEditSideEffect.Idle,
 	).value
+
+	BackHandler {
+		if (uiState.value.isSelectingGroupImage ) {
+			viewModel.onIntent(GroupEditIntent.OnBackToGroupCreation)
+		} else {
+			viewModel.onIntent(GroupEditIntent.OnBackClick)
+		}
+	}
 
 	LaunchedEffect(Unit) {
 		if (uiState.value.isInitializing) {

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/sideeffect/GroupCreationSideEffect.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/sideeffect/GroupCreationSideEffect.kt
@@ -5,7 +5,7 @@ import com.boostcamp.mapisode.ui.base.SideEffect
 
 @Immutable
 sealed class GroupCreationSideEffect : SideEffect {
-	data object Idle : GroupSideEffect()
+	data object Idle : GroupCreationSideEffect()
 	data class ShowToast(val messageResId: Int) : GroupCreationSideEffect()
 	data object NavigateToGroupScreen : GroupCreationSideEffect()
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/sideeffect/GroupEditSideEffect.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/sideeffect/GroupEditSideEffect.kt
@@ -5,7 +5,7 @@ import com.boostcamp.mapisode.ui.base.SideEffect
 
 @Immutable
 sealed class GroupEditSideEffect : SideEffect {
-	data object Idle : GroupSideEffect()
+	data object Idle : GroupEditSideEffect()
 	data class ShowToast(val messageResId: Int) : GroupEditSideEffect()
 	data object NavigateToGroupDetailScreen : GroupEditSideEffect()
 }

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupCreationState.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupCreationState.kt
@@ -8,6 +8,5 @@ import com.boostcamp.mapisode.ui.base.UiState
 data class GroupCreationState(
 	val isInitializing: Boolean = true,
 	val isSelectingGroupImage: Boolean = false,
-	val isGroupEditError: Boolean = false,
 	val group: GroupCreationModel = GroupCreationModel(),
 ) : UiState

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupCreationState.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupCreationState.kt
@@ -6,7 +6,7 @@ import com.boostcamp.mapisode.ui.base.UiState
 
 @Immutable
 data class GroupCreationState(
-	val isInitializing: Boolean = true,
+	val isInitializing: Boolean = false,
 	val isSelectingGroupImage: Boolean = false,
 	val group: GroupCreationModel = GroupCreationModel(),
 ) : UiState

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupCreationState.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupCreationState.kt
@@ -1,7 +1,13 @@
 package com.boostcamp.mapisode.mygroup.state
 
 import androidx.compose.runtime.Immutable
+import com.boostcamp.mapisode.mygroup.model.GroupCreationModel
 import com.boostcamp.mapisode.ui.base.UiState
 
 @Immutable
-data class GroupCreationState(val isGroupEditError: Boolean = false) : UiState
+data class GroupCreationState(
+	val isInitializing: Boolean = true,
+	val isSelectingGroupImage: Boolean = false,
+	val isGroupEditError: Boolean = false,
+	val group: GroupCreationModel = GroupCreationModel(),
+) : UiState

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupEditState.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupEditState.kt
@@ -2,11 +2,13 @@ package com.boostcamp.mapisode.mygroup.state
 
 import androidx.compose.runtime.Immutable
 import com.boostcamp.mapisode.model.GroupModel
+import com.boostcamp.mapisode.mygroup.model.GroupCreationModel
 import com.boostcamp.mapisode.ui.base.UiState
 
 @Immutable
 data class GroupEditState(
 	val isInitializing: Boolean = true,
-	val isGroupEditError: Boolean = false,
-	val group: GroupModel? = null,
+	val isRetryingInitializing: Boolean = false,
+	val isSelectingGroupImage: Boolean = false,
+	val group: GroupCreationModel = GroupCreationModel(),
 ) : UiState

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupEditState.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupEditState.kt
@@ -1,7 +1,6 @@
 package com.boostcamp.mapisode.mygroup.state
 
 import androidx.compose.runtime.Immutable
-import com.boostcamp.mapisode.model.GroupModel
 import com.boostcamp.mapisode.mygroup.model.GroupCreationModel
 import com.boostcamp.mapisode.ui.base.UiState
 

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupEditState.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupEditState.kt
@@ -6,7 +6,7 @@ import com.boostcamp.mapisode.ui.base.UiState
 
 @Immutable
 data class GroupEditState(
-	val isInitializing: Boolean = true,
+	val isInitializing: Boolean = false,
 	val isSelectingGroupImage: Boolean = false,
 	val group: GroupCreationModel = GroupCreationModel(),
 ) : UiState

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupEditState.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/state/GroupEditState.kt
@@ -7,7 +7,6 @@ import com.boostcamp.mapisode.ui.base.UiState
 @Immutable
 data class GroupEditState(
 	val isInitializing: Boolean = true,
-	val isRetryingInitializing: Boolean = false,
 	val isSelectingGroupImage: Boolean = false,
 	val group: GroupCreationModel = GroupCreationModel(),
 ) : UiState

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupCreationViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupCreationViewModel.kt
@@ -61,7 +61,7 @@ class GroupCreationViewModel @Inject constructor(
 			userId["userId"] = userPreferenceDataStore.getUserId().first() ?: ""
 			intent {
 				copy(
-					isInitializing = false,
+					isInitializing = true,
 					group = group.copy(
 						id = UUID.randomUUID().toString().replace("-", ""),
 						adminUser = userId["userId"] ?: "",

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupEditViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupEditViewModel.kt
@@ -78,11 +78,17 @@ class GroupEditViewModel @Inject constructor(private val groupRepository: GroupR
 		viewModelScope.launch {
 			try {
 				if (title.length !in 2..24) {
-					postSideEffect(GroupEditSideEffect.ShowToast(R.string.message_error_title_length))
+					postSideEffect(
+						GroupEditSideEffect.ShowToast(R.string.message_error_title_length),
+					)
 				} else if (content.isEmpty()) {
-					postSideEffect(GroupEditSideEffect.ShowToast(R.string.message_error_content_empty))
+					postSideEffect(
+						GroupEditSideEffect.ShowToast(R.string.message_error_content_empty),
+					)
 				} else if (imageUrl.isBlank()) {
-					postSideEffect(GroupEditSideEffect.ShowToast(R.string.message_error_image_url_blank))
+					postSideEffect(
+						GroupEditSideEffect.ShowToast(R.string.message_error_image_url_blank),
+					)
 				} else {
 					intent {
 						copy(

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupEditViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupEditViewModel.kt
@@ -53,7 +53,7 @@ class GroupEditViewModel @Inject constructor(private val groupRepository: GroupR
 				val group = groupRepository.getGroupByGroupId(groupId).toGroupCreationModel()
 				intent {
 					copy(
-						isInitializing = false,
+						isInitializing = true,
 						group = group,
 					)
 				}

--- a/feature/mygroup/src/main/res/values/strings.xml
+++ b/feature/mygroup/src/main/res/values/strings.xml
@@ -34,6 +34,9 @@
 	<string name="overview_date">"작성일 :&#32;"</string>
 	<string name="overview_content">"내용 :&#32;"</string>
 	<string name="message_error_edit_input">입력 조건을 만족해주세요.</string>
+	<string name="message_error_title_length">제목은 2자 이상 24자 이하로 입력해주세요.</string>
+	<string name="message_error_content_empty">내용은 비울 수 없습니다.</string>
+	<string name="message_error_image_url_blank">이미지를 비울 수 없습니다.</string>
 	<string name="message_error_edit_group">그룹 수정에 실패했습니다.</string>
 	<string name="message_error_creation_group_success">그룹 생성에 성공했습니다.</string>
 	<string name="message_error_creation_group_fail">그룹 생성에 실패했습니다.</string>
@@ -42,4 +45,5 @@
 	<string name="content_episode_count">에피소드 게시수</string>
 	<string name="content_number_count">개</string>
 	<string name="content_recent_episode_upload">"최근 업로드 :&#32;"</string>
+	<string name="message_error_permission_denied">권한이 없습니다.</string>
 </resources>

--- a/feature/mygroup/src/main/res/values/strings.xml
+++ b/feature/mygroup/src/main/res/values/strings.xml
@@ -46,4 +46,12 @@
 	<string name="content_number_count">개</string>
 	<string name="content_recent_episode_upload">"최근 업로드 :&#32;"</string>
 	<string name="message_error_permission_denied">권한이 없습니다.</string>
+    <string name="group_creation_topbar_title">그룹 생성</string>
+	<string name="group_creation_image_label">그룹 대표 이미지</string>
+	<string name="group_creation_select_image_guide">이미지를 선택하세요</string>
+	<string name="group_creation_name_label">이름</string>
+	<string name="group_creation_description_label">설명</string>
+	<string name="group_creation_create_button">생성하기</string>
+	<string name="group_edit_topbar_title">그룹 편집</string>
+	<string name="group_edit_button">편집하기</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -79,7 +79,6 @@ junit = "4.13.2"
 androidx-junit = "1.2.1"
 espresso-core = "3.6.1"
 material = "1.12.0"
-firebaseStorage = "21.0.1"
 
 [libraries]
 # Androidx Core
@@ -173,7 +172,6 @@ compose-compiler-gradlePlugin = { group = "org.jetbrains.kotlin", name = "compos
 ksp-gradlePlugin = { group = "com.google.devtools.ksp", name = "com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
 hilt-gradlePlugin = { group = "com.google.dagger", name = "hilt-android-gradle-plugin", version.ref = "hilt" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
-google-firebase-storage = { group = "com.google.firebase", name = "firebase-storage", version.ref = "firebaseStorage" }
 
 [bundles]
 # AndroidX Core Libraries

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -79,6 +79,7 @@ junit = "4.13.2"
 androidx-junit = "1.2.1"
 espresso-core = "3.6.1"
 material = "1.12.0"
+firebaseStorage = "21.0.1"
 
 [libraries]
 # Androidx Core
@@ -172,6 +173,7 @@ compose-compiler-gradlePlugin = { group = "org.jetbrains.kotlin", name = "compos
 ksp-gradlePlugin = { group = "com.google.devtools.ksp", name = "com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
 hilt-gradlePlugin = { group = "com.google.dagger", name = "hilt-android-gradle-plugin", version.ref = "hilt" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
+google-firebase-storage = { group = "com.google.firebase", name = "firebase-storage", version.ref = "firebaseStorage" }
 
 [bundles]
 # AndroidX Core Libraries


### PR DESCRIPTION
- closed #174

## *📍 Work Description*

- 포토피커 적용
- firestore 함수 수정
- 백핸들러 설정
- 예외별 토스트 메세지 처리
- 이미지 규격 설정

## *📸 Screenshot*


https://github.com/user-attachments/assets/e02563db-b72f-4f1b-945a-e0032b5f2d9d


## *📢 To Reviewers*
- 사인님 커스텀 포토피커를 그룹 생성화면과 그룹 편집 화면에 적용했습니다.
- firestore에 그룹 collection에 저장하기 전에 firebase storage에 이미지를 저장/편집을 한 후에 이미지 저장 주소를 포함하여 그룹 collection에 저장합니다.
- 백핸들러를 통해 디바이스 뒤로가기 버튼을 누를 때 그룹 생성/편집 화면으로 돌아옵니다.
- 이미지, 제목, 설명 조건을 충족시키지 않고 생성을 하면 토스트 메세지로 경고를 띄웁니다.
- 모든 사진 사이즈는 coil의 contentSalce 속성에 ContentScale.FillBounds 를 대입하여 모든 사진 영역이 경계에 꽉 차서 전부 보이도록 했습니다.

## ⏲️Time

    - 5시간
