### PR TITLE
[FEAT/#189] Designsystem / datepicker 생성

### DIFF
--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/datepicker/MapisodeDateBox.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/datepicker/MapisodeDateBox.kt
@@ -1,0 +1,57 @@
+package com.boostcamp.mapisode.designsystem.compose.datepicker
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.boostcamp.mapisode.designsystem.compose.MapisodeText
+import com.boostcamp.mapisode.designsystem.compose.TextAlignment
+import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
+import java.time.LocalDate
+
+@Composable
+fun MapisodeDateBox(
+	date: LocalDate,
+	isSelected: Boolean,
+	isSunday: Boolean,
+	onSelect: () -> Unit,
+) {
+	Box(
+		modifier = Modifier
+			.size(36.dp)
+			.clip(RoundedCornerShape(4.dp))
+			.background(
+				if (isSelected) {
+					MapisodeTheme.colorScheme.dateBoxSelectedBackground
+				} else {
+					Color.Transparent
+				},
+			)
+			.clickable(onClick = onSelect),
+		contentAlignment = Alignment.Center,
+	) {
+		MapisodeText(
+			text = date.dayOfMonth.toString(),
+			color = when {
+				isSelected -> MapisodeTheme.colorScheme.dateBoxSelectedText
+				date == LocalDate.now() -> MapisodeTheme.colorScheme.dateBoxTodayText
+				isSunday -> MapisodeTheme.colorScheme.dateBoxSundayText
+				else -> MapisodeTheme.colorScheme.dateBoxUnselectedText
+			},
+			modifier = Modifier
+				.fillMaxWidth()
+				.clip(RoundedCornerShape(4.dp))
+				.padding(vertical = 8.dp),
+			textAlignment = TextAlignment.Center,
+		)
+	}
+}

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/datepicker/MapisodeDatePicker.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/datepicker/MapisodeDatePicker.kt
@@ -1,0 +1,102 @@
+package com.boostcamp.mapisode.designsystem.compose.datepicker
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.compose.ui.window.SecureFlagPolicy
+import com.boostcamp.mapisode.designsystem.compose.MapisodeText
+import com.boostcamp.mapisode.designsystem.compose.Surface
+import com.boostcamp.mapisode.designsystem.compose.ripple.MapisodeRippleBIndication
+import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
+import java.time.LocalDate
+
+@Composable
+fun MapisodeDatePicker(
+	onDismissRequest: () -> Unit,
+	onDateSelected: (LocalDate) -> Unit,
+	initialDate: LocalDate = LocalDate.now(),
+) {
+	var selectedDate by remember { mutableStateOf(initialDate) }
+
+	Dialog(
+		onDismissRequest = {
+			onDismissRequest()
+		},
+		properties = DialogProperties(
+			dismissOnBackPress = true,
+			dismissOnClickOutside = false,
+			securePolicy = SecureFlagPolicy.Inherit,
+		),
+	) {
+		Surface(
+			color = MapisodeTheme.colorScheme.datePickerBackground,
+			rounding = 8.dp,
+		) {
+			Column(
+				modifier = Modifier.padding(16.dp),
+				horizontalAlignment = Alignment.CenterHorizontally,
+				verticalArrangement = Arrangement.Center,
+			) {
+				MapisodeDateSelector(
+					initialDate = initialDate,
+					onDateSelected = {
+						selectedDate = it
+					},
+				)
+
+				Row(
+					modifier = Modifier.fillMaxWidth(),
+					horizontalArrangement = Arrangement.End,
+				) {
+					MapisodeText(
+						text = "취소",
+						modifier = Modifier.clickable(
+							enabled = true,
+							onClick = {
+								onDismissRequest()
+							},
+							indication = MapisodeRippleBIndication,
+							interactionSource = remember { MutableInteractionSource() },
+						),
+						color = MapisodeTheme.colorScheme.dialogDismiss,
+						style = MapisodeTheme.typography.labelLarge,
+					)
+					Spacer(modifier = Modifier.width(24.dp))
+					MapisodeText(
+						text = "선택",
+						modifier = Modifier.clickable(
+							enabled = true,
+							onClick = {
+								onDateSelected(selectedDate)
+								onDismissRequest()
+							},
+							indication = MapisodeRippleBIndication,
+							interactionSource = remember { MutableInteractionSource() },
+						),
+						color = MapisodeTheme.colorScheme.dialogConfirm,
+						style = MapisodeTheme.typography.labelLarge,
+					)
+				}
+
+				Spacer(modifier = Modifier.height(16.dp))
+			}
+		}
+	}
+}

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/datepicker/MapisodeDatePicker.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/datepicker/MapisodeDatePicker.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -37,7 +38,7 @@ fun MapisodeDatePicker(
 	onDateSelected: (LocalDate) -> Unit,
 	initialDate: LocalDate = LocalDate.now(),
 ) {
-	var selectedDate by remember { mutableStateOf(initialDate) }
+	var selectedDate by rememberSaveable { mutableStateOf(initialDate) }
 
 	Dialog(
 		onDismissRequest = {
@@ -60,7 +61,7 @@ fun MapisodeDatePicker(
 				horizontalAlignment = Alignment.CenterHorizontally,
 			) {
 				MapisodeDateSelector(
-					initialDate = initialDate,
+					initialDate = selectedDate,
 					onDateSelected = {
 						selectedDate = it
 					},

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/datepicker/MapisodeDatePicker.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/datepicker/MapisodeDatePicker.kt
@@ -44,17 +44,16 @@ fun MapisodeDatePicker(
 			onDismissRequest()
 		},
 		properties = DialogProperties(
-			dismissOnBackPress = true,
-			dismissOnClickOutside = false,
 			securePolicy = SecureFlagPolicy.Inherit,
 		),
 	) {
 		Box(
 			modifier = Modifier
-				.height(380.dp)
+				.height(360.dp)
 				.clip(RoundedCornerShape(16.dp))
 				.background(MapisodeTheme.colorScheme.datePickerBackground)
-				.padding(20.dp),
+				.padding(horizontal = 20.dp, vertical = 10.dp)
+				.padding(bottom = 10.dp),
 		) {
 			Column(
 				modifier = Modifier.fillMaxSize(),
@@ -102,9 +101,7 @@ fun MapisodeDatePicker(
 					color = MapisodeTheme.colorScheme.datePickerRequest,
 					style = MapisodeTheme.typography.labelLarge,
 				)
-				Spacer(modifier = Modifier.width(8.dp))
 			}
-			Spacer(modifier = Modifier.height(8.dp))
 		}
 	}
 }

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/datepicker/MapisodeDatePicker.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/datepicker/MapisodeDatePicker.kt
@@ -1,15 +1,19 @@
 package com.boostcamp.mapisode.designsystem.compose.datepicker
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -17,12 +21,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.window.SecureFlagPolicy
 import com.boostcamp.mapisode.designsystem.compose.MapisodeText
-import com.boostcamp.mapisode.designsystem.compose.Surface
 import com.boostcamp.mapisode.designsystem.compose.ripple.MapisodeRippleBIndication
 import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 import java.time.LocalDate
@@ -45,14 +49,16 @@ fun MapisodeDatePicker(
 			securePolicy = SecureFlagPolicy.Inherit,
 		),
 	) {
-		Surface(
-			color = MapisodeTheme.colorScheme.datePickerBackground,
-			rounding = 8.dp,
+		Box(
+			modifier = Modifier
+				.height(380.dp)
+				.clip(RoundedCornerShape(16.dp))
+				.background(MapisodeTheme.colorScheme.datePickerBackground)
+				.padding(20.dp),
 		) {
 			Column(
-				modifier = Modifier.padding(16.dp),
+				modifier = Modifier.fillMaxSize(),
 				horizontalAlignment = Alignment.CenterHorizontally,
-				verticalArrangement = Arrangement.Center,
 			) {
 				MapisodeDateSelector(
 					initialDate = initialDate,
@@ -60,43 +66,45 @@ fun MapisodeDatePicker(
 						selectedDate = it
 					},
 				)
-
-				Row(
-					modifier = Modifier.fillMaxWidth(),
-					horizontalArrangement = Arrangement.End,
-				) {
-					MapisodeText(
-						text = "취소",
-						modifier = Modifier.clickable(
-							enabled = true,
-							onClick = {
-								onDismissRequest()
-							},
-							indication = MapisodeRippleBIndication,
-							interactionSource = remember { MutableInteractionSource() },
-						),
-						color = MapisodeTheme.colorScheme.dialogDismiss,
-						style = MapisodeTheme.typography.labelLarge,
-					)
-					Spacer(modifier = Modifier.width(24.dp))
-					MapisodeText(
-						text = "선택",
-						modifier = Modifier.clickable(
-							enabled = true,
-							onClick = {
-								onDateSelected(selectedDate)
-								onDismissRequest()
-							},
-							indication = MapisodeRippleBIndication,
-							interactionSource = remember { MutableInteractionSource() },
-						),
-						color = MapisodeTheme.colorScheme.dialogConfirm,
-						style = MapisodeTheme.typography.labelLarge,
-					)
-				}
-
-				Spacer(modifier = Modifier.height(16.dp))
 			}
+
+			Row(
+				modifier = Modifier
+					.fillMaxWidth()
+					.align(Alignment.BottomEnd),
+				horizontalArrangement = Arrangement.End,
+			) {
+				MapisodeText(
+					text = "취소",
+					modifier = Modifier.clickable(
+						enabled = true,
+						onClick = {
+							onDismissRequest()
+						},
+						indication = MapisodeRippleBIndication,
+						interactionSource = remember { MutableInteractionSource() },
+					),
+					color = MapisodeTheme.colorScheme.datePickerDismiss,
+					style = MapisodeTheme.typography.labelLarge,
+				)
+				Spacer(modifier = Modifier.width(24.dp))
+				MapisodeText(
+					text = "선택",
+					modifier = Modifier.clickable(
+						enabled = true,
+						onClick = {
+							onDateSelected(selectedDate)
+							onDismissRequest()
+						},
+						indication = MapisodeRippleBIndication,
+						interactionSource = remember { MutableInteractionSource() },
+					),
+					color = MapisodeTheme.colorScheme.datePickerRequest,
+					style = MapisodeTheme.typography.labelLarge,
+				)
+				Spacer(modifier = Modifier.width(8.dp))
+			}
+			Spacer(modifier = Modifier.height(8.dp))
 		}
 	}
 }

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/datepicker/MapisodeDatePicker.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/datepicker/MapisodeDatePicker.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -50,14 +49,12 @@ fun MapisodeDatePicker(
 	) {
 		Box(
 			modifier = Modifier
-				.height(360.dp)
+				.height(340.dp)
 				.clip(RoundedCornerShape(16.dp))
 				.background(MapisodeTheme.colorScheme.datePickerBackground)
-				.padding(horizontal = 20.dp, vertical = 10.dp)
-				.padding(bottom = 10.dp),
+				.padding(vertical = 10.dp, horizontal = 20.dp),
 		) {
 			Column(
-				modifier = Modifier.fillMaxSize(),
 				horizontalAlignment = Alignment.CenterHorizontally,
 			) {
 				MapisodeDateSelector(
@@ -71,7 +68,8 @@ fun MapisodeDatePicker(
 			Row(
 				modifier = Modifier
 					.fillMaxWidth()
-					.align(Alignment.BottomEnd),
+					.align(Alignment.BottomEnd)
+					.padding(end = 10.dp, bottom = 10.dp),
 				horizontalArrangement = Arrangement.End,
 			) {
 				MapisodeText(

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/datepicker/MapisodeDateSelector.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/datepicker/MapisodeDateSelector.kt
@@ -1,0 +1,99 @@
+package com.boostcamp.mapisode.designsystem.compose.datepicker
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.boostcamp.mapisode.designsystem.R
+import com.boostcamp.mapisode.designsystem.compose.IconSize
+import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
+import com.boostcamp.mapisode.designsystem.compose.MapisodeIconButton
+import com.boostcamp.mapisode.designsystem.compose.MapisodeText
+import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
+import kotlinx.collections.immutable.persistentListOf
+import java.time.LocalDate
+import java.time.YearMonth
+
+@Composable
+fun MapisodeDateSelector(
+	initialDate: LocalDate = LocalDate.now(),
+	onDateSelected: (LocalDate) -> Unit,
+) {
+	var selectedMonth by remember { mutableStateOf(YearMonth.from(initialDate)) }
+	var selectedDate by remember { mutableStateOf(initialDate) }
+
+	Column(
+		modifier = Modifier
+			.fillMaxWidth()
+			.padding(16.dp),
+	) {
+		Row(
+			modifier = Modifier.fillMaxWidth(),
+			horizontalArrangement = Arrangement.SpaceBetween,
+			verticalAlignment = Alignment.CenterVertically,
+		) {
+			MapisodeIconButton(
+				onClick = {
+					selectedMonth = selectedMonth.minusMonths(1)
+				},
+			) {
+				MapisodeIcon(
+					id = R.drawable.ic_arrow_back_ios,
+					iconSize = IconSize.Small,
+				)
+			}
+
+			MapisodeText(
+				text = "${selectedMonth.month} ${selectedMonth.year}",
+			)
+
+			MapisodeIconButton(
+				onClick = {
+					selectedMonth = selectedMonth.plusMonths(1)
+				},
+			) {
+				MapisodeIcon(
+					id = R.drawable.ic_arrow_forward_ios,
+					iconSize = IconSize.Small,
+				)
+			}
+		}
+
+		Spacer(modifier = Modifier.height(8.dp))
+
+		Row(
+			modifier = Modifier.fillMaxWidth(),
+			horizontalArrangement = Arrangement.SpaceEvenly,
+		) {
+			persistentListOf("월", "화", "수", "목", "금", "토", "일").forEach { day ->
+				MapisodeText(
+					text = day,
+					style = MapisodeTheme.typography.labelMedium,
+					color = MapisodeTheme.colorScheme.dayOfWeekText,
+				)
+			}
+		}
+
+		Spacer(modifier = Modifier.height(8.dp))
+
+		MapisodeDateTable(
+			selectedMonth = selectedMonth,
+			selectedDate = selectedDate,
+			onDateSelect = {
+				selectedDate = it
+				onDateSelected(it)
+			},
+		)
+	}
+}

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/datepicker/MapisodeDateSelector.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/datepicker/MapisodeDateSelector.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.boostcamp.mapisode.designsystem.R
 import com.boostcamp.mapisode.designsystem.compose.IconSize
@@ -35,8 +36,7 @@ fun MapisodeDateSelector(
 
 	Column(
 		modifier = Modifier
-			.fillMaxWidth()
-			.padding(16.dp),
+			.fillMaxWidth(),
 	) {
 		Row(
 			modifier = Modifier.fillMaxWidth(),
@@ -47,6 +47,7 @@ fun MapisodeDateSelector(
 				onClick = {
 					selectedMonth = selectedMonth.minusMonths(1)
 				},
+				backgroundColor = Color.Transparent,
 			) {
 				MapisodeIcon(
 					id = R.drawable.ic_arrow_back_ios,
@@ -56,12 +57,14 @@ fun MapisodeDateSelector(
 
 			MapisodeText(
 				text = "${selectedMonth.month} ${selectedMonth.year}",
+				style = MapisodeTheme.typography.labelLarge,
 			)
 
 			MapisodeIconButton(
 				onClick = {
 					selectedMonth = selectedMonth.plusMonths(1)
 				},
+				backgroundColor = Color.Transparent,
 			) {
 				MapisodeIcon(
 					id = R.drawable.ic_arrow_forward_ios,
@@ -73,13 +76,13 @@ fun MapisodeDateSelector(
 		Spacer(modifier = Modifier.height(8.dp))
 
 		Row(
-			modifier = Modifier.fillMaxWidth(),
-			horizontalArrangement = Arrangement.SpaceEvenly,
+			modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+			horizontalArrangement = Arrangement.SpaceBetween,
 		) {
 			persistentListOf("월", "화", "수", "목", "금", "토", "일").forEach { day ->
 				MapisodeText(
 					text = day,
-					style = MapisodeTheme.typography.labelMedium,
+					style = MapisodeTheme.typography.labelLarge,
 					color = MapisodeTheme.colorScheme.dayOfWeekText,
 				)
 			}

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/datepicker/MapisodeDateTable.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/datepicker/MapisodeDateTable.kt
@@ -16,7 +16,7 @@ import java.time.YearMonth
 fun MapisodeDateTable(
 	selectedMonth: YearMonth,
 	selectedDate: LocalDate,
-	onDateSelect: (LocalDate) -> Unit
+	onDateSelect: (LocalDate) -> Unit,
 ) {
 	// 해당 월의 일 수
 	val daysInMonth = selectedMonth.lengthOfMonth()
@@ -37,7 +37,7 @@ fun MapisodeDateTable(
 
 	LazyVerticalGrid(
 		columns = GridCells.Fixed(7),
-		contentPadding = PaddingValues(vertical = 8.dp)
+		contentPadding = PaddingValues(vertical = 8.dp),
 	) {
 		items(finalDateList) { date ->
 			date?.let {
@@ -45,7 +45,7 @@ fun MapisodeDateTable(
 					date = it,
 					isSelected = it == selectedDate,
 					isSunday = it.dayOfWeek.value == 7,
-					onSelect = { onDateSelect(it) }
+					onSelect = { onDateSelect(it) },
 				)
 			} ?: Spacer(modifier = Modifier.size(36.dp))
 		}

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/datepicker/MapisodeDateTable.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/datepicker/MapisodeDateTable.kt
@@ -1,0 +1,53 @@
+package com.boostcamp.mapisode.designsystem.compose.datepicker
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import java.time.LocalDate
+import java.time.YearMonth
+
+@Composable
+fun MapisodeDateTable(
+	selectedMonth: YearMonth,
+	selectedDate: LocalDate,
+	onDateSelect: (LocalDate) -> Unit
+) {
+	// 해당 월의 일 수
+	val daysInMonth = selectedMonth.lengthOfMonth()
+	// 1일이 무슨 요일인지
+	val firstDayOfMonth = selectedMonth.atDay(1).dayOfWeek.value % 7
+
+	val dateList = mutableListOf<LocalDate?>()
+
+	// 1일 이전은 빈 칸 null 처리
+	for (i in 0 until firstDayOfMonth) {
+		dateList.add(null)
+	}
+	for (day in 1..daysInMonth) {
+		dateList.add(selectedMonth.atDay(day))
+	}
+
+	val finalDateList = dateList.toList()
+
+	LazyVerticalGrid(
+		columns = GridCells.Fixed(7),
+		contentPadding = PaddingValues(vertical = 8.dp)
+	) {
+		items(finalDateList) { date ->
+			date?.let {
+				MapisodeDateBox(
+					date = it,
+					isSelected = it == selectedDate,
+					isSunday = it.dayOfWeek.value == 7,
+					onSelect = { onDateSelect(it) }
+				)
+			} ?: Spacer(modifier = Modifier.size(36.dp))
+		}
+	}
+}

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/theme/ColorScheme.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/theme/ColorScheme.kt
@@ -2,6 +2,7 @@ package com.boostcamp.mapisode.designsystem.theme
 
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color
+import okhttp3.internal.http2.Header
 
 @Immutable
 data class CustomColorScheme(
@@ -31,6 +32,11 @@ data class CustomColorScheme(
 	val dateBoxUnselectedText: Color,
 	val dateBoxTodayText: Color,
 	val dateBoxSundayText: Color,
+	val dayOfWeekText: Color,
+	val datePickerHeader: Color,
+	val datePickerRequest: Color,
+	val datePickerDismiss: Color,
+	val datePickerBackground: Color,
 
 	// Menu
 	val menuBackground: Color,
@@ -146,6 +152,11 @@ val lightColorScheme = CustomColorScheme(
 	dateBoxUnselectedText = Neutral80,
 	dateBoxTodayText = Neutral100,
 	dateBoxSundayText = Error40,
+	dayOfWeekText = Neutral90,
+	datePickerHeader = Neutral110,
+	datePickerRequest = Neutral110,
+	datePickerDismiss = Error30,
+	datePickerBackground = Neutral10,
 
 	// Menu
 	menuBackground = Neutral10,
@@ -261,6 +272,11 @@ val darkColorScheme = CustomColorScheme(
 	dateBoxUnselectedText = Neutral70,
 	dateBoxTodayText = Neutral10,
 	dateBoxSundayText = Error10,
+	dayOfWeekText = Neutral40,
+	datePickerHeader = Neutral10,
+	datePickerRequest = Neutral10,
+	datePickerDismiss = Error20,
+	datePickerBackground = Neutral110,
 
 	// Menu
 	menuBackground = Neutral110,

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/theme/ColorScheme.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/theme/ColorScheme.kt
@@ -2,7 +2,6 @@ package com.boostcamp.mapisode.designsystem.theme
 
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color
-import okhttp3.internal.http2.Header
 
 @Immutable
 data class CustomColorScheme(
@@ -37,6 +36,7 @@ data class CustomColorScheme(
 	val datePickerRequest: Color,
 	val datePickerDismiss: Color,
 	val datePickerBackground: Color,
+	val datePickerBorder: Color,
 
 	// Menu
 	val menuBackground: Color,
@@ -152,11 +152,12 @@ val lightColorScheme = CustomColorScheme(
 	dateBoxUnselectedText = Neutral80,
 	dateBoxTodayText = Neutral100,
 	dateBoxSundayText = Error40,
-	dayOfWeekText = Neutral90,
+	dayOfWeekText = Neutral100,
 	datePickerHeader = Neutral110,
 	datePickerRequest = Neutral110,
 	datePickerDismiss = Error30,
 	datePickerBackground = Neutral10,
+	datePickerBorder = Neutral70,
 
 	// Menu
 	menuBackground = Neutral10,
@@ -272,11 +273,12 @@ val darkColorScheme = CustomColorScheme(
 	dateBoxUnselectedText = Neutral70,
 	dateBoxTodayText = Neutral10,
 	dateBoxSundayText = Error10,
-	dayOfWeekText = Neutral40,
+	dayOfWeekText = Neutral20,
 	datePickerHeader = Neutral10,
 	datePickerRequest = Neutral10,
 	datePickerDismiss = Error20,
-	datePickerBackground = Neutral110,
+	datePickerBackground = Neutral90,
+	datePickerBorder = Neutral70,
 
 	// Menu
 	menuBackground = Neutral110,

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/theme/ColorScheme.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/theme/ColorScheme.kt
@@ -25,6 +25,13 @@ data class CustomColorScheme(
 	// Scrim
 	val scrim: Color,
 
+	// Date Picker
+	val dateBoxSelectedBackground: Color,
+	val dateBoxSelectedText: Color,
+	val dateBoxUnselectedText: Color,
+	val dateBoxTodayText: Color,
+	val dateBoxSundayText: Color,
+
 	// Menu
 	val menuBackground: Color,
 	val menuStroke: Color,
@@ -133,6 +140,13 @@ val lightColorScheme = CustomColorScheme(
 	// Scrim
 	scrim = Neutral110.copy(alpha = 0.32f),
 
+	// Date Picker
+	dateBoxSelectedBackground = Primary30,
+	dateBoxSelectedText = Neutral10,
+	dateBoxUnselectedText = Neutral80,
+	dateBoxTodayText = Neutral100,
+	dateBoxSundayText = Error40,
+
 	// Menu
 	menuBackground = Neutral10,
 	menuStroke = Neutral110,
@@ -240,6 +254,13 @@ val darkColorScheme = CustomColorScheme(
 
 	// Scrim
 	scrim = Neutral10.copy(alpha = 0.32f),
+
+	// Date Picker
+	dateBoxSelectedBackground = Primary40,
+	dateBoxSelectedText = Neutral10,
+	dateBoxUnselectedText = Neutral70,
+	dateBoxTodayText = Neutral10,
+	dateBoxSundayText = Error10,
 
 	// Menu
 	menuBackground = Neutral110,

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/edit/EpisodeEditScreen.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/edit/EpisodeEditScreen.kt
@@ -29,9 +29,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.DatePicker
-import androidx.compose.material3.DatePickerDialog
-import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -64,6 +61,7 @@ import com.boostcamp.mapisode.designsystem.compose.MapisodeText
 import com.boostcamp.mapisode.designsystem.compose.MapisodeTextField
 import com.boostcamp.mapisode.designsystem.compose.button.MapisodeFilledButton
 import com.boostcamp.mapisode.designsystem.compose.button.MapisodeImageButton
+import com.boostcamp.mapisode.designsystem.compose.datepicker.MapisodeDatePicker
 import com.boostcamp.mapisode.designsystem.compose.menu.MapisodeDropdownMenu
 import com.boostcamp.mapisode.designsystem.compose.menu.MapisodeDropdownMenuItem
 import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
@@ -74,6 +72,7 @@ import com.naver.maps.map.CameraPosition
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
+import java.time.ZoneId
 import java.util.Date
 
 @Composable
@@ -176,10 +175,9 @@ fun EpisodeEditScreen(
 		mutableStateOf(state.episode.memoryDate)
 	}
 	var isGroupMenuPoppedUp by remember { mutableStateOf(false) }
-	var isCategoryMenuPoppedUp by remember { mutableStateOf(false) }
+	var isCategoryMenuPoppedUp by rememberSaveable { mutableStateOf(false) }
 	var showDatePickerDialog by remember { mutableStateOf(false) }
 	var contentWidth by remember { mutableIntStateOf(0) }
-	val datePickerState = rememberDatePickerState()
 
 	MapisodeScaffold(
 		isNavigationBarPaddingExist = true,
@@ -478,33 +476,13 @@ fun EpisodeEditScreen(
 			)
 
 			if (showDatePickerDialog) {
-				DatePickerDialog(
+				MapisodeDatePicker(
 					onDismissRequest = { showDatePickerDialog = false },
-					confirmButton = {
-						MapisodeFilledButton(
-							modifier = Modifier.padding(end = 20.dp, bottom = 32.dp),
-							onClick = {
-								showDatePickerDialog = false
-								datePickerState.selectedDateMillis?.let { milli ->
-									date = Date(milli)
-								}
-							},
-							text = "확인",
-						)
+					onDateSelected = { localDate ->
+						date = Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant())
+						showDatePickerDialog = false
 					},
-					dismissButton = {
-						MapisodeFilledButton(
-							modifier = Modifier.padding(end = 12.dp, bottom = 32.dp),
-							onClick = { showDatePickerDialog = false },
-							text = "취소",
-						)
-					},
-				) {
-					DatePicker(
-						state = datePickerState,
-						showModeToggle = false,
-					)
-				}
+				)
 			}
 
 			Spacer(modifier = Modifier.height(20.dp))

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/edit/EpisodeEditScreen.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/edit/EpisodeEditScreen.kt
@@ -175,8 +175,8 @@ fun EpisodeEditScreen(
 		mutableStateOf(state.episode.memoryDate)
 	}
 	var isGroupMenuPoppedUp by remember { mutableStateOf(false) }
-	var isCategoryMenuPoppedUp by rememberSaveable { mutableStateOf(false) }
-	var showDatePickerDialog by remember { mutableStateOf(false) }
+	var isCategoryMenuPoppedUp by remember { mutableStateOf(false) }
+	var showDatePickerDialog by rememberSaveable { mutableStateOf(false) }
 	var contentWidth by remember { mutableIntStateOf(0) }
 
 	MapisodeScaffold(
@@ -482,6 +482,7 @@ fun EpisodeEditScreen(
 						date = Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant())
 						showDatePickerDialog = false
 					},
+					initialDate = date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate(),
 				)
 			}
 


### PR DESCRIPTION
- closed #189 
## *📍 Work Description*

- 커스텀 Date Picker 생성
- 디자인 설정
- 에피소드 편집 화면 Date Picker교체

## *📸 Screenshot*

https://github.com/user-attachments/assets/cc6b9d2c-afdc-42ed-85e5-6a001d5fb29d

## *📢 To Reviewers*
- 내부 날짜와 글자 사이즈는 고정이라 높이와 너비는 고정입니다.
- configuration change 발생시 날짜 선택 상태가 저장되지 않습니다. -> 수정* 대응했습니다.
- LocalDate, Dialog가 DatePicker 구현을 전부 다 했습니다.

## ⏲️Time

    - 4시간
