### PR TITLE
[FEAT/#129] 이미지 스토리 뷰어 구현

### DIFF
--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
 	alias(libs.plugins.mapisode.android.library)
+	alias(libs.plugins.mapisode.android.compose)
 }
 
 android {

--- a/core/common/src/main/java/com/boostcamp/mapisode/common/util/ModifierExt.kt
+++ b/core/common/src/main/java/com/boostcamp/mapisode/common/util/ModifierExt.kt
@@ -15,7 +15,6 @@ fun Modifier.throttleClickable(
 	throttleTime: Long = DEFAULT_THROTTLE_TIME,
 	onClick: () -> Unit,
 ): Modifier {
-
 	var lastClickTime by rememberSaveable { mutableLongStateOf(0L) }
 
 	return this.clickable {

--- a/core/common/src/main/java/com/boostcamp/mapisode/common/util/ModifierExt.kt
+++ b/core/common/src/main/java/com/boostcamp/mapisode/common/util/ModifierExt.kt
@@ -1,0 +1,31 @@
+package com.boostcamp.mapisode.common.util
+
+import androidx.compose.foundation.clickable
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+
+private const val DEFAULT_THROTTLE_TIME = 500L
+
+@Composable
+fun Modifier.throttleClickable(
+	throttleTime: Long = DEFAULT_THROTTLE_TIME,
+	onClick: () -> Unit,
+): Modifier {
+
+	var lastClickTime by rememberSaveable { mutableLongStateOf(0L) }
+
+	return this.clickable {
+		val currentTime: Long = System.currentTimeMillis()
+
+		if (currentTime - lastClickTime < throttleTime) {
+			return@clickable
+		}
+
+		onClick()
+		lastClickTime = currentTime
+	}
+}

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeLinearProgressBar.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeLinearProgressBar.kt
@@ -1,0 +1,52 @@
+package com.boostcamp.mapisode.designsystem.compose
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
+
+@Composable
+fun MapisodeLinearProgressBar(
+	modifier: Modifier = Modifier,
+	progress: Float,
+	backgroundColor: Color = Color.Gray,
+	progressColor: Color = MapisodeTheme.colorScheme.circularIndicator,
+) {
+	Canvas(modifier = modifier) {
+		val width = size.width
+		val height = size.height
+		val cornerRadius = height / 2
+
+		// 배경 바
+		drawRoundRect(
+			color = backgroundColor,
+			size = Size(width, height),
+			cornerRadius = CornerRadius(cornerRadius, cornerRadius),
+		)
+
+		// 프로그레스 바
+		drawRoundRect(
+			color = progressColor,
+			size = Size(width * progress, height),
+			cornerRadius = CornerRadius(cornerRadius, cornerRadius),
+		)
+	}
+}
+
+@Preview(showBackground = true)
+@Composable
+fun MapisodeLinearProgressBarPreview() {
+	MapisodeLinearProgressBar(
+		modifier = Modifier
+			.fillMaxWidth()
+			.height(10.dp),
+		progress = 0.5f,
+	)
+}

--- a/core/navigation/src/main/java/com/boostcamp/mapisode/navigation/HomeRoute.kt
+++ b/core/navigation/src/main/java/com/boostcamp/mapisode/navigation/HomeRoute.kt
@@ -12,4 +12,7 @@ sealed interface HomeRoute : Route {
 
 	@Serializable
 	data class Edit(val episodeId: String) : HomeRoute
+
+	@Serializable
+	data object Story : HomeRoute
 }

--- a/core/ui/src/main/kotlin/com/boostcamp/mapisode/ui/story/StoryProgressBars.kt
+++ b/core/ui/src/main/kotlin/com/boostcamp/mapisode/ui/story/StoryProgressBars.kt
@@ -23,7 +23,7 @@ fun StoryProgressBars(
 	imageCount: Int,
 	currentIndex: Int,
 	progress: Float,
-	barHeight: Dp = 10.dp,
+	barHeight: Dp = 6.dp,
 	spacing: Dp = 6.dp,
 ) {
 	Row(

--- a/core/ui/src/main/kotlin/com/boostcamp/mapisode/ui/story/StoryProgressBars.kt
+++ b/core/ui/src/main/kotlin/com/boostcamp/mapisode/ui/story/StoryProgressBars.kt
@@ -1,0 +1,65 @@
+package com.boostcamp.mapisode.ui.story
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.boostcamp.mapisode.designsystem.compose.MapisodeLinearProgressBar
+
+@Composable
+fun StoryProgressBars(
+	modifier: Modifier = Modifier,
+	imageCount: Int,
+	currentIndex: Int,
+	progress: Float,
+	barHeight: Dp = 10.dp,
+	spacing: Dp = 6.dp,
+) {
+	Row(
+		modifier = modifier
+			.fillMaxWidth()
+			.background(Color.Transparent),
+		horizontalArrangement = Arrangement.spacedBy(spacing),
+	) {
+		repeat(imageCount) { index ->
+			Box(
+				modifier = Modifier
+					.weight(1f)
+					.height(barHeight)
+					.background(Color.Transparent),
+			) {
+				MapisodeLinearProgressBar(
+					modifier = Modifier
+						.fillMaxSize()
+						.clip(RoundedCornerShape(barHeight / 2)),
+					progress = when {
+						index < currentIndex -> 1f
+						index == currentIndex -> progress
+						else -> 0f
+					},
+				)
+			}
+		}
+	}
+}
+
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+fun StoryProgressBarsPreview() {
+	StoryProgressBars(
+		imageCount = 5,
+		currentIndex = 2,
+		progress = 0.5f,
+	)
+}

--- a/core/ui/src/main/kotlin/com/boostcamp/mapisode/ui/story/StoryViewer.kt
+++ b/core/ui/src/main/kotlin/com/boostcamp/mapisode/ui/story/StoryViewer.kt
@@ -2,15 +2,44 @@ package com.boostcamp.mapisode.ui.story
 
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil3.annotation.ExperimentalCoilApi
+import coil3.compose.AsyncImage
+import coil3.compose.AsyncImagePreviewHandler
+import coil3.compose.LocalAsyncImagePreviewHandler
+import coil3.test.FakeImage
+import com.boostcamp.mapisode.designsystem.compose.MapisodeText
+import com.boostcamp.mapisode.designsystem.theme.AppTypography
 import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.launch
 
 @Composable
 fun StoryViewer(
@@ -22,6 +51,7 @@ fun StoryViewer(
 	var currentIndex by rememberSaveable { mutableIntStateOf(0) }
 	val progressAnimatable = remember { Animatable(0f) }
 	var isPaused by rememberSaveable { mutableStateOf(false) }
+	val coroutineScope = rememberCoroutineScope()
 
 	LaunchedEffect(
 		key1 = currentIndex,
@@ -31,14 +61,117 @@ fun StoryViewer(
 			progressAnimatable.snapTo(0f)
 			progressAnimatable.animateTo(
 				targetValue = 1f,
-				animationSpec = tween(durationMillis = 5000),
+				animationSpec = tween(durationMillis = 7000),
 			)
-			// 시간이 다 지나면 다음 이미지로
-			if (currentIndex < imageUrls.size - 1) {
-				currentIndex += 1
-			} else {
-				onClose()
+			if (progressAnimatable.value == 1f) {
+				// 다음 사진으로 이동
+				if (currentIndex < imageUrls.size - 1) {
+					currentIndex += 1
+				} else {
+					onClose()
+				}
 			}
 		}
+	}
+
+	Box(
+		modifier = Modifier
+			.fillMaxSize()
+			.pointerInput(Unit) {
+				detectTapGestures(
+					onPress = {
+						isPaused = true
+						tryAwaitRelease()
+						isPaused = false
+					},
+					onTap = { offset ->
+						val width = size.width
+						coroutineScope.launch {
+							if (offset.x < width / 2) {
+								// 왼쪽 터치 동작
+								if (progressAnimatable.value > 0.1f) {
+									progressAnimatable.snapTo(0f)
+								} else if (currentIndex > 0) {
+									currentIndex -= 1
+									progressAnimatable.snapTo(0f)
+								} else {
+									onClose()
+								}
+							} else {
+								// 오른쪽 터치 동작
+								if (currentIndex < imageUrls.size - 1) {
+									currentIndex += 1
+									progressAnimatable.snapTo(0f)
+								} else {
+									onClose()
+								}
+							}
+						}
+					},
+				)
+			},
+	) {
+		AsyncImage(
+			model = imageUrls[currentIndex],
+			contentDescription = "애피소드 이미지",
+			modifier = Modifier.fillMaxSize(),
+			contentScale = ContentScale.Crop,
+		)
+
+		StoryProgressBars(
+			imageCount = imageUrls.size,
+			currentIndex = currentIndex,
+			progress = progressAnimatable.value,
+			modifier = Modifier
+				.align(Alignment.TopCenter)
+				.padding(top = 16.dp, start = 12.dp, end = 12.dp),
+		)
+
+		Row(
+			modifier = Modifier
+				.fillMaxWidth()
+				.padding(16.dp)
+				.align(Alignment.BottomStart),
+		) {
+			AsyncImage(
+				model = authorProfileUrl,
+				contentDescription = "유저 프로필 이미지",
+				modifier = Modifier
+					.size(48.dp)
+					.clip(CircleShape),
+				contentScale = ContentScale.Crop,
+			)
+
+			Spacer(modifier = Modifier.width(8.dp))
+
+			MapisodeText(
+				text = authorName,
+				color = Color.White,
+				modifier = Modifier
+					.align(Alignment.CenterVertically),
+				style = AppTypography.bodyLarge
+			)
+		}
+	}
+}
+
+@OptIn(ExperimentalCoilApi::class)
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+fun StoryViewerPreview() {
+	val previewHandler = AsyncImagePreviewHandler {
+		FakeImage(color = 0xFFE0E0E0.toInt())
+	}
+
+	CompositionLocalProvider(LocalAsyncImagePreviewHandler provides previewHandler) {
+		StoryViewer(
+			imageUrls = persistentListOf(
+				"https://github.com/user-attachments/assets/502a3888-7a98-420c-93e1-1286d340f9dc",
+				"https://github.com/user-attachments/assets/502a3888-7a98-420c-93e1-1286d340f9dc",
+				"https://github.com/user-attachments/assets/502a3888-7a98-420c-93e1-1286d340f9dc",
+			),
+			authorName = "haeti",
+			authorProfileUrl = "https://github.com/user-attachments/assets/46a5a57f-d7a4-4962-ba21-74eca38d48c6",
+		)
 	}
 }

--- a/core/ui/src/main/kotlin/com/boostcamp/mapisode/ui/story/StoryViewer.kt
+++ b/core/ui/src/main/kotlin/com/boostcamp/mapisode/ui/story/StoryViewer.kt
@@ -115,7 +115,7 @@ fun StoryViewer(
 			model = imageUrls[currentIndex],
 			contentDescription = "애피소드 이미지",
 			modifier = Modifier.fillMaxSize(),
-			contentScale = ContentScale.Crop,
+			contentScale = ContentScale.FillWidth,
 		)
 
 		StoryProgressBars(

--- a/core/ui/src/main/kotlin/com/boostcamp/mapisode/ui/story/StoryViewer.kt
+++ b/core/ui/src/main/kotlin/com/boostcamp/mapisode/ui/story/StoryViewer.kt
@@ -147,9 +147,8 @@ fun StoryViewer(
 			MapisodeText(
 				text = authorName,
 				color = Color.White,
-				modifier = Modifier
-					.align(Alignment.CenterVertically),
-				style = AppTypography.bodyLarge
+				modifier = Modifier.align(Alignment.CenterVertically),
+				style = AppTypography.bodyLarge,
 			)
 		}
 	}
@@ -171,7 +170,7 @@ fun StoryViewerPreview() {
 				"https://github.com/user-attachments/assets/502a3888-7a98-420c-93e1-1286d340f9dc",
 			),
 			authorName = "haeti",
-			authorProfileUrl = "https://github.com/user-attachments/assets/46a5a57f-d7a4-4962-ba21-74eca38d48c6",
+			authorProfileUrl = "",
 		)
 	}
 }

--- a/core/ui/src/main/kotlin/com/boostcamp/mapisode/ui/story/StoryViewer.kt
+++ b/core/ui/src/main/kotlin/com/boostcamp/mapisode/ui/story/StoryViewer.kt
@@ -52,12 +52,14 @@ fun StoryViewer(
 	val progressAnimatable = remember { Animatable(0f) }
 	var isPaused by rememberSaveable { mutableStateOf(false) }
 	val coroutineScope = rememberCoroutineScope()
+	var isClosed by rememberSaveable { mutableStateOf(false) }
 
 	LaunchedEffect(
 		key1 = currentIndex,
 		key2 = isPaused,
 	) {
 		if (!isPaused) {
+			progressAnimatable.stop()
 			progressAnimatable.snapTo(0f)
 			progressAnimatable.animateTo(
 				targetValue = 1f,
@@ -68,7 +70,10 @@ fun StoryViewer(
 				if (currentIndex < imageUrls.size - 1) {
 					currentIndex += 1
 				} else {
-					onClose()
+					if (!isClosed) {
+						isClosed = true
+						onClose()
+					}
 				}
 			}
 		}
@@ -95,7 +100,10 @@ fun StoryViewer(
 									currentIndex -= 1
 									progressAnimatable.snapTo(0f)
 								} else {
-									onClose()
+									if (!isClosed) {
+										isClosed = true
+										onClose()
+									}
 								}
 							} else {
 								// 오른쪽 터치 동작
@@ -103,7 +111,10 @@ fun StoryViewer(
 									currentIndex += 1
 									progressAnimatable.snapTo(0f)
 								} else {
-									onClose()
+									if (!isClosed) {
+										isClosed = true
+										onClose()
+									}
 								}
 							}
 						}

--- a/core/ui/src/main/kotlin/com/boostcamp/mapisode/ui/story/StoryViewer.kt
+++ b/core/ui/src/main/kotlin/com/boostcamp/mapisode/ui/story/StoryViewer.kt
@@ -28,12 +28,15 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil3.annotation.ExperimentalCoilApi
 import coil3.compose.AsyncImage
 import coil3.compose.AsyncImagePreviewHandler
 import coil3.compose.LocalAsyncImagePreviewHandler
+import coil3.request.ImageRequest
+import coil3.request.crossfade
 import coil3.test.FakeImage
 import com.boostcamp.mapisode.designsystem.compose.MapisodeText
 import com.boostcamp.mapisode.designsystem.theme.AppTypography
@@ -53,6 +56,7 @@ fun StoryViewer(
 	var isPaused by rememberSaveable { mutableStateOf(false) }
 	val coroutineScope = rememberCoroutineScope()
 	var isClosed by rememberSaveable { mutableStateOf(false) }
+	val context = LocalContext.current
 
 	LaunchedEffect(
 		key1 = currentIndex,
@@ -123,7 +127,10 @@ fun StoryViewer(
 			},
 	) {
 		AsyncImage(
-			model = imageUrls[currentIndex],
+			model = ImageRequest.Builder(context)
+				.data(imageUrls[currentIndex])
+				.crossfade(true)
+				.build(),
 			contentDescription = "애피소드 이미지",
 			modifier = Modifier.fillMaxSize(),
 			contentScale = ContentScale.FillWidth,

--- a/core/ui/src/main/kotlin/com/boostcamp/mapisode/ui/story/StoryViewer.kt
+++ b/core/ui/src/main/kotlin/com/boostcamp/mapisode/ui/story/StoryViewer.kt
@@ -1,0 +1,44 @@
+package com.boostcamp.mapisode.ui.story
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import kotlinx.collections.immutable.PersistentList
+
+@Composable
+fun StoryViewer(
+	imageUrls: PersistentList<String>,
+	authorName: String,
+	authorProfileUrl: String,
+	onClose: () -> Unit = {},
+) {
+	var currentIndex by rememberSaveable { mutableIntStateOf(0) }
+	val progressAnimatable = remember { Animatable(0f) }
+	var isPaused by rememberSaveable { mutableStateOf(false) }
+
+	LaunchedEffect(
+		key1 = currentIndex,
+		key2 = isPaused,
+	) {
+		if (!isPaused) {
+			progressAnimatable.snapTo(0f)
+			progressAnimatable.animateTo(
+				targetValue = 1f,
+				animationSpec = tween(durationMillis = 5000),
+			)
+			// 시간이 다 지나면 다음 이미지로
+			if (currentIndex < imageUrls.size - 1) {
+				currentIndex += 1
+			} else {
+				onClose()
+			}
+		}
+	}
+}

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/detail/EpisodeDetailIntent.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/detail/EpisodeDetailIntent.kt
@@ -4,4 +4,5 @@ import com.boostcamp.mapisode.ui.base.UiIntent
 
 sealed class EpisodeDetailIntent : UiIntent {
 	data class LoadEpisodeDetail(val episodeId: String) : EpisodeDetailIntent()
+	data object OpenStoryViewer : EpisodeDetailIntent()
 }

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/detail/EpisodeDetailScreen.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/detail/EpisodeDetailScreen.kt
@@ -41,6 +41,10 @@ import coil3.annotation.ExperimentalCoilApi
 import coil3.compose.AsyncImage
 import coil3.compose.AsyncImagePreviewHandler
 import coil3.compose.LocalAsyncImagePreviewHandler
+import coil3.imageLoader
+import coil3.request.ImageRequest
+import coil3.request.crossfade
+import coil3.size.Size
 import coil3.test.FakeImage
 import com.boostcamp.mapisode.designsystem.R
 import com.boostcamp.mapisode.designsystem.compose.Direction
@@ -119,6 +123,17 @@ internal fun EpisodeDetailScreen(
 	onBackClick: () -> Unit = {},
 ) {
 	val context = LocalContext.current
+	val imageLoader = context.imageLoader
+
+	LaunchedEffect(state.episode.imageUrls) {
+		state.episode.imageUrls.forEach { imageUrl ->
+			val request = ImageRequest.Builder(context)
+				.data(imageUrl)
+				.size(Size.ORIGINAL) // 원본 크기로 로드
+				.build()
+			imageLoader.enqueue(request)
+		}
+	}
 
 	MapisodeScaffold(
 		modifier = Modifier.fillMaxSize(),
@@ -170,7 +185,10 @@ internal fun EpisodeDetailScreen(
 				) {
 					imageUrls.forEach { imageUrl ->
 						AsyncImage(
-							model = imageUrl,
+							model = ImageRequest.Builder(context)
+								.data(imageUrl)
+								.crossfade(true)
+								.build(),
 							contentDescription = "애피소드 이미지",
 							modifier = Modifier
 								.size(110.dp)

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/detail/EpisodeDetailScreen.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/detail/EpisodeDetailScreen.kt
@@ -3,6 +3,7 @@ package com.boostcamp.mapisode.home.detail
 import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -65,7 +66,6 @@ import com.boostcamp.mapisode.home.component.MapisodeChip
 internal fun EpisodeDetailRoute(
 	episodeId: String,
 	viewModel: EpisodeDetailViewModel = hiltViewModel(),
-	onEpisodeEditClick: (String) -> Unit,
 	onBackClick: () -> Unit = {},
 ) {
 	val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -82,6 +82,10 @@ internal fun EpisodeDetailRoute(
 					val message = context.getString(sideEffect.messageResId)
 					Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
 				}
+
+				is EpisodeDetailSideEffect.OpenStoryViewer -> {
+					onOpenStoryViewer()
+				}
 			}
 		}
 	}
@@ -96,8 +100,9 @@ internal fun EpisodeDetailRoute(
 	} else {
 		EpisodeDetailScreen(
 			state = uiState,
-			onEpisodeEditClick = { onEpisodeEditClick(episodeId) },
 			onBackClick = onBackClick,
+			onEpisodeEditClick = { onEpisodeEditClick(episodeId) },
+			onOpenStoryViewer = { viewModel.onIntent(EpisodeDetailIntent.OpenStoryViewer) },
 		)
 	}
 }
@@ -236,7 +241,8 @@ internal fun EpisodeDetailScreen(
 						.padding(horizontal = 20.dp),
 					itemVerticalAlignment = Alignment.CenterVertically,
 				) {
-					val chipType = mapCategoryToChipType(state.episode.category) ?: ChipType.OTHER
+					val chipType =
+						mapCategoryToChipType(state.episode.category) ?: ChipType.OTHER
 
 					MapisodeChip(
 						text = context.getString(chipType.textResId),

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/detail/EpisodeDetailScreen.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/detail/EpisodeDetailScreen.kt
@@ -65,6 +65,8 @@ import com.boostcamp.mapisode.home.component.MapisodeChip
 @Composable
 internal fun EpisodeDetailRoute(
 	episodeId: String,
+	onEpisodeEditClick: (String) -> Unit,
+	onOpenStoryViewer: () -> Unit,
 	viewModel: EpisodeDetailViewModel = hiltViewModel(),
 	onBackClick: () -> Unit = {},
 ) {
@@ -102,7 +104,7 @@ internal fun EpisodeDetailRoute(
 			state = uiState,
 			onBackClick = onBackClick,
 			onEpisodeEditClick = { onEpisodeEditClick(episodeId) },
-			onOpenStoryViewer = { viewModel.onIntent(EpisodeDetailIntent.OpenStoryViewer) },
+			onStoryViewerClick = { viewModel.onIntent(EpisodeDetailIntent.OpenStoryViewer) },
 		)
 	}
 }
@@ -113,6 +115,7 @@ internal fun EpisodeDetailScreen(
 	state: EpisodeDetailState,
 	modifier: Modifier = Modifier,
 	onEpisodeEditClick: () -> Unit,
+	onStoryViewerClick: () -> Unit,
 	onBackClick: () -> Unit = {},
 ) {
 	val context = LocalContext.current
@@ -171,7 +174,8 @@ internal fun EpisodeDetailScreen(
 							contentDescription = "애피소드 이미지",
 							modifier = Modifier
 								.size(110.dp)
-								.clip(RoundedCornerShape(16.dp)),
+								.clip(RoundedCornerShape(16.dp))
+								.clickable { onStoryViewerClick() },
 							contentScale = ContentScale.Crop,
 						)
 					}
@@ -318,6 +322,6 @@ fun EpisodeDetailScreenPreview(
 	}
 
 	CompositionLocalProvider(LocalAsyncImagePreviewHandler provides previewHandler) {
-		EpisodeDetailScreen(state = state, onEpisodeEditClick = {})
+		EpisodeDetailScreen(state = state, onEpisodeEditClick = {}, onStoryViewerClick = {})
 	}
 }

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/detail/EpisodeDetailSideEffect.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/detail/EpisodeDetailSideEffect.kt
@@ -4,4 +4,5 @@ import com.boostcamp.mapisode.ui.base.SideEffect
 
 sealed class EpisodeDetailSideEffect : SideEffect {
 	data class ShowToast(val messageResId: Int) : EpisodeDetailSideEffect()
+	data object OpenStoryViewer : EpisodeDetailSideEffect()
 }

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/detail/EpisodeDetailState.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/detail/EpisodeDetailState.kt
@@ -5,7 +5,7 @@ import com.boostcamp.mapisode.model.UserModel
 import com.boostcamp.mapisode.ui.base.UiState
 
 data class EpisodeDetailState(
-	val isLoading: Boolean = true,
+	val isLoading: Boolean = false,
 	val episode: EpisodeModel = EpisodeModel(),
 	val author: UserModel? = null,
 ) : UiState

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/detail/EpisodeDetailViewModel.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/detail/EpisodeDetailViewModel.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-internal class EpisodeDetailViewModel @Inject constructor(
+class EpisodeDetailViewModel @Inject constructor(
 	private val episodeRepository: EpisodeRepository,
 	private val userRepository: UserRepository,
 ) : BaseViewModel<EpisodeDetailIntent, EpisodeDetailState, EpisodeDetailSideEffect>(
@@ -18,9 +18,8 @@ internal class EpisodeDetailViewModel @Inject constructor(
 ) {
 	override fun onIntent(intent: EpisodeDetailIntent) {
 		when (intent) {
-			is EpisodeDetailIntent.LoadEpisodeDetail -> {
-				loadEpisodeDetail(intent.episodeId)
-			}
+			is EpisodeDetailIntent.LoadEpisodeDetail -> loadEpisodeDetail(intent.episodeId)
+			is EpisodeDetailIntent.OpenStoryViewer -> postSideEffect(EpisodeDetailSideEffect.OpenStoryViewer)
 		}
 	}
 

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/navigation/HomeNavigation.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/navigation/HomeNavigation.kt
@@ -40,11 +40,19 @@ fun NavController.navigateEpisodeEdit(
 	navigate(HomeRoute.Edit(episodeId), navOptions)
 }
 
+fun NavController.navigateStoryViewer(
+	navOptions: NavOptions? = null,
+) {
+	navigate(HomeRoute.Story, navOptions)
+}
+
 fun NavGraphBuilder.addHomeNavGraph(
+	navController: NavController,
 	onTextMarkerClick: (EpisodeLatLng) -> Unit,
 	onEpisodeEditClick: (String) -> Unit,
 	onEpisodeClick: (String) -> Unit,
 	onListFabClick: (String) -> Unit,
+	onStoryClick: () -> Unit,
 	onBackClick: () -> Unit,
 ) {
 	composable<MainRoute.Home> {
@@ -60,6 +68,7 @@ fun NavGraphBuilder.addHomeNavGraph(
 		EpisodeDetailRoute(
 			episodeId = episodeId,
 			onEpisodeEditClick = onEpisodeEditClick,
+			onOpenStoryViewer = onStoryClick,
 			onBackClick = onBackClick,
 		)
 	}
@@ -72,5 +81,16 @@ fun NavGraphBuilder.addHomeNavGraph(
 	composable<HomeRoute.Edit> { backStackEntry ->
 		val episodeId = backStackEntry.toRoute<HomeRoute.Edit>().episodeId
 		EpisodeEditRoute(episodeId = episodeId, onBackClick = onBackClick)
+	}
+
+	composable<HomeRoute.Story> { backStackEntry ->
+		val parentEntry = remember(backStackEntry) {
+			navController.getBackStackEntry<HomeRoute.Detail>()
+		}
+
+		StoryViewerRoute(
+			viewModel = hiltViewModel(parentEntry),
+			onBackClick = onBackClick,
+		)
 	}
 }

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/navigation/HomeNavigation.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/navigation/HomeNavigation.kt
@@ -1,5 +1,7 @@
 package com.boostcamp.mapisode.home.navigation
 
+import androidx.compose.runtime.remember
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
@@ -9,6 +11,7 @@ import com.boostcamp.mapisode.home.HomeRoute
 import com.boostcamp.mapisode.home.detail.EpisodeDetailRoute
 import com.boostcamp.mapisode.home.edit.EpisodeEditRoute
 import com.boostcamp.mapisode.home.list.EpisodeListRoute
+import com.boostcamp.mapisode.home.story.StoryViewerRoute
 import com.boostcamp.mapisode.model.EpisodeLatLng
 import com.boostcamp.mapisode.navigation.HomeRoute
 import com.boostcamp.mapisode.navigation.MainRoute

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/story/StoryViewerScreen.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/story/StoryViewerScreen.kt
@@ -1,0 +1,24 @@
+package com.boostcamp.mapisode.home.story
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.boostcamp.mapisode.home.detail.EpisodeDetailViewModel
+import com.boostcamp.mapisode.ui.story.StoryViewer
+import kotlinx.collections.immutable.toPersistentList
+
+@Composable
+fun StoryViewerRoute(
+	viewModel: EpisodeDetailViewModel = hiltViewModel(),
+	onBackClick: () -> Unit = {},
+) {
+	val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+	StoryViewer(
+		imageUrls = uiState.episode.imageUrls.toPersistentList(),
+		authorName = uiState.author?.name ?: "UNKNOWN",
+		authorProfileUrl = uiState.author?.profileUrl ?: "",
+		onClose = onBackClick,
+	)
+}

--- a/feature/main/src/main/java/com/boostcamp/mapisode/main/MainNavigator.kt
+++ b/feature/main/src/main/java/com/boostcamp/mapisode/main/MainNavigator.kt
@@ -16,6 +16,7 @@ import com.boostcamp.mapisode.episode.navigation.navigateWriteInfo
 import com.boostcamp.mapisode.home.navigation.navigateEpisodeDetail
 import com.boostcamp.mapisode.home.navigation.navigateEpisodeEdit
 import com.boostcamp.mapisode.home.navigation.navigateEpisodeList
+import com.boostcamp.mapisode.home.navigation.navigateStoryViewer
 import com.boostcamp.mapisode.model.EpisodeLatLng
 import com.boostcamp.mapisode.mygroup.navigation.navigateGroupCreation
 import com.boostcamp.mapisode.mygroup.navigation.navigateGroupDetail
@@ -122,6 +123,10 @@ internal class MainNavigator(
 
 	fun navigateToProfileEdit() {
 		navController.navigateToProfileEdit()
+	}
+
+	fun navigateToStoryViewer() {
+		navController.navigateStoryViewer()
 	}
 
 	private fun popBackStack() {

--- a/feature/main/src/main/java/com/boostcamp/mapisode/main/component/MainNavHost.kt
+++ b/feature/main/src/main/java/com/boostcamp/mapisode/main/component/MainNavHost.kt
@@ -26,12 +26,14 @@ internal fun MainNavHost(
 			startDestination = navigator.startDestination,
 		) {
 			addHomeNavGraph(
+				navController = navigator.navController,
 				onTextMarkerClick = { latLng ->
 					navigator.navigate(MainNavTab.EPISODE, latLng)
 				},
 				onEpisodeEditClick = navigator::navigateToEpisodeEdit,
 				onEpisodeClick = navigator::navigateToEpisodeDetail,
 				onListFabClick = navigator::navigateToEpisodeList,
+				onStoryClick = navigator::navigateToStoryViewer,
 				onBackClick = navigator::popBackStackIfNotHome,
 			)
 			addAuthNavGraph(


### PR DESCRIPTION
- closed #129 

❗ 이미지 캐싱, 스토리 사진 ContentScale 변경 사항이 있어 리뷰 재요청드립니다
❗ 또한 Modifier 확장함수인 throttleClick을 구현해놨으니 활용해주시기 바랍니다. 

## *📍 Work Description*
- 별도의 Route로 정의 (물리적인 뒤로가기를 위함)
- 커스텀 Linear Progrss Bar 구현
- 한 사진을 7초 동안 보여주고, 그에 따라 프로그레스바가 진행됨
- 왼쪽을 터치하면 이전 사진, 오른쪽 사진을 터치하면 다음 사진으로 이동
- 위 경우에서 만약 현재 사진의 프로그레스바 진행률이 10% 미만이면 해당 사진을 다시 처음부터 보여줌
- 맨 첫 사진에서 왼쪽 터치, 맨 마지막 사진에서 오른쪽 터치 시 close됨

## 이미지 로딩 관련
- 기존에 같은 이미지 url인데도 크기와 ContentScale이 달라 두 화면에서 모두 로딩을 하게 됨.
- 위와 같은 상황에서는 캐싱을 해도 서로 다른 캐시 키를 가지기 때문에 캐싱의 효과를 보지 못함 
- 이와 같은 상황을 프리 로딩으로 해결함

### Before
**로딩시간**
<img src="https://github.com/user-attachments/assets/6ebc3d3d-2752-4e22-8a0c-0badc1c0664e" width=500 />  

**메모리 소비량**
<img src="https://github.com/user-attachments/assets/95791e21-5024-48fc-9207-5367d4ee2d21" width=500 />  

### After
**로딩시간**
<img src="https://github.com/user-attachments/assets/f650bc8c-aff3-4951-8b3c-779551920d5b" width=500 />  

**메모리 소비량**
<img src="https://github.com/user-attachments/assets/4dad5e7c-6d92-42dc-827d-49858aabc9e5" width=500 />  

보시다시피 이미지 로딩 시간은 대폭 감소하고, 메모리 소비량은 좀 늘었습니다. 저희 플젝에서는 크게 문제가 될 것 같지는 않지만, 더 좋은 방법을 고민해보도록하겠습니다. 

## *📸 Screenshot*

<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->

https://github.com/user-attachments/assets/1b6a5a0d-b44e-4dfd-9204-373b6665484d


## *📢 To Reviewers*
- 현재 에피소드 상세와 스토리가 동일한 이미지인데도 캐싱이 되고 있지 않습니다. coil 속성을 좀 만져서 최적화를 할 생각입니다.
- ryu 유저가 프사가 없어서 프로필 사진이 현재 보이지 않습니다. 다른 유저들은 잘 보입니다
- 몰입 모드는 별도의 PR로 올리겠습니다. 

## ⏲️Time

    - 5 h
