### PR TITLE
[REFACTOR/#202] Group / 사진 Crop으로 띄우기

### DIFF
--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/card/GroupInfoCard.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/card/GroupInfoCard.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -44,6 +45,7 @@ fun GroupInfoCard(
 			modifier = Modifier
 				.size(140.dp)
 				.clip(shape = RoundedCornerShape(16.dp)),
+			contentScale = ContentScale.Crop,
 		)
 		MapisodeDivider(thickness = Thickness.Thick)
 		Column(

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupCreationScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupCreationScreen.kt
@@ -232,7 +232,7 @@ fun GroupCreationField(
 							modifier = Modifier
 								.fillMaxSize()
 								.aspectRatio(1f),
-							contentScale = ContentScale.FillBounds,
+							contentScale = ContentScale.Crop,
 						)
 					}
 				}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupEditScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupEditScreen.kt
@@ -234,7 +234,7 @@ fun GroupEditField(
 							model = profileUrl,
 							contentDescription = "그룹 이미지",
 							modifier = Modifier.fillMaxSize(),
-							contentScale = ContentScale.FillBounds,
+							contentScale = ContentScale.Crop,
 						)
 					}
 				}


### PR DESCRIPTION
- closed #202 

## *📍 Work Description*

- ContentScale `Fit`, `FillBounds` -> `Crop` 변경

## *📸 Screenshot*

<img src="https://github.com/user-attachments/assets/9dba1dc5-13fb-4a66-89f9-b72e1f12feb7" width=400>
<br>
<img src="https://github.com/user-attachments/assets/3ffa1d8d-fa0a-4bc8-bd69-cab3517c941a" width=400>


## *📢 To Reviewers*
- QA 에서 받은 이미지 개선사항 적용
- FillBounds는 비율이 맞지 않는 문제, Fill 은 화면에 가득차지 않는 문제

## ⏲️Time

    - 0.2 시간
