### PR TITLE
[FIX/#204] firebase / storage 업로드 

### DIFF
--- a/app/src/main/kotlin/com/boostcamp/mapisode/MapisodeApplication.kt
+++ b/app/src/main/kotlin/com/boostcamp/mapisode/MapisodeApplication.kt
@@ -1,7 +1,10 @@
 package com.boostcamp.mapisode
 
 import android.app.Application
-import com.google.firebase.FirebaseApp
+import com.google.firebase.Firebase
+import com.google.firebase.appcheck.appCheck
+import com.google.firebase.appcheck.playintegrity.PlayIntegrityAppCheckProviderFactory
+import com.google.firebase.initialize
 import dagger.hilt.android.HiltAndroidApp
 import timber.log.Timber
 
@@ -11,7 +14,10 @@ class MapisodeApplication : Application() {
 		super.onCreate()
 
 		initTimber()
-		FirebaseApp.initializeApp(this)
+		Firebase.initialize(context = this)
+		Firebase.appCheck.installAppCheckProviderFactory(
+			PlayIntegrityAppCheckProviderFactory.getInstance(),
+		)
 	}
 
 	private fun initTimber() {

--- a/data/episode/src/main/java/com/boostcamp/mapisode/episode/EpisodeRepositoryImpl.kt
+++ b/data/episode/src/main/java/com/boostcamp/mapisode/episode/EpisodeRepositoryImpl.kt
@@ -184,9 +184,15 @@ class EpisodeRepositoryImpl @Inject constructor(
 				updatedUrls.add(downloadUrl.toString())
 			}
 
-			val createdBy = database.collection("user").document(episodeModel.createdBy)
-			val group = database.collection("group").document(episodeModel.group)
-			database.document("episode/${episodeModel.id}")
+			val createdBy = database.collection(
+				FirestoreConstants.COLLECTION_USER,
+			).document(episodeModel.createdBy)
+			val group = database.collection(
+				FirestoreConstants.COLLECTION_GROUP,
+			).document(episodeModel.group)
+			database.document(
+				"${FirestoreConstants.COLLECTION_EPISODE}/${episodeModel.id}",
+			)
 				.set(episodeModel.toFirestoreModelForUpdate(createdBy, group, updatedUrls))
 				.await()
 		} catch (e: FirebaseException) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -120,6 +120,7 @@ firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.r
 firebase-auth = { group = "com.google.firebase", name = "firebase-auth" }
 firebase-firestore = { group = "com.google.firebase", name = "firebase-firestore" }
 firebase-storage = { group = "com.google.firebase", name = "firebase-storage" }
+firebase-appcheck = { group = "com.google.firebase", name = "firebase-appcheck-playintegrity" }
 
 # Google
 google-play-services-auth = { group = "com.google.android.gms", name = "play-services-auth", version.ref = "google-play-services-auth" }
@@ -233,7 +234,8 @@ datastore = [
 firebase = [
 	"firebase-auth",
 	"firebase-firestore",
-	"firebase-storage"
+	"firebase-storage",
+	"firebase-appcheck"
 ]
 
 # Navigation


### PR DESCRIPTION
- closed #204

## *📍 Work Description*

- firebase storage에 요청하는 에피소드 업데이트 함수 수정 (withTimeout 제거)
- firebase app check 추가

## *📸 Screenshot*

<img src="https://github.com/user-attachments/assets/c7c13557-3200-484a-8d27-40f4c5d31a18" width=800>
<br><br>
<img src="https://github.com/user-attachments/assets/665b87c5-9fce-429f-bfe3-57cf49aa14bc" width=800>


## *📢 To Reviewers*
- 특정 기기에서 이미지가 업로드가 안되어 무한 대기에 걸리는 현상이 있었습니다.
- kotlinx에서 제공하는 withTimeout를 사용하여 5초 이내에 실행되지 않으면 예외를 띄우는 코루틴을 firebase-storage 업로드 요청 로직에 감싸서 사용하니 api35 의 기기에서는 무한대기가 발생했습니다. 이를 제거하여 실행 가능하게 했습니다.
- play store 배포시 인증된 유저만 firebase에 접근가능할 수 있도록 app check 를 설정했습니다.
- app check 는 디버그를 지원하지 않지만 unenforced 상태로 만들어 배포 전에도 접근 가능하게 할 수 있습니다.

## ⏲️Time

    - 3시간
