### PR TITLE
[FIX/#155] Group / Toast 추가

### DIFF
--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupCreationViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupCreationViewModel.kt
@@ -113,14 +113,16 @@ class GroupCreationViewModel @Inject constructor(
 					groupRepository.createGroup(currentState.group.toGroupModel())
 					postSideEffect(
 						GroupCreationSideEffect.ShowToast(
-							R.string.message_error_creation_group_success,
+							R.string.message_success_creation_group,
 						),
 					)
 					delay(100)
 					postSideEffect(GroupCreationSideEffect.NavigateToGroupScreen)
 				}
 			} catch (e: Exception) {
-				postSideEffect(GroupCreationSideEffect.ShowToast(R.string.message_error_edit_group))
+				postSideEffect(
+					GroupCreationSideEffect.ShowToast(R.string.message_error_creation_group),
+				)
 				delay(100)
 				postSideEffect(GroupCreationSideEffect.Idle)
 			}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupDetailViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupDetailViewModel.kt
@@ -118,8 +118,6 @@ class GroupDetailViewModel @Inject constructor(
 			try {
 				val code = groupRepository.issueInvitationCode(groupId.value)
 				postSideEffect(GroupDetailSideEffect.IssueInvitationCode(code))
-				delay(100)
-				postSideEffect(GroupDetailSideEffect.ShowToast(R.string.message_issue_code_success))
 			} catch (e: Exception) {
 				postSideEffect(GroupDetailSideEffect.ShowToast(R.string.message_issue_code_fail))
 			}

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupEditViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupEditViewModel.kt
@@ -100,6 +100,10 @@ class GroupEditViewModel @Inject constructor(private val groupRepository: GroupR
 						)
 					}
 					groupRepository.updateGroup(currentState.group.toGroupModel())
+					postSideEffect(
+						GroupEditSideEffect.ShowToast(R.string.message_success_edit_group),
+					)
+					delay(100)
 					postSideEffect(GroupEditSideEffect.NavigateToGroupDetailScreen)
 				}
 			} catch (e: Exception) {

--- a/feature/mygroup/src/main/res/values/strings.xml
+++ b/feature/mygroup/src/main/res/values/strings.xml
@@ -38,8 +38,9 @@
 	<string name="message_error_content_empty">내용은 비울 수 없습니다.</string>
 	<string name="message_error_image_url_blank">이미지를 비울 수 없습니다.</string>
 	<string name="message_error_edit_group">그룹 수정에 실패했습니다.</string>
-	<string name="message_error_creation_group_success">그룹 생성에 성공했습니다.</string>
-	<string name="message_error_creation_group_fail">그룹 생성에 실패했습니다.</string>
+	<string name="message_success_edit_group">그룹을 수정했습니다.</string>
+	<string name="message_success_creation_group">그룹 생성에 성공했습니다.</string>
+	<string name="message_error_creation_group">그룹 생성에 실패했습니다.</string>
 	<string name="content_member_joined_at">"참여 날짜 :&#32;"</string>
 	<string name="message_user_not_found">사용자를 찾을 수 없습니다.</string>
 	<string name="content_episode_count">에피소드 게시수</string>


### PR DESCRIPTION
- closed #155 

## *📍 Work Description*

- 클립보드 매니저를 통해 setPrimaryClip 함수 호출시 Toast 처리, 중복 Toast 제거
- 그룹 편집 완료시 toast 띄우기

## *📸 Screenshot*


https://github.com/user-attachments/assets/cafd6205-e442-4139-b6aa-846b40f18e91

https://github.com/user-attachments/assets/298b056f-ca53-4c1f-be9f-ba95bb9a0fba

## *📢 To Reviewers*
- 그룹 화면에서 모든 성공/실패 결과에 토스트를 띄우도록 추가했습니다.
- ClipboardManager 내부에서 토스트를 띄우고 있어 클립보드 복사 성공시 띄우는 Toast 제거

## ⏲️Time

    - 0.5 시간


