### PR TITLE
[FIX/#154] Group / 이미 참여된 그룹 중복 참여 방지

### DIFF
--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupJoinViewModel.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/viewmodel/GroupJoinViewModel.kt
@@ -70,11 +70,14 @@ class GroupJoinViewModel @Inject constructor(
 			try {
 				groupRepository.joinGroup(userId, group.id)
 				intent { copy(isJoinedSuccess = true) }
+				postSideEffect(GroupJoinSideEffect.ShowToast(R.string.group_join_success))
+			} catch (e: NullPointerException) {
+				intent { copy(isGroupLoading = false, isJoinedSuccess = false, group = null) }
+				postSideEffect(GroupJoinSideEffect.ShowToast(R.string.message_already_joined))
 			} catch (e: Exception) {
 				intent { copy(isGroupLoading = false, isJoinedSuccess = false, group = null) }
 				postSideEffect(GroupJoinSideEffect.ShowToast(R.string.group_join_failure))
 			}
-			postSideEffect(GroupJoinSideEffect.ShowToast(R.string.group_join_success))
 			delay(100)
 			postSideEffect(GroupJoinSideEffect.NavigateToGroupScreen)
 		}

--- a/feature/mygroup/src/main/res/values/strings.xml
+++ b/feature/mygroup/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
     <string name="group_join_not_exist">그룹이 존재하지 않습니다.</string>
 	<string name="group_join_success">그룹 참여 성공</string>
 	<string name="group_join_failure">그룹 참여 실패</string>
+	<string name="message_already_joined">이미 참여중인 그룹입니다.</string>
 	<string name="group_load_failure">그룹을 불러오는데 실패했습니다.</string>
 	<string name="group_description_label">그룹 설명</string>
 	<string name="message_issue_code">클립보드에 복사되었습니다.</string>


### PR DESCRIPTION
- closed #154 

## *📍 Work Description*

- 그룹 collection의 members field 에 본인 uid 확인 후 처리
- 예외 경우가 다르므로 Exception 의 하위 타입으로 throw 한 뒤에 해당 함수의 catch 와 viewmodel의 catch 에서 잡아서 다른 처리를 하도록 설정

## *📸 Screenshot*

https://github.com/user-attachments/assets/c19fbcaf-7a13-42da-83af-3c1003defcb6


## *📢 To Reviewers*
- 성공시 실패시에도 뒤로가면서 토스트를 띄웁니다.

## ⏲️Time

    - 0.5시간
