### PR TITLE
[FIX/#208] Episode / 에피소드 상세화면에서 편집 화면 이동 네비게이션 설정

### DIFF
--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/detail/EpisodeDetailScreen.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/detail/EpisodeDetailScreen.kt
@@ -155,6 +155,7 @@ internal fun EpisodeDetailScreen(
 				Row(
 					modifier = Modifier
 						.wrapContentWidth()
+						.padding(horizontal = 20.dp)
 						.horizontalScroll(rememberScrollState()),
 					horizontalArrangement = Arrangement.spacedBy(10.dp),
 					verticalAlignment = Alignment.CenterVertically,

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/detail/EpisodeDetailScreen.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/detail/EpisodeDetailScreen.kt
@@ -65,6 +65,7 @@ import com.boostcamp.mapisode.home.component.MapisodeChip
 internal fun EpisodeDetailRoute(
 	episodeId: String,
 	viewModel: EpisodeDetailViewModel = hiltViewModel(),
+	onEpisodeEditClick: (String) -> Unit,
 	onBackClick: () -> Unit = {},
 ) {
 	val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -93,7 +94,11 @@ internal fun EpisodeDetailRoute(
 			MapisodeCircularLoadingIndicator()
 		}
 	} else {
-		EpisodeDetailScreen(state = uiState, onBackClick = onBackClick)
+		EpisodeDetailScreen(
+			state = uiState,
+			onEpisodeEditClick = { onEpisodeEditClick(episodeId) },
+			onBackClick = onBackClick,
+		)
 	}
 }
 
@@ -102,6 +107,7 @@ internal fun EpisodeDetailRoute(
 internal fun EpisodeDetailScreen(
 	state: EpisodeDetailState,
 	modifier: Modifier = Modifier,
+	onEpisodeEditClick: () -> Unit,
 	onBackClick: () -> Unit = {},
 ) {
 	val context = LocalContext.current
@@ -125,7 +131,7 @@ internal fun EpisodeDetailScreen(
 				},
 				actions = {
 					MapisodeIconButton(
-						onClick = {},
+						onClick = { onEpisodeEditClick() },
 					) {
 						MapisodeIcon(
 							id = R.drawable.ic_edit,
@@ -150,7 +156,7 @@ internal fun EpisodeDetailScreen(
 					modifier = Modifier
 						.wrapContentWidth()
 						.horizontalScroll(rememberScrollState()),
-					horizontalArrangement = Arrangement.spacedBy(4.dp),
+					horizontalArrangement = Arrangement.spacedBy(10.dp),
 					verticalAlignment = Alignment.CenterVertically,
 				) {
 					imageUrls.forEach { imageUrl ->
@@ -160,6 +166,7 @@ internal fun EpisodeDetailScreen(
 							modifier = Modifier
 								.size(110.dp)
 								.clip(RoundedCornerShape(16.dp)),
+							contentScale = ContentScale.Crop,
 						)
 					}
 				}
@@ -304,6 +311,6 @@ fun EpisodeDetailScreenPreview(
 	}
 
 	CompositionLocalProvider(LocalAsyncImagePreviewHandler provides previewHandler) {
-		EpisodeDetailScreen(state = state)
+		EpisodeDetailScreen(state = state, onEpisodeEditClick = {})
 	}
 }

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/edit/EpisodeEditScreen.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/edit/EpisodeEditScreen.kt
@@ -225,7 +225,7 @@ fun EpisodeEditScreen(
 							contentDescription = "애피소드 이미지",
 							modifier = Modifier
 								.size(110.dp)
-								.clip(RoundedCornerShape(8.dp)),
+								.clip(RoundedCornerShape(16.dp)),
 							contentScale = ContentScale.Crop,
 						)
 					}

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/navigation/HomeNavigation.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/navigation/HomeNavigation.kt
@@ -42,6 +42,7 @@ fun NavController.navigateEpisodeEdit(
 
 fun NavGraphBuilder.addHomeNavGraph(
 	onTextMarkerClick: (EpisodeLatLng) -> Unit,
+	onEpisodeEditClick: (String) -> Unit,
 	onEpisodeClick: (String) -> Unit,
 	onListFabClick: (String) -> Unit,
 	onBackClick: () -> Unit,
@@ -56,7 +57,11 @@ fun NavGraphBuilder.addHomeNavGraph(
 
 	composable<HomeRoute.Detail> { backStackEntry ->
 		val episodeId = backStackEntry.toRoute<HomeRoute.Detail>().episodeId
-		EpisodeDetailRoute(episodeId = episodeId, onBackClick = onBackClick)
+		EpisodeDetailRoute(
+			episodeId = episodeId,
+			onEpisodeEditClick = onEpisodeEditClick,
+			onBackClick = onBackClick,
+		)
 	}
 
 	composable<HomeRoute.List> { backStackEntry ->

--- a/feature/main/src/main/java/com/boostcamp/mapisode/main/component/MainNavHost.kt
+++ b/feature/main/src/main/java/com/boostcamp/mapisode/main/component/MainNavHost.kt
@@ -29,6 +29,7 @@ internal fun MainNavHost(
 				onTextMarkerClick = { latLng ->
 					navigator.navigate(MainNavTab.EPISODE, latLng)
 				},
+				onEpisodeEditClick = navigator::navigateToEpisodeEdit,
 				onEpisodeClick = navigator::navigateToEpisodeDetail,
 				onListFabClick = navigator::navigateToEpisodeList,
 				onBackClick = navigator::popBackStackIfNotHome,


### PR DESCRIPTION
- closed #208

## *📍 Work Description*

-  에피소드 상세화면에서 편집 화면 이동 네비게이션 설정

## *📸 Screenshot*


https://github.com/user-attachments/assets/0b0323e4-edea-43e8-b66c-b20f7bae126f

## *📢 To Reviewers*
- 네비게이션 연결했습니다

## ⏲️Time

    - 0.2 시간
