### PR TITLE
[FIX/#212] Photopicker / 사진 찍고 나서 다른 곳 선택하면 복사되는 문제 해결

### DIFF
--- a/core/ui/src/main/kotlin/com/boostcamp/mapisode/ui/photopicker/MapisodePhotoPicker.kt
+++ b/core/ui/src/main/kotlin/com/boostcamp/mapisode/ui/photopicker/MapisodePhotoPicker.kt
@@ -45,7 +45,7 @@ fun MapisodePhotoPicker(
 	val context = LocalContext.current
 	var photos by rememberSaveable { mutableStateOf<List<PhotoInfo>>(emptyList()) }
 	var isPermissionsGranted by rememberSaveable { mutableStateOf(false) }
-	val addedPhoto = rememberSaveable { mutableStateOf<PhotoInfo?>(null) }
+	val addedPhoto = remember { mutableStateOf<PhotoInfo?>(null) }
 	val cameraPhotos = rememberMutableStateListOf<PhotoInfo>()
 
 	val photoLoader = remember(context) { PhotoLoader(context) }
@@ -122,7 +122,12 @@ fun PhotoPicker(
 	modifier: Modifier = Modifier,
 ) {
 	val selectedPhotos = rememberMutableStateListOf<PhotoInfo>()
-	if (addedPhoto != null) selectedPhotos.add(addedPhoto)
+
+	LaunchedEffect(addedPhoto) {
+		if (addedPhoto != null && !selectedPhotos.contains(addedPhoto)) {
+			selectedPhotos.add(addedPhoto)
+		}
+	}
 
 	MapisodeScaffold(
 		modifier = Modifier.fillMaxSize(),


### PR DESCRIPTION
- closed #212 

## *📍 Work Description*

- 사진 찍고 나서 다른 곳 다녀오면 선택된 사진이 복사되는 문제 해결

## *📢 To Reviewers*
- 감사합니다!

## ⏲️Time

    - 2 h
