### PR TITLE
[FEAT/#122] 스토리 몰입모드 구현 및 배경 변경

### DIFF
--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeLinearProgressBar.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/MapisodeLinearProgressBar.kt
@@ -16,7 +16,7 @@ import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
 fun MapisodeLinearProgressBar(
 	modifier: Modifier = Modifier,
 	progress: Float,
-	backgroundColor: Color = Color.Gray,
+	backgroundColor: Color = Color.White,
 	progressColor: Color = MapisodeTheme.colorScheme.circularIndicator,
 ) {
 	Canvas(modifier = modifier) {

--- a/core/ui/src/main/kotlin/com/boostcamp/mapisode/ui/story/StoryViewer.kt
+++ b/core/ui/src/main/kotlin/com/boostcamp/mapisode/ui/story/StoryViewer.kt
@@ -2,6 +2,7 @@ package com.boostcamp.mapisode.ui.story
 
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -86,6 +87,7 @@ fun StoryViewer(
 	Box(
 		modifier = Modifier
 			.fillMaxSize()
+			.background(Color.Gray)
 			.pointerInput(Unit) {
 				detectTapGestures(
 					onPress = {

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/story/StoryViewerScreen.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/story/StoryViewerScreen.kt
@@ -1,7 +1,14 @@
 package com.boostcamp.mapisode.home.story
 
+import android.app.Activity
+import android.os.Build
+import android.view.View
+import android.view.WindowInsets
+import android.view.WindowInsetsController
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.boostcamp.mapisode.home.detail.EpisodeDetailViewModel
@@ -14,6 +21,37 @@ fun StoryViewerRoute(
 	onBackClick: () -> Unit = {},
 ) {
 	val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+	val context = LocalContext.current
+	val window = (context as? Activity)?.window
+
+	DisposableEffect(Unit) {
+		// 몰입 모드 활성화
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+			val windowInsetsController = window?.insetsController
+			windowInsetsController?.systemBarsBehavior =
+				WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+			windowInsetsController?.hide(WindowInsets.Type.systemBars())
+		} else {
+			@Suppress("DEPRECATION")
+			window?.decorView?.systemUiVisibility = (
+				View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+					or View.SYSTEM_UI_FLAG_FULLSCREEN
+					or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+				)
+		}
+
+		onDispose {
+			// 몰입 모드 비활성화
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+				val windowInsetsController = window?.insetsController
+				windowInsetsController?.show(WindowInsets.Type.systemBars())
+			} else {
+				@Suppress("DEPRECATION")
+				window?.decorView?.systemUiVisibility = View.SYSTEM_UI_FLAG_VISIBLE
+			}
+		}
+	}
 
 	StoryViewer(
 		imageUrls = uiState.episode.imageUrls.toPersistentList(),


### PR DESCRIPTION
- closed #222 

## *📍 Work Description*
- 몰입모드를 통해 이미지를 더 크게 볼 수 있습니다.
- 유저의 이름이 더 잘 보이도록 배경을 회색으로 통일했습니다.

## *📸 Screenshot*

<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->

https://github.com/user-attachments/assets/c5f1eb8d-61b3-4eba-b5ed-627d4f01e5a7


## *📢 To Reviewers*
- 이미지에서 Palette를 통해 주요 색깔 뽑아서 인스타처럼 그라데이션 주려고 했는데, 클린 아키텍처(context 문제) + 하드웨어 비트맵을 사용 해제해야됨 -> 프리로딩 의미가 없어짐 등등 문제로 시도하다가 폐기했습니다..

## ⏲️Time

    - 3 h
