### PR TITLE
[REFACTOR/#225] 에피소드 디테일, 포토피커 / 다크모드 대응

### DIFF
--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/card/GroupInfoCard.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/compose/card/GroupInfoCard.kt
@@ -84,11 +84,6 @@ fun GroupInfoCard(
 			)
 
 			Spacer(modifier = Modifier.height(4.dp))
-
-			MapisodeText(
-				text = stringResource(R.string.group_recent_upload),
-				style = MapisodeTheme.typography.labelMedium,
-			)
 		}
 	}
 }

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/theme/ColorScheme.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/theme/ColorScheme.kt
@@ -122,6 +122,10 @@ data class CustomColorScheme(
 	// Checkbox
 	val checkboxBackground: Color,
 	val checkboxStroke: Color,
+
+	// EpisodeCard
+	val episodeBoxBackground: Color,
+	val episodeBoxStroke: Color,
 )
 
 // Light Theme Color Scheme
@@ -243,6 +247,10 @@ val lightColorScheme = CustomColorScheme(
 	// Checkbox
 	checkboxBackground = Primary20.copy(alpha = 0.5f),
 	checkboxStroke = Primary50.copy(alpha = 0.5f),
+
+	// EpisodeCard
+	episodeBoxBackground = Neutral10,
+	episodeBoxStroke = Neutral40,
 )
 
 // Dark Theme Color Scheme
@@ -364,4 +372,8 @@ val darkColorScheme = CustomColorScheme(
 	// Checkbox
 	checkboxBackground = Primary20.copy(alpha = 0.6f),
 	checkboxStroke = Neutral40,
+
+	// EpisodeCard
+	episodeBoxBackground = Neutral50,
+	episodeBoxStroke = Neutral40,
 )

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/theme/ColorScheme.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/theme/ColorScheme.kt
@@ -310,7 +310,7 @@ val darkColorScheme = CustomColorScheme(
 	outlineButtonContent = Neutral40,
 
 	// Chip
-	chipSelectedBackground = Neutral80,
+	chipSelectedBackground = Neutral70,
 	chipUnselectedBackground = Neutral100,
 	chipText = Neutral10,
 	chipSelectedStroke = Primary30,

--- a/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/theme/ColorScheme.kt
+++ b/core/designsystem/src/main/kotlin/com/boostcamp/mapisode/designsystem/theme/ColorScheme.kt
@@ -304,7 +304,7 @@ val darkColorScheme = CustomColorScheme(
 	// Button
 	filledButtonEnableBackground = Primary50,
 	filledButtonDisableBackground = Neutral80,
-	filledButtonContent = Neutral110,
+	filledButtonContent = Neutral40,
 	outlineButtonBackground = Neutral110,
 	outlineButtonStroke = Neutral40,
 	outlineButtonContent = Neutral40,

--- a/core/ui/src/main/kotlin/com/boostcamp/mapisode/ui/photopicker/MapisodePhotoPicker.kt
+++ b/core/ui/src/main/kotlin/com/boostcamp/mapisode/ui/photopicker/MapisodePhotoPicker.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -20,11 +19,15 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIcon
 import com.boostcamp.mapisode.designsystem.compose.MapisodeIconButton
 import com.boostcamp.mapisode.designsystem.compose.MapisodeScaffold
+import com.boostcamp.mapisode.designsystem.compose.MapisodeText
 import com.boostcamp.mapisode.designsystem.compose.topbar.TopAppBar
+import com.boostcamp.mapisode.designsystem.theme.MapisodeTheme
+import com.boostcamp.mapisode.ui.R
 import com.boostcamp.mapisode.ui.photopicker.component.CameraItem
 import com.boostcamp.mapisode.ui.photopicker.component.PhotoItem
 import com.boostcamp.mapisode.ui.photopicker.model.PhotoInfo
@@ -82,7 +85,11 @@ fun MapisodePhotoPicker(
 				cameraPhotos.add(photo)
 			}
 		} catch (e: IOException) {
-			Toast.makeText(context, "사진 저장에 실패했습니다.", Toast.LENGTH_SHORT).show()
+			Toast.makeText(
+				context,
+				context.getString(R.string.photopicker_fail),
+				Toast.LENGTH_SHORT,
+			).show()
 		}
 	}
 
@@ -151,7 +158,10 @@ fun PhotoPicker(
 						},
 						enabled = selectedPhotos.size > 0,
 					) {
-						Text("완료")
+						MapisodeText(
+							text = stringResource(R.string.photopicker_confirm),
+							style = MapisodeTheme.typography.titleMedium,
+						)
 					}
 				},
 			)

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="photopicker_confirm">선택</string>
+	<string name="photopicker_fail">사진 저장에 실패했습니다.</string>
+</resources>

--- a/feature/episode/src/main/java/com/boostcamp/mapisode/episode/PickLocationScreen.kt
+++ b/feature/episode/src/main/java/com/boostcamp/mapisode/episode/PickLocationScreen.kt
@@ -1,5 +1,6 @@
 package com.boostcamp.mapisode.episode
 
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -29,6 +30,7 @@ import com.naver.maps.map.compose.CameraPositionState
 import com.naver.maps.map.compose.ExperimentalNaverMapApi
 import com.naver.maps.map.compose.LocationTrackingMode
 import com.naver.maps.map.compose.MapProperties
+import com.naver.maps.map.compose.MapType
 import com.naver.maps.map.compose.MapUiSettings
 import com.naver.maps.map.compose.Marker
 import com.naver.maps.map.compose.NaverMap
@@ -85,6 +87,8 @@ internal fun PickLocationScreen(
 				cameraPositionState = cameraPositionState,
 				properties = MapProperties(
 					locationTrackingMode = LocationTrackingMode.NoFollow,
+					isNightModeEnabled = isSystemInDarkTheme(),
+					mapType = MapType.Navi,
 				),
 				uiSettings = MapUiSettings(
 					isZoomControlEnabled = false,

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/HomeScreen.kt
@@ -7,6 +7,7 @@ import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -64,6 +65,7 @@ import com.naver.maps.map.compose.CameraPositionState
 import com.naver.maps.map.compose.ExperimentalNaverMapApi
 import com.naver.maps.map.compose.LocationTrackingMode
 import com.naver.maps.map.compose.MapProperties
+import com.naver.maps.map.compose.MapType
 import com.naver.maps.map.compose.MapUiSettings
 import com.naver.maps.map.compose.Marker
 import com.naver.maps.map.compose.MarkerState
@@ -304,6 +306,8 @@ private fun HomeScreen(
 			properties = MapProperties(
 				locationTrackingMode = LocationTrackingMode.NoFollow,
 				isIndoorEnabled = true,
+				isNightModeEnabled = isSystemInDarkTheme(),
+				mapType = MapType.Navi,
 			),
 			uiSettings = MapUiSettings(
 				isZoomGesturesEnabled = true,

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/component/EpisodeListCard.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/component/EpisodeListCard.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -42,8 +41,15 @@ fun EpisodeListCard(
 		modifier = Modifier
 			.fillMaxWidth()
 			.height(130.dp)
-			.background(Color.White, shape = RoundedCornerShape(8.dp))
-			.border(1.dp, Color.LightGray, shape = RoundedCornerShape(8.dp))
+			.background(
+				color = MapisodeTheme.colorScheme.episodeBoxBackground,
+				shape = RoundedCornerShape(8.dp),
+			)
+			.border(
+				width = 1.dp,
+				color = MapisodeTheme.colorScheme.episodeBoxStroke,
+				shape = RoundedCornerShape(8.dp),
+			)
 			.padding(10.dp),
 	) {
 		AsyncImage(

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/detail/EpisodeDetailScreen.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/detail/EpisodeDetailScreen.kt
@@ -207,10 +207,13 @@ internal fun EpisodeDetailScreen(
 					.fillMaxWidth()
 					.padding(horizontal = 20.dp)
 					.clip(RoundedCornerShape(12.dp))
-					.background(color = Color.White, shape = RoundedCornerShape(12.dp))
+					.background(
+						color = MapisodeTheme.colorScheme.episodeBoxBackground,
+						shape = RoundedCornerShape(12.dp),
+					)
 					.border(
 						width = 1.dp,
-						color = Color.Black,
+						color = MapisodeTheme.colorScheme.episodeBoxStroke,
 						shape = RoundedCornerShape(12.dp),
 					),
 			) {

--- a/feature/home/src/main/java/com/boostcamp/mapisode/home/edit/LocationSelectionScreen.kt
+++ b/feature/home/src/main/java/com/boostcamp/mapisode/home/edit/LocationSelectionScreen.kt
@@ -1,5 +1,6 @@
 package com.boostcamp.mapisode.home.edit
 
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -35,6 +36,7 @@ import com.naver.maps.map.compose.CameraPositionState
 import com.naver.maps.map.compose.ExperimentalNaverMapApi
 import com.naver.maps.map.compose.LocationTrackingMode
 import com.naver.maps.map.compose.MapProperties
+import com.naver.maps.map.compose.MapType
 import com.naver.maps.map.compose.MapUiSettings
 import com.naver.maps.map.compose.Marker
 import com.naver.maps.map.compose.NaverMap
@@ -84,6 +86,8 @@ internal fun LocationSelectionScreen(
 				cameraPositionState = cameraPositionState,
 				properties = MapProperties(
 					locationTrackingMode = LocationTrackingMode.NoFollow,
+					isNightModeEnabled = isSystemInDarkTheme(),
+					mapType = MapType.Navi,
 				),
 				uiSettings = MapUiSettings(
 					isZoomControlEnabled = false,

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupDetailScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupDetailScreen.kt
@@ -42,7 +42,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -157,7 +156,8 @@ fun GroupDetailScreen(
 			}
 
 			is GroupDetailSideEffect.IssueInvitationCode -> {
-				val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+				val clipboard =
+					context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
 				val clip = ClipData.newPlainText("label", effect.invitationCode)
 				clipboard.setPrimaryClip(clip)
 			}
@@ -545,8 +545,15 @@ fun EpisodeCard(
 		modifier = Modifier
 			.fillMaxWidth()
 			.height(130.dp)
-			.background(Color.White, shape = RoundedCornerShape(8.dp))
-			.border(1.dp, Color.LightGray, shape = RoundedCornerShape(8.dp))
+			.background(
+				color = MapisodeTheme.colorScheme.episodeBoxBackground,
+				shape = RoundedCornerShape(8.dp),
+			)
+			.border(
+				width = 1.dp,
+				color = MapisodeTheme.colorScheme.episodeBoxStroke,
+				shape = RoundedCornerShape(8.dp),
+			)
 			.padding(10.dp)
 			.clickable {
 				onEpisodeClick(episode.id)

--- a/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupDetailScreen.kt
+++ b/feature/mygroup/src/main/java/com/boostcamp/mapisode/mygroup/screen/GroupDetailScreen.kt
@@ -502,12 +502,7 @@ fun GroupMemberContent(
 				maxLines = 1,
 			)
 			Spacer(modifier = Modifier.padding(2.dp))
-			MapisodeText(
-				text = stringResource(S.string.content_member_joined_at) +
-					member.joinedAt.toFormattedString(),
-				style = MapisodeTheme.typography.labelMedium,
-				maxLines = 1,
-			)
+
 			MapisodeText(
 				text = buildString {
 					append(stringResource(S.string.content_recent_episode_upload))

--- a/feature/mypage/src/main/java/com/boostcamp/mapisode/mypage/screen/MypageScreen.kt
+++ b/feature/mypage/src/main/java/com/boostcamp/mapisode/mypage/screen/MypageScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -220,6 +221,7 @@ private fun Profile(
 			modifier = Modifier
 				.size(52.dp)
 				.clip(CircleShape),
+			contentScale = ContentScale.Crop,
 		)
 
 		Spacer(modifier = Modifier.width(16.dp))


### PR DESCRIPTION
- closed #225 

## *📍 Work Description*

- 에피소드 카드 다크모드 대응
- 포토피커 완료 버튼 다크모드 대응

## *📸 Screenshot*

<img src="https://github.com/user-attachments/assets/482d12f8-a706-473b-a11c-3ab6fabc126d" width=200/>
<img src="https://github.com/user-attachments/assets/813e9dfe-9f67-4da3-98e9-3eb87f5c07c2" width=200/>
<img src="https://github.com/user-attachments/assets/67964d94-a5b6-41f8-9c13-204264519daf" width=200/>
<img src="https://github.com/user-attachments/assets/3ba308c0-3f94-4769-83c1-15bf9e371f1d" width=200/>

## *📢 To Reviewers*
- 다크 모드 대응했습니다.

## ⏲️Time

    - 1.5 h
